### PR TITLE
added support for pagination for the Watson News Data api.

### DIFF
--- a/watson_developer_cloud/alchemy_data_news_v1.py
+++ b/watson_developer_cloud/alchemy_data_news_v1.py
@@ -36,5 +36,8 @@ class AlchemyDataNewsV1(WatsonDeveloperCloudService):
                   'next': next_page}
         if isinstance(query_fields, dict):
             for key in query_fields:
-                params[key if key.startswith('q.') else 'q.' + key] = query_fields[key]
+                if key.startswith('enriched.url') or key.startswith('original.url'):
+                    params[key if key.startswith('q.') else 'q.' + key] = query_fields[key]
+                else:
+                    params[key] = query_fields[key]
         return self._alchemy_html_request(method_url='/data/GetNews', method='GET', params=params)

--- a/watson_developer_cloud/alchemy_data_news_v1.py
+++ b/watson_developer_cloud/alchemy_data_news_v1.py
@@ -25,7 +25,7 @@ class AlchemyDataNewsV1(WatsonDeveloperCloudService):
     def __init__(self, url=default_url, **kwargs):
         WatsonDeveloperCloudService.__init__(self, 'alchemy_api', url, **kwargs)
 
-    def get_news_documents(self, start, end, max_results=10, query_fields=None, return_fields=None, time_slice=None):
+    def get_news_documents(self, start, end, max_results=10, query_fields=None, return_fields=None, time_slice=None, next_page=None):
         if isinstance(return_fields, list):
             return_fields = ','.join(return_fields)
         params = {'start': start,
@@ -33,6 +33,8 @@ class AlchemyDataNewsV1(WatsonDeveloperCloudService):
                   'maxResults': max_results,
                   'return': return_fields,
                   'timeSlice': time_slice}
+        if isinstance(next_page, str):
+            params['next'] = next_page
         if isinstance(query_fields, dict):
             for key in query_fields:
                 params[key if key.startswith('q.') else 'q.' + key] = query_fields[key]

--- a/watson_developer_cloud/alchemy_data_news_v1.py
+++ b/watson_developer_cloud/alchemy_data_news_v1.py
@@ -32,9 +32,8 @@ class AlchemyDataNewsV1(WatsonDeveloperCloudService):
                   'end': end,
                   'maxResults': max_results,
                   'return': return_fields,
-                  'timeSlice': time_slice}
-        if isinstance(next_page, str):
-            params['next'] = next_page
+                  'timeSlice': time_slice,
+                  'next': next_page}
         if isinstance(query_fields, dict):
             for key in query_fields:
                 params[key if key.startswith('q.') else 'q.' + key] = query_fields[key]


### PR DESCRIPTION
Added a next_page parameter to allow for pagination to work with minimal changes to the get_news_documents function. This PR is in response to the issue I created about the lack pagination support #53.