### PR TITLE
Updates Tone Analyzer to GA version: latest api(2016-05-19) and 'params' arg

### DIFF
--- a/resources/tone_response.json
+++ b/resources/tone_response.json
@@ -1,0 +1,8680 @@
+{
+    "document_tone": {
+        "tone_categories": [
+            {
+                "tones": [
+                    {
+                        "score": 0.971214,
+                        "tone_id": "anger",
+                        "tone_name": "Anger"
+                    },
+                    {
+                        "score": 0.546126,
+                        "tone_id": "disgust",
+                        "tone_name": "Disgust"
+                    },
+                    {
+                        "score": 0.543228,
+                        "tone_id": "fear",
+                        "tone_name": "Fear"
+                    },
+                    {
+                        "score": 0.072227,
+                        "tone_id": "joy",
+                        "tone_name": "Joy"
+                    },
+                    {
+                        "score": 0.057439,
+                        "tone_id": "sadness",
+                        "tone_name": "Sadness"
+                    }
+                ],
+                "category_id": "emotion_tone",
+                "category_name": "Emotion Tone"
+            },
+            {
+                "tones": [
+                    {
+                        "score": 0.53,
+                        "tone_id": "analytical",
+                        "tone_name": "Analytical"
+                    },
+                    {
+                        "score": 0.003,
+                        "tone_id": "confident",
+                        "tone_name": "Confident"
+                    },
+                    {
+                        "score": 0,
+                        "tone_id": "tentative",
+                        "tone_name": "Tentative"
+                    }
+                ],
+                "category_id": "language_tone",
+                "category_name": "Language Tone"
+            },
+            {
+                "tones": [
+                    {
+                        "score": 0.55,
+                        "tone_id": "openness_big5",
+                        "tone_name": "Openness"
+                    },
+                    {
+                        "score": 0.241,
+                        "tone_id": "conscientiousness_big5",
+                        "tone_name": "Conscientiousness"
+                    },
+                    {
+                        "score": 0.513,
+                        "tone_id": "extraversion_big5",
+                        "tone_name": "Extraversion"
+                    },
+                    {
+                        "score": 0.467,
+                        "tone_id": "agreeableness_big5",
+                        "tone_name": "Agreeableness"
+                    },
+                    {
+                        "score": 0.749,
+                        "tone_id": "emotional_range_big5",
+                        "tone_name": "Emotional Range"
+                    }
+                ],
+                "category_id": "social_tone",
+                "category_name": "Social Tone"
+            }
+        ]
+    },
+    "sentences_tone": [
+        {
+            "sentence_id": 0,
+            "text": "Call me Ishmael.",
+            "input_from": 0,
+            "input_to": 16,
+            "tone_categories": []
+        },
+        {
+            "sentence_id": 1,
+            "text": "Some years ago-never mind how long precisely-having little or no money in my purse, and nothing particular to interest me on shore, I thought I would sail about a little and see the watery part of the world.",
+            "input_from": 17,
+            "input_to": 224,
+            "tone_categories": [
+                {
+                    "tones": [
+                        {
+                            "score": 0.170393,
+                            "tone_id": "anger",
+                            "tone_name": "Anger"
+                        },
+                        {
+                            "score": 0.350151,
+                            "tone_id": "disgust",
+                            "tone_name": "Disgust"
+                        },
+                        {
+                            "score": 0.201739,
+                            "tone_id": "fear",
+                            "tone_name": "Fear"
+                        },
+                        {
+                            "score": 0.114688,
+                            "tone_id": "joy",
+                            "tone_name": "Joy"
+                        },
+                        {
+                            "score": 0.469036,
+                            "tone_id": "sadness",
+                            "tone_name": "Sadness"
+                        }
+                    ],
+                    "category_id": "emotion_tone",
+                    "category_name": "Emotion Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0.114,
+                            "tone_id": "analytical",
+                            "tone_name": "Analytical"
+                        },
+                        {
+                            "score": 0,
+                            "tone_id": "confident",
+                            "tone_name": "Confident"
+                        },
+                        {
+                            "score": 0.728,
+                            "tone_id": "tentative",
+                            "tone_name": "Tentative"
+                        }
+                    ],
+                    "category_id": "language_tone",
+                    "category_name": "Language Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0.406,
+                            "tone_id": "openness_big5",
+                            "tone_name": "Openness"
+                        },
+                        {
+                            "score": 0.166,
+                            "tone_id": "conscientiousness_big5",
+                            "tone_name": "Conscientiousness"
+                        },
+                        {
+                            "score": 0.284,
+                            "tone_id": "extraversion_big5",
+                            "tone_name": "Extraversion"
+                        },
+                        {
+                            "score": 0.375,
+                            "tone_id": "agreeableness_big5",
+                            "tone_name": "Agreeableness"
+                        },
+                        {
+                            "score": 0.92,
+                            "tone_id": "emotional_range_big5",
+                            "tone_name": "Emotional Range"
+                        }
+                    ],
+                    "category_id": "social_tone",
+                    "category_name": "Social Tone"
+                }
+            ]
+        },
+        {
+            "sentence_id": 2,
+            "text": "It is a way I have of driving off the spleen and regulating the circulation.",
+            "input_from": 225,
+            "input_to": 301,
+            "tone_categories": [
+                {
+                    "tones": [
+                        {
+                            "score": 0.335625,
+                            "tone_id": "anger",
+                            "tone_name": "Anger"
+                        },
+                        {
+                            "score": 0.263686,
+                            "tone_id": "disgust",
+                            "tone_name": "Disgust"
+                        },
+                        {
+                            "score": 0.429728,
+                            "tone_id": "fear",
+                            "tone_name": "Fear"
+                        },
+                        {
+                            "score": 0.20467,
+                            "tone_id": "joy",
+                            "tone_name": "Joy"
+                        },
+                        {
+                            "score": 0.139387,
+                            "tone_id": "sadness",
+                            "tone_name": "Sadness"
+                        }
+                    ],
+                    "category_id": "emotion_tone",
+                    "category_name": "Emotion Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0,
+                            "tone_id": "analytical",
+                            "tone_name": "Analytical"
+                        },
+                        {
+                            "score": 0,
+                            "tone_id": "confident",
+                            "tone_name": "Confident"
+                        },
+                        {
+                            "score": 0,
+                            "tone_id": "tentative",
+                            "tone_name": "Tentative"
+                        }
+                    ],
+                    "category_id": "language_tone",
+                    "category_name": "Language Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0.628,
+                            "tone_id": "openness_big5",
+                            "tone_name": "Openness"
+                        },
+                        {
+                            "score": 0.755,
+                            "tone_id": "conscientiousness_big5",
+                            "tone_name": "Conscientiousness"
+                        },
+                        {
+                            "score": 0.253,
+                            "tone_id": "extraversion_big5",
+                            "tone_name": "Extraversion"
+                        },
+                        {
+                            "score": 0.461,
+                            "tone_id": "agreeableness_big5",
+                            "tone_name": "Agreeableness"
+                        },
+                        {
+                            "score": 0.312,
+                            "tone_id": "emotional_range_big5",
+                            "tone_name": "Emotional Range"
+                        }
+                    ],
+                    "category_id": "social_tone",
+                    "category_name": "Social Tone"
+                }
+            ]
+        },
+        {
+            "sentence_id": 3,
+            "text": "Whenever I find myself growing grim about the mouth; whenever it is a damp, drizzly November in my soul; whenever I find myself involuntarily pausing before coffin warehouses, and bringing up the rear of every funeral I meet; and especially whenever my hypos get such an upper hand of me, that it requires a strong moral principle to prevent me from deliberately stepping into the street, and methodically knocking people's hats off-then, I account it high time to get to sea as soon as I can.",
+            "input_from": 302,
+            "input_to": 795,
+            "tone_categories": [
+                {
+                    "tones": [
+                        {
+                            "score": 0.53187,
+                            "tone_id": "anger",
+                            "tone_name": "Anger"
+                        },
+                        {
+                            "score": 0.50254,
+                            "tone_id": "disgust",
+                            "tone_name": "Disgust"
+                        },
+                        {
+                            "score": 0.36085,
+                            "tone_id": "fear",
+                            "tone_name": "Fear"
+                        },
+                        {
+                            "score": 0.037935,
+                            "tone_id": "joy",
+                            "tone_name": "Joy"
+                        },
+                        {
+                            "score": 0.158363,
+                            "tone_id": "sadness",
+                            "tone_name": "Sadness"
+                        }
+                    ],
+                    "category_id": "emotion_tone",
+                    "category_name": "Emotion Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0.203,
+                            "tone_id": "analytical",
+                            "tone_name": "Analytical"
+                        },
+                        {
+                            "score": 0.008,
+                            "tone_id": "confident",
+                            "tone_name": "Confident"
+                        },
+                        {
+                            "score": 0,
+                            "tone_id": "tentative",
+                            "tone_name": "Tentative"
+                        }
+                    ],
+                    "category_id": "language_tone",
+                    "category_name": "Language Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0.318,
+                            "tone_id": "openness_big5",
+                            "tone_name": "Openness"
+                        },
+                        {
+                            "score": 0.7,
+                            "tone_id": "conscientiousness_big5",
+                            "tone_name": "Conscientiousness"
+                        },
+                        {
+                            "score": 0.444,
+                            "tone_id": "extraversion_big5",
+                            "tone_name": "Extraversion"
+                        },
+                        {
+                            "score": 0.51,
+                            "tone_id": "agreeableness_big5",
+                            "tone_name": "Agreeableness"
+                        },
+                        {
+                            "score": 0.81,
+                            "tone_id": "emotional_range_big5",
+                            "tone_name": "Emotional Range"
+                        }
+                    ],
+                    "category_id": "social_tone",
+                    "category_name": "Social Tone"
+                }
+            ]
+        },
+        {
+            "sentence_id": 4,
+            "text": "This is my substitute for pistol and ball.",
+            "input_from": 796,
+            "input_to": 838,
+            "tone_categories": [
+                {
+                    "tones": [
+                        {
+                            "score": 0.175965,
+                            "tone_id": "anger",
+                            "tone_name": "Anger"
+                        },
+                        {
+                            "score": 0.290521,
+                            "tone_id": "disgust",
+                            "tone_name": "Disgust"
+                        },
+                        {
+                            "score": 0.215051,
+                            "tone_id": "fear",
+                            "tone_name": "Fear"
+                        },
+                        {
+                            "score": 0.302646,
+                            "tone_id": "joy",
+                            "tone_name": "Joy"
+                        },
+                        {
+                            "score": 0.259432,
+                            "tone_id": "sadness",
+                            "tone_name": "Sadness"
+                        }
+                    ],
+                    "category_id": "emotion_tone",
+                    "category_name": "Emotion Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0,
+                            "tone_id": "analytical",
+                            "tone_name": "Analytical"
+                        },
+                        {
+                            "score": 0,
+                            "tone_id": "confident",
+                            "tone_name": "Confident"
+                        },
+                        {
+                            "score": 0,
+                            "tone_id": "tentative",
+                            "tone_name": "Tentative"
+                        }
+                    ],
+                    "category_id": "language_tone",
+                    "category_name": "Language Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0.569,
+                            "tone_id": "openness_big5",
+                            "tone_name": "Openness"
+                        },
+                        {
+                            "score": 0.571,
+                            "tone_id": "conscientiousness_big5",
+                            "tone_name": "Conscientiousness"
+                        },
+                        {
+                            "score": 0.446,
+                            "tone_id": "extraversion_big5",
+                            "tone_name": "Extraversion"
+                        },
+                        {
+                            "score": 0.56,
+                            "tone_id": "agreeableness_big5",
+                            "tone_name": "Agreeableness"
+                        },
+                        {
+                            "score": 0.81,
+                            "tone_id": "emotional_range_big5",
+                            "tone_name": "Emotional Range"
+                        }
+                    ],
+                    "category_id": "social_tone",
+                    "category_name": "Social Tone"
+                }
+            ]
+        },
+        {
+            "sentence_id": 5,
+            "text": "With a philosophical flourish Cato throws himself upon his sword; I quietly take to the ship.",
+            "input_from": 839,
+            "input_to": 932,
+            "tone_categories": [
+                {
+                    "tones": [
+                        {
+                            "score": 0.183406,
+                            "tone_id": "anger",
+                            "tone_name": "Anger"
+                        },
+                        {
+                            "score": 0.518299,
+                            "tone_id": "disgust",
+                            "tone_name": "Disgust"
+                        },
+                        {
+                            "score": 0.150604,
+                            "tone_id": "fear",
+                            "tone_name": "Fear"
+                        },
+                        {
+                            "score": 0.168203,
+                            "tone_id": "joy",
+                            "tone_name": "Joy"
+                        },
+                        {
+                            "score": 0.307349,
+                            "tone_id": "sadness",
+                            "tone_name": "Sadness"
+                        }
+                    ],
+                    "category_id": "emotion_tone",
+                    "category_name": "Emotion Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0,
+                            "tone_id": "analytical",
+                            "tone_name": "Analytical"
+                        },
+                        {
+                            "score": 0,
+                            "tone_id": "confident",
+                            "tone_name": "Confident"
+                        },
+                        {
+                            "score": 0,
+                            "tone_id": "tentative",
+                            "tone_name": "Tentative"
+                        }
+                    ],
+                    "category_id": "language_tone",
+                    "category_name": "Language Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0.346,
+                            "tone_id": "openness_big5",
+                            "tone_name": "Openness"
+                        },
+                        {
+                            "score": 0.888,
+                            "tone_id": "conscientiousness_big5",
+                            "tone_name": "Conscientiousness"
+                        },
+                        {
+                            "score": 0.706,
+                            "tone_id": "extraversion_big5",
+                            "tone_name": "Extraversion"
+                        },
+                        {
+                            "score": 0.795,
+                            "tone_id": "agreeableness_big5",
+                            "tone_name": "Agreeableness"
+                        },
+                        {
+                            "score": 0.107,
+                            "tone_id": "emotional_range_big5",
+                            "tone_name": "Emotional Range"
+                        }
+                    ],
+                    "category_id": "social_tone",
+                    "category_name": "Social Tone"
+                }
+            ]
+        },
+        {
+            "sentence_id": 6,
+            "text": "There is nothing surprising in this.",
+            "input_from": 933,
+            "input_to": 969,
+            "tone_categories": [
+                {
+                    "tones": [
+                        {
+                            "score": 0.202684,
+                            "tone_id": "anger",
+                            "tone_name": "Anger"
+                        },
+                        {
+                            "score": 0.331177,
+                            "tone_id": "disgust",
+                            "tone_name": "Disgust"
+                        },
+                        {
+                            "score": 0.335063,
+                            "tone_id": "fear",
+                            "tone_name": "Fear"
+                        },
+                        {
+                            "score": 0.249111,
+                            "tone_id": "joy",
+                            "tone_name": "Joy"
+                        },
+                        {
+                            "score": 0.433038,
+                            "tone_id": "sadness",
+                            "tone_name": "Sadness"
+                        }
+                    ],
+                    "category_id": "emotion_tone",
+                    "category_name": "Emotion Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0,
+                            "tone_id": "analytical",
+                            "tone_name": "Analytical"
+                        },
+                        {
+                            "score": 0,
+                            "tone_id": "confident",
+                            "tone_name": "Confident"
+                        },
+                        {
+                            "score": 0,
+                            "tone_id": "tentative",
+                            "tone_name": "Tentative"
+                        }
+                    ],
+                    "category_id": "language_tone",
+                    "category_name": "Language Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0.35,
+                            "tone_id": "openness_big5",
+                            "tone_name": "Openness"
+                        },
+                        {
+                            "score": 0.044,
+                            "tone_id": "conscientiousness_big5",
+                            "tone_name": "Conscientiousness"
+                        },
+                        {
+                            "score": 0.795,
+                            "tone_id": "extraversion_big5",
+                            "tone_name": "Extraversion"
+                        },
+                        {
+                            "score": 0.935,
+                            "tone_id": "agreeableness_big5",
+                            "tone_name": "Agreeableness"
+                        },
+                        {
+                            "score": 0.739,
+                            "tone_id": "emotional_range_big5",
+                            "tone_name": "Emotional Range"
+                        }
+                    ],
+                    "category_id": "social_tone",
+                    "category_name": "Social Tone"
+                }
+            ]
+        },
+        {
+            "sentence_id": 7,
+            "text": "If they but knew it, almost all men in their degree, some time or other, cherish very nearly the same feelings towards the ocean with me.",
+            "input_from": 970,
+            "input_to": 1107,
+            "tone_categories": [
+                {
+                    "tones": [
+                        {
+                            "score": 0.263035,
+                            "tone_id": "anger",
+                            "tone_name": "Anger"
+                        },
+                        {
+                            "score": 0.203018,
+                            "tone_id": "disgust",
+                            "tone_name": "Disgust"
+                        },
+                        {
+                            "score": 0.108853,
+                            "tone_id": "fear",
+                            "tone_name": "Fear"
+                        },
+                        {
+                            "score": 0.135628,
+                            "tone_id": "joy",
+                            "tone_name": "Joy"
+                        },
+                        {
+                            "score": 0.430709,
+                            "tone_id": "sadness",
+                            "tone_name": "Sadness"
+                        }
+                    ],
+                    "category_id": "emotion_tone",
+                    "category_name": "Emotion Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0.605,
+                            "tone_id": "analytical",
+                            "tone_name": "Analytical"
+                        },
+                        {
+                            "score": 0,
+                            "tone_id": "confident",
+                            "tone_name": "Confident"
+                        },
+                        {
+                            "score": 0.176,
+                            "tone_id": "tentative",
+                            "tone_name": "Tentative"
+                        }
+                    ],
+                    "category_id": "language_tone",
+                    "category_name": "Language Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0.315,
+                            "tone_id": "openness_big5",
+                            "tone_name": "Openness"
+                        },
+                        {
+                            "score": 0.041,
+                            "tone_id": "conscientiousness_big5",
+                            "tone_name": "Conscientiousness"
+                        },
+                        {
+                            "score": 0.721,
+                            "tone_id": "extraversion_big5",
+                            "tone_name": "Extraversion"
+                        },
+                        {
+                            "score": 0.707,
+                            "tone_id": "agreeableness_big5",
+                            "tone_name": "Agreeableness"
+                        },
+                        {
+                            "score": 0.953,
+                            "tone_id": "emotional_range_big5",
+                            "tone_name": "Emotional Range"
+                        }
+                    ],
+                    "category_id": "social_tone",
+                    "category_name": "Social Tone"
+                }
+            ]
+        },
+        {
+            "sentence_id": 8,
+            "text": "There now is your insular city of the Manhattoes, belted round by wharves as Indian isles by coral reefs-commerce surrounds it with her surf.",
+            "input_from": 1108,
+            "input_to": 1249,
+            "tone_categories": [
+                {
+                    "tones": [
+                        {
+                            "score": 0.208645,
+                            "tone_id": "anger",
+                            "tone_name": "Anger"
+                        },
+                        {
+                            "score": 0.505883,
+                            "tone_id": "disgust",
+                            "tone_name": "Disgust"
+                        },
+                        {
+                            "score": 0.139235,
+                            "tone_id": "fear",
+                            "tone_name": "Fear"
+                        },
+                        {
+                            "score": 0.123256,
+                            "tone_id": "joy",
+                            "tone_name": "Joy"
+                        },
+                        {
+                            "score": 0.209934,
+                            "tone_id": "sadness",
+                            "tone_name": "Sadness"
+                        }
+                    ],
+                    "category_id": "emotion_tone",
+                    "category_name": "Emotion Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0,
+                            "tone_id": "analytical",
+                            "tone_name": "Analytical"
+                        },
+                        {
+                            "score": 0,
+                            "tone_id": "confident",
+                            "tone_name": "Confident"
+                        },
+                        {
+                            "score": 0,
+                            "tone_id": "tentative",
+                            "tone_name": "Tentative"
+                        }
+                    ],
+                    "category_id": "language_tone",
+                    "category_name": "Language Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0.591,
+                            "tone_id": "openness_big5",
+                            "tone_name": "Openness"
+                        },
+                        {
+                            "score": 0.655,
+                            "tone_id": "conscientiousness_big5",
+                            "tone_name": "Conscientiousness"
+                        },
+                        {
+                            "score": 0.587,
+                            "tone_id": "extraversion_big5",
+                            "tone_name": "Extraversion"
+                        },
+                        {
+                            "score": 0.5,
+                            "tone_id": "agreeableness_big5",
+                            "tone_name": "Agreeableness"
+                        },
+                        {
+                            "score": 0.115,
+                            "tone_id": "emotional_range_big5",
+                            "tone_name": "Emotional Range"
+                        }
+                    ],
+                    "category_id": "social_tone",
+                    "category_name": "Social Tone"
+                }
+            ]
+        },
+        {
+            "sentence_id": 9,
+            "text": "Right and left, the streets take you waterward.",
+            "input_from": 1250,
+            "input_to": 1297,
+            "tone_categories": [
+                {
+                    "tones": [
+                        {
+                            "score": 0.296232,
+                            "tone_id": "anger",
+                            "tone_name": "Anger"
+                        },
+                        {
+                            "score": 0.248731,
+                            "tone_id": "disgust",
+                            "tone_name": "Disgust"
+                        },
+                        {
+                            "score": 0.249263,
+                            "tone_id": "fear",
+                            "tone_name": "Fear"
+                        },
+                        {
+                            "score": 0.315715,
+                            "tone_id": "joy",
+                            "tone_name": "Joy"
+                        },
+                        {
+                            "score": 0.234019,
+                            "tone_id": "sadness",
+                            "tone_name": "Sadness"
+                        }
+                    ],
+                    "category_id": "emotion_tone",
+                    "category_name": "Emotion Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0,
+                            "tone_id": "analytical",
+                            "tone_name": "Analytical"
+                        },
+                        {
+                            "score": 0,
+                            "tone_id": "confident",
+                            "tone_name": "Confident"
+                        },
+                        {
+                            "score": 0,
+                            "tone_id": "tentative",
+                            "tone_name": "Tentative"
+                        }
+                    ],
+                    "category_id": "language_tone",
+                    "category_name": "Language Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0.249,
+                            "tone_id": "openness_big5",
+                            "tone_name": "Openness"
+                        },
+                        {
+                            "score": 0.813,
+                            "tone_id": "conscientiousness_big5",
+                            "tone_name": "Conscientiousness"
+                        },
+                        {
+                            "score": 0.832,
+                            "tone_id": "extraversion_big5",
+                            "tone_name": "Extraversion"
+                        },
+                        {
+                            "score": 0.817,
+                            "tone_id": "agreeableness_big5",
+                            "tone_name": "Agreeableness"
+                        },
+                        {
+                            "score": 0.017,
+                            "tone_id": "emotional_range_big5",
+                            "tone_name": "Emotional Range"
+                        }
+                    ],
+                    "category_id": "social_tone",
+                    "category_name": "Social Tone"
+                }
+            ]
+        },
+        {
+            "sentence_id": 10,
+            "text": "Its extreme downtown is the battery, where that noble mole is washed by waves, and cooled by breezes, which a few hours previous were out of sight of land.",
+            "input_from": 1298,
+            "input_to": 1453,
+            "tone_categories": [
+                {
+                    "tones": [
+                        {
+                            "score": 0.373581,
+                            "tone_id": "anger",
+                            "tone_name": "Anger"
+                        },
+                        {
+                            "score": 0.556262,
+                            "tone_id": "disgust",
+                            "tone_name": "Disgust"
+                        },
+                        {
+                            "score": 0.197002,
+                            "tone_id": "fear",
+                            "tone_name": "Fear"
+                        },
+                        {
+                            "score": 0.108432,
+                            "tone_id": "joy",
+                            "tone_name": "Joy"
+                        },
+                        {
+                            "score": 0.158906,
+                            "tone_id": "sadness",
+                            "tone_name": "Sadness"
+                        }
+                    ],
+                    "category_id": "emotion_tone",
+                    "category_name": "Emotion Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0,
+                            "tone_id": "analytical",
+                            "tone_name": "Analytical"
+                        },
+                        {
+                            "score": 0,
+                            "tone_id": "confident",
+                            "tone_name": "Confident"
+                        },
+                        {
+                            "score": 0,
+                            "tone_id": "tentative",
+                            "tone_name": "Tentative"
+                        }
+                    ],
+                    "category_id": "language_tone",
+                    "category_name": "Language Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0.778,
+                            "tone_id": "openness_big5",
+                            "tone_name": "Openness"
+                        },
+                        {
+                            "score": 0.484,
+                            "tone_id": "conscientiousness_big5",
+                            "tone_name": "Conscientiousness"
+                        },
+                        {
+                            "score": 0.311,
+                            "tone_id": "extraversion_big5",
+                            "tone_name": "Extraversion"
+                        },
+                        {
+                            "score": 0.301,
+                            "tone_id": "agreeableness_big5",
+                            "tone_name": "Agreeableness"
+                        },
+                        {
+                            "score": 0.261,
+                            "tone_id": "emotional_range_big5",
+                            "tone_name": "Emotional Range"
+                        }
+                    ],
+                    "category_id": "social_tone",
+                    "category_name": "Social Tone"
+                }
+            ]
+        },
+        {
+            "sentence_id": 11,
+            "text": "Look at the crowds of water-gazers there.",
+            "input_from": 1454,
+            "input_to": 1495,
+            "tone_categories": [
+                {
+                    "tones": [
+                        {
+                            "score": 0.098702,
+                            "tone_id": "anger",
+                            "tone_name": "Anger"
+                        },
+                        {
+                            "score": 0.639292,
+                            "tone_id": "disgust",
+                            "tone_name": "Disgust"
+                        },
+                        {
+                            "score": 0.2851,
+                            "tone_id": "fear",
+                            "tone_name": "Fear"
+                        },
+                        {
+                            "score": 0.124082,
+                            "tone_id": "joy",
+                            "tone_name": "Joy"
+                        },
+                        {
+                            "score": 0.294147,
+                            "tone_id": "sadness",
+                            "tone_name": "Sadness"
+                        }
+                    ],
+                    "category_id": "emotion_tone",
+                    "category_name": "Emotion Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0,
+                            "tone_id": "analytical",
+                            "tone_name": "Analytical"
+                        },
+                        {
+                            "score": 0,
+                            "tone_id": "confident",
+                            "tone_name": "Confident"
+                        },
+                        {
+                            "score": 0,
+                            "tone_id": "tentative",
+                            "tone_name": "Tentative"
+                        }
+                    ],
+                    "category_id": "language_tone",
+                    "category_name": "Language Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0.929,
+                            "tone_id": "openness_big5",
+                            "tone_name": "Openness"
+                        },
+                        {
+                            "score": 0.224,
+                            "tone_id": "conscientiousness_big5",
+                            "tone_name": "Conscientiousness"
+                        },
+                        {
+                            "score": 0.337,
+                            "tone_id": "extraversion_big5",
+                            "tone_name": "Extraversion"
+                        },
+                        {
+                            "score": 0.221,
+                            "tone_id": "agreeableness_big5",
+                            "tone_name": "Agreeableness"
+                        },
+                        {
+                            "score": 0.192,
+                            "tone_id": "emotional_range_big5",
+                            "tone_name": "Emotional Range"
+                        }
+                    ],
+                    "category_id": "social_tone",
+                    "category_name": "Social Tone"
+                }
+            ]
+        },
+        {
+            "sentence_id": 12,
+            "text": "Circumambulate the city of a dreamy Sabbath afternoon.",
+            "input_from": 1496,
+            "input_to": 1550,
+            "tone_categories": [
+                {
+                    "tones": [
+                        {
+                            "score": 0.169689,
+                            "tone_id": "anger",
+                            "tone_name": "Anger"
+                        },
+                        {
+                            "score": 0.206569,
+                            "tone_id": "disgust",
+                            "tone_name": "Disgust"
+                        },
+                        {
+                            "score": 0.181326,
+                            "tone_id": "fear",
+                            "tone_name": "Fear"
+                        },
+                        {
+                            "score": 0.247856,
+                            "tone_id": "joy",
+                            "tone_name": "Joy"
+                        },
+                        {
+                            "score": 0.395501,
+                            "tone_id": "sadness",
+                            "tone_name": "Sadness"
+                        }
+                    ],
+                    "category_id": "emotion_tone",
+                    "category_name": "Emotion Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0,
+                            "tone_id": "analytical",
+                            "tone_name": "Analytical"
+                        },
+                        {
+                            "score": 0,
+                            "tone_id": "confident",
+                            "tone_name": "Confident"
+                        },
+                        {
+                            "score": 0,
+                            "tone_id": "tentative",
+                            "tone_name": "Tentative"
+                        }
+                    ],
+                    "category_id": "language_tone",
+                    "category_name": "Language Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0.975,
+                            "tone_id": "openness_big5",
+                            "tone_name": "Openness"
+                        },
+                        {
+                            "score": 0.932,
+                            "tone_id": "conscientiousness_big5",
+                            "tone_name": "Conscientiousness"
+                        },
+                        {
+                            "score": 0.388,
+                            "tone_id": "extraversion_big5",
+                            "tone_name": "Extraversion"
+                        },
+                        {
+                            "score": 0.137,
+                            "tone_id": "agreeableness_big5",
+                            "tone_name": "Agreeableness"
+                        },
+                        {
+                            "score": 0.18,
+                            "tone_id": "emotional_range_big5",
+                            "tone_name": "Emotional Range"
+                        }
+                    ],
+                    "category_id": "social_tone",
+                    "category_name": "Social Tone"
+                }
+            ]
+        },
+        {
+            "sentence_id": 13,
+            "text": "Go from Corlears Hook to Coenties Slip, and from thence, by Whitehall, northward.",
+            "input_from": 1551,
+            "input_to": 1632,
+            "tone_categories": [
+                {
+                    "tones": [
+                        {
+                            "score": 0.207906,
+                            "tone_id": "anger",
+                            "tone_name": "Anger"
+                        },
+                        {
+                            "score": 0.371378,
+                            "tone_id": "disgust",
+                            "tone_name": "Disgust"
+                        },
+                        {
+                            "score": 0.280693,
+                            "tone_id": "fear",
+                            "tone_name": "Fear"
+                        },
+                        {
+                            "score": 0.102245,
+                            "tone_id": "joy",
+                            "tone_name": "Joy"
+                        },
+                        {
+                            "score": 0.416521,
+                            "tone_id": "sadness",
+                            "tone_name": "Sadness"
+                        }
+                    ],
+                    "category_id": "emotion_tone",
+                    "category_name": "Emotion Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0,
+                            "tone_id": "analytical",
+                            "tone_name": "Analytical"
+                        },
+                        {
+                            "score": 0,
+                            "tone_id": "confident",
+                            "tone_name": "Confident"
+                        },
+                        {
+                            "score": 0,
+                            "tone_id": "tentative",
+                            "tone_name": "Tentative"
+                        }
+                    ],
+                    "category_id": "language_tone",
+                    "category_name": "Language Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0.93,
+                            "tone_id": "openness_big5",
+                            "tone_name": "Openness"
+                        },
+                        {
+                            "score": 0.571,
+                            "tone_id": "conscientiousness_big5",
+                            "tone_name": "Conscientiousness"
+                        },
+                        {
+                            "score": 0.265,
+                            "tone_id": "extraversion_big5",
+                            "tone_name": "Extraversion"
+                        },
+                        {
+                            "score": 0.234,
+                            "tone_id": "agreeableness_big5",
+                            "tone_name": "Agreeableness"
+                        },
+                        {
+                            "score": 0.305,
+                            "tone_id": "emotional_range_big5",
+                            "tone_name": "Emotional Range"
+                        }
+                    ],
+                    "category_id": "social_tone",
+                    "category_name": "Social Tone"
+                }
+            ]
+        },
+        {
+            "sentence_id": 14,
+            "text": "What do you see?-Posted like silent sentinels all around the town, stand thousands upon thousands of mortal men fixed in ocean reveries.",
+            "input_from": 1633,
+            "input_to": 1769,
+            "tone_categories": [
+                {
+                    "tones": [
+                        {
+                            "score": 0.262753,
+                            "tone_id": "anger",
+                            "tone_name": "Anger"
+                        },
+                        {
+                            "score": 0.696676,
+                            "tone_id": "disgust",
+                            "tone_name": "Disgust"
+                        },
+                        {
+                            "score": 0.194555,
+                            "tone_id": "fear",
+                            "tone_name": "Fear"
+                        },
+                        {
+                            "score": 0.15851,
+                            "tone_id": "joy",
+                            "tone_name": "Joy"
+                        },
+                        {
+                            "score": 0.270896,
+                            "tone_id": "sadness",
+                            "tone_name": "Sadness"
+                        }
+                    ],
+                    "category_id": "emotion_tone",
+                    "category_name": "Emotion Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0,
+                            "tone_id": "analytical",
+                            "tone_name": "Analytical"
+                        },
+                        {
+                            "score": 0,
+                            "tone_id": "confident",
+                            "tone_name": "Confident"
+                        },
+                        {
+                            "score": 0.082,
+                            "tone_id": "tentative",
+                            "tone_name": "Tentative"
+                        }
+                    ],
+                    "category_id": "language_tone",
+                    "category_name": "Language Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0.351,
+                            "tone_id": "openness_big5",
+                            "tone_name": "Openness"
+                        },
+                        {
+                            "score": 0.201,
+                            "tone_id": "conscientiousness_big5",
+                            "tone_name": "Conscientiousness"
+                        },
+                        {
+                            "score": 0.722,
+                            "tone_id": "extraversion_big5",
+                            "tone_name": "Extraversion"
+                        },
+                        {
+                            "score": 0.628,
+                            "tone_id": "agreeableness_big5",
+                            "tone_name": "Agreeableness"
+                        },
+                        {
+                            "score": 0.347,
+                            "tone_id": "emotional_range_big5",
+                            "tone_name": "Emotional Range"
+                        }
+                    ],
+                    "category_id": "social_tone",
+                    "category_name": "Social Tone"
+                }
+            ]
+        },
+        {
+            "sentence_id": 15,
+            "text": "Some leaning against the spiles; some seated upon the pier-heads; some looking over the bulwarks of ships from China; some high aloft in the rigging, as if striving to get a still better seaward peep.",
+            "input_from": 1770,
+            "input_to": 1970,
+            "tone_categories": [
+                {
+                    "tones": [
+                        {
+                            "score": 0.382868,
+                            "tone_id": "anger",
+                            "tone_name": "Anger"
+                        },
+                        {
+                            "score": 0.489318,
+                            "tone_id": "disgust",
+                            "tone_name": "Disgust"
+                        },
+                        {
+                            "score": 0.205163,
+                            "tone_id": "fear",
+                            "tone_name": "Fear"
+                        },
+                        {
+                            "score": 0.118944,
+                            "tone_id": "joy",
+                            "tone_name": "Joy"
+                        },
+                        {
+                            "score": 0.425947,
+                            "tone_id": "sadness",
+                            "tone_name": "Sadness"
+                        }
+                    ],
+                    "category_id": "emotion_tone",
+                    "category_name": "Emotion Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0.135,
+                            "tone_id": "analytical",
+                            "tone_name": "Analytical"
+                        },
+                        {
+                            "score": 0,
+                            "tone_id": "confident",
+                            "tone_name": "Confident"
+                        },
+                        {
+                            "score": 0.767,
+                            "tone_id": "tentative",
+                            "tone_name": "Tentative"
+                        }
+                    ],
+                    "category_id": "language_tone",
+                    "category_name": "Language Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0.954,
+                            "tone_id": "openness_big5",
+                            "tone_name": "Openness"
+                        },
+                        {
+                            "score": 0.691,
+                            "tone_id": "conscientiousness_big5",
+                            "tone_name": "Conscientiousness"
+                        },
+                        {
+                            "score": 0.157,
+                            "tone_id": "extraversion_big5",
+                            "tone_name": "Extraversion"
+                        },
+                        {
+                            "score": 0.226,
+                            "tone_id": "agreeableness_big5",
+                            "tone_name": "Agreeableness"
+                        },
+                        {
+                            "score": 0.243,
+                            "tone_id": "emotional_range_big5",
+                            "tone_name": "Emotional Range"
+                        }
+                    ],
+                    "category_id": "social_tone",
+                    "category_name": "Social Tone"
+                }
+            ]
+        },
+        {
+            "sentence_id": 16,
+            "text": "But these are all landsmen; of week days pent up in lath and plaster-tied to counters, nailed to benches, clinched to desks.",
+            "input_from": 1971,
+            "input_to": 2095,
+            "tone_categories": [
+                {
+                    "tones": [
+                        {
+                            "score": 0.109781,
+                            "tone_id": "anger",
+                            "tone_name": "Anger"
+                        },
+                        {
+                            "score": 0.348402,
+                            "tone_id": "disgust",
+                            "tone_name": "Disgust"
+                        },
+                        {
+                            "score": 0.100454,
+                            "tone_id": "fear",
+                            "tone_name": "Fear"
+                        },
+                        {
+                            "score": 0.439683,
+                            "tone_id": "joy",
+                            "tone_name": "Joy"
+                        },
+                        {
+                            "score": 0.396121,
+                            "tone_id": "sadness",
+                            "tone_name": "Sadness"
+                        }
+                    ],
+                    "category_id": "emotion_tone",
+                    "category_name": "Emotion Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0,
+                            "tone_id": "analytical",
+                            "tone_name": "Analytical"
+                        },
+                        {
+                            "score": 0.493,
+                            "tone_id": "confident",
+                            "tone_name": "Confident"
+                        },
+                        {
+                            "score": 0,
+                            "tone_id": "tentative",
+                            "tone_name": "Tentative"
+                        }
+                    ],
+                    "category_id": "language_tone",
+                    "category_name": "Language Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0.871,
+                            "tone_id": "openness_big5",
+                            "tone_name": "Openness"
+                        },
+                        {
+                            "score": 0.405,
+                            "tone_id": "conscientiousness_big5",
+                            "tone_name": "Conscientiousness"
+                        },
+                        {
+                            "score": 0.274,
+                            "tone_id": "extraversion_big5",
+                            "tone_name": "Extraversion"
+                        },
+                        {
+                            "score": 0.258,
+                            "tone_id": "agreeableness_big5",
+                            "tone_name": "Agreeableness"
+                        },
+                        {
+                            "score": 0.671,
+                            "tone_id": "emotional_range_big5",
+                            "tone_name": "Emotional Range"
+                        }
+                    ],
+                    "category_id": "social_tone",
+                    "category_name": "Social Tone"
+                }
+            ]
+        },
+        {
+            "sentence_id": 17,
+            "text": "How then is this?",
+            "input_from": 2096,
+            "input_to": 2113,
+            "tone_categories": [
+                {
+                    "tones": [
+                        {
+                            "score": 0.289338,
+                            "tone_id": "anger",
+                            "tone_name": "Anger"
+                        },
+                        {
+                            "score": 0.487263,
+                            "tone_id": "disgust",
+                            "tone_name": "Disgust"
+                        },
+                        {
+                            "score": 0.184789,
+                            "tone_id": "fear",
+                            "tone_name": "Fear"
+                        },
+                        {
+                            "score": 0.060132,
+                            "tone_id": "joy",
+                            "tone_name": "Joy"
+                        },
+                        {
+                            "score": 0.370277,
+                            "tone_id": "sadness",
+                            "tone_name": "Sadness"
+                        }
+                    ],
+                    "category_id": "emotion_tone",
+                    "category_name": "Emotion Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0.847,
+                            "tone_id": "analytical",
+                            "tone_name": "Analytical"
+                        },
+                        {
+                            "score": 0,
+                            "tone_id": "confident",
+                            "tone_name": "Confident"
+                        },
+                        {
+                            "score": 0,
+                            "tone_id": "tentative",
+                            "tone_name": "Tentative"
+                        }
+                    ],
+                    "category_id": "language_tone",
+                    "category_name": "Language Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0.31,
+                            "tone_id": "openness_big5",
+                            "tone_name": "Openness"
+                        },
+                        {
+                            "score": 0.132,
+                            "tone_id": "conscientiousness_big5",
+                            "tone_name": "Conscientiousness"
+                        },
+                        {
+                            "score": 0.157,
+                            "tone_id": "extraversion_big5",
+                            "tone_name": "Extraversion"
+                        },
+                        {
+                            "score": 0.335,
+                            "tone_id": "agreeableness_big5",
+                            "tone_name": "Agreeableness"
+                        },
+                        {
+                            "score": 0.954,
+                            "tone_id": "emotional_range_big5",
+                            "tone_name": "Emotional Range"
+                        }
+                    ],
+                    "category_id": "social_tone",
+                    "category_name": "Social Tone"
+                }
+            ]
+        },
+        {
+            "sentence_id": 18,
+            "text": "Are the green fields gone?",
+            "input_from": 2114,
+            "input_to": 2140,
+            "tone_categories": [
+                {
+                    "tones": [
+                        {
+                            "score": 0.150856,
+                            "tone_id": "anger",
+                            "tone_name": "Anger"
+                        },
+                        {
+                            "score": 0.364911,
+                            "tone_id": "disgust",
+                            "tone_name": "Disgust"
+                        },
+                        {
+                            "score": 0.294397,
+                            "tone_id": "fear",
+                            "tone_name": "Fear"
+                        },
+                        {
+                            "score": 0.153937,
+                            "tone_id": "joy",
+                            "tone_name": "Joy"
+                        },
+                        {
+                            "score": 0.284773,
+                            "tone_id": "sadness",
+                            "tone_name": "Sadness"
+                        }
+                    ],
+                    "category_id": "emotion_tone",
+                    "category_name": "Emotion Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0,
+                            "tone_id": "analytical",
+                            "tone_name": "Analytical"
+                        },
+                        {
+                            "score": 0,
+                            "tone_id": "confident",
+                            "tone_name": "Confident"
+                        },
+                        {
+                            "score": 0,
+                            "tone_id": "tentative",
+                            "tone_name": "Tentative"
+                        }
+                    ],
+                    "category_id": "language_tone",
+                    "category_name": "Language Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0.418,
+                            "tone_id": "openness_big5",
+                            "tone_name": "Openness"
+                        },
+                        {
+                            "score": 0.897,
+                            "tone_id": "conscientiousness_big5",
+                            "tone_name": "Conscientiousness"
+                        },
+                        {
+                            "score": 0.157,
+                            "tone_id": "extraversion_big5",
+                            "tone_name": "Extraversion"
+                        },
+                        {
+                            "score": 0.342,
+                            "tone_id": "agreeableness_big5",
+                            "tone_name": "Agreeableness"
+                        },
+                        {
+                            "score": 0.102,
+                            "tone_id": "emotional_range_big5",
+                            "tone_name": "Emotional Range"
+                        }
+                    ],
+                    "category_id": "social_tone",
+                    "category_name": "Social Tone"
+                }
+            ]
+        },
+        {
+            "sentence_id": 19,
+            "text": "What do they here?",
+            "input_from": 2141,
+            "input_to": 2159,
+            "tone_categories": [
+                {
+                    "tones": [
+                        {
+                            "score": 0.298403,
+                            "tone_id": "anger",
+                            "tone_name": "Anger"
+                        },
+                        {
+                            "score": 0.484869,
+                            "tone_id": "disgust",
+                            "tone_name": "Disgust"
+                        },
+                        {
+                            "score": 0.244632,
+                            "tone_id": "fear",
+                            "tone_name": "Fear"
+                        },
+                        {
+                            "score": 0.119957,
+                            "tone_id": "joy",
+                            "tone_name": "Joy"
+                        },
+                        {
+                            "score": 0.282312,
+                            "tone_id": "sadness",
+                            "tone_name": "Sadness"
+                        }
+                    ],
+                    "category_id": "emotion_tone",
+                    "category_name": "Emotion Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0,
+                            "tone_id": "analytical",
+                            "tone_name": "Analytical"
+                        },
+                        {
+                            "score": 0,
+                            "tone_id": "confident",
+                            "tone_name": "Confident"
+                        },
+                        {
+                            "score": 0,
+                            "tone_id": "tentative",
+                            "tone_name": "Tentative"
+                        }
+                    ],
+                    "category_id": "language_tone",
+                    "category_name": "Language Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0.06,
+                            "tone_id": "openness_big5",
+                            "tone_name": "Openness"
+                        },
+                        {
+                            "score": 0.19,
+                            "tone_id": "conscientiousness_big5",
+                            "tone_name": "Conscientiousness"
+                        },
+                        {
+                            "score": 0.93,
+                            "tone_id": "extraversion_big5",
+                            "tone_name": "Extraversion"
+                        },
+                        {
+                            "score": 0.985,
+                            "tone_id": "agreeableness_big5",
+                            "tone_name": "Agreeableness"
+                        },
+                        {
+                            "score": 0.261,
+                            "tone_id": "emotional_range_big5",
+                            "tone_name": "Emotional Range"
+                        }
+                    ],
+                    "category_id": "social_tone",
+                    "category_name": "Social Tone"
+                }
+            ]
+        },
+        {
+            "sentence_id": 20,
+            "text": "But look! here come more crowds, pacing straight for the water, and seemingly bound for a dive.",
+            "input_from": 2160,
+            "input_to": 2255,
+            "tone_categories": [
+                {
+                    "tones": [
+                        {
+                            "score": 0.081729,
+                            "tone_id": "anger",
+                            "tone_name": "Anger"
+                        },
+                        {
+                            "score": 0.366571,
+                            "tone_id": "disgust",
+                            "tone_name": "Disgust"
+                        },
+                        {
+                            "score": 0.179309,
+                            "tone_id": "fear",
+                            "tone_name": "Fear"
+                        },
+                        {
+                            "score": 0.336148,
+                            "tone_id": "joy",
+                            "tone_name": "Joy"
+                        },
+                        {
+                            "score": 0.33228,
+                            "tone_id": "sadness",
+                            "tone_name": "Sadness"
+                        }
+                    ],
+                    "category_id": "emotion_tone",
+                    "category_name": "Emotion Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0.459,
+                            "tone_id": "analytical",
+                            "tone_name": "Analytical"
+                        },
+                        {
+                            "score": 0,
+                            "tone_id": "confident",
+                            "tone_name": "Confident"
+                        },
+                        {
+                            "score": 0.38,
+                            "tone_id": "tentative",
+                            "tone_name": "Tentative"
+                        }
+                    ],
+                    "category_id": "language_tone",
+                    "category_name": "Language Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0.891,
+                            "tone_id": "openness_big5",
+                            "tone_name": "Openness"
+                        },
+                        {
+                            "score": 0.286,
+                            "tone_id": "conscientiousness_big5",
+                            "tone_name": "Conscientiousness"
+                        },
+                        {
+                            "score": 0.371,
+                            "tone_id": "extraversion_big5",
+                            "tone_name": "Extraversion"
+                        },
+                        {
+                            "score": 0.222,
+                            "tone_id": "agreeableness_big5",
+                            "tone_name": "Agreeableness"
+                        },
+                        {
+                            "score": 0.528,
+                            "tone_id": "emotional_range_big5",
+                            "tone_name": "Emotional Range"
+                        }
+                    ],
+                    "category_id": "social_tone",
+                    "category_name": "Social Tone"
+                }
+            ]
+        },
+        {
+            "sentence_id": 21,
+            "text": "Strange!",
+            "input_from": 2256,
+            "input_to": 2264,
+            "tone_categories": []
+        },
+        {
+            "sentence_id": 22,
+            "text": "Nothing will content them but the extremest limit of the land; loitering under the shady lee of yonder warehouses will not suffice.",
+            "input_from": 2265,
+            "input_to": 2396,
+            "tone_categories": [
+                {
+                    "tones": [
+                        {
+                            "score": 0.214428,
+                            "tone_id": "anger",
+                            "tone_name": "Anger"
+                        },
+                        {
+                            "score": 0.400577,
+                            "tone_id": "disgust",
+                            "tone_name": "Disgust"
+                        },
+                        {
+                            "score": 0.44209,
+                            "tone_id": "fear",
+                            "tone_name": "Fear"
+                        },
+                        {
+                            "score": 0.079106,
+                            "tone_id": "joy",
+                            "tone_name": "Joy"
+                        },
+                        {
+                            "score": 0.253806,
+                            "tone_id": "sadness",
+                            "tone_name": "Sadness"
+                        }
+                    ],
+                    "category_id": "emotion_tone",
+                    "category_name": "Emotion Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0,
+                            "tone_id": "analytical",
+                            "tone_name": "Analytical"
+                        },
+                        {
+                            "score": 0,
+                            "tone_id": "confident",
+                            "tone_name": "Confident"
+                        },
+                        {
+                            "score": 0,
+                            "tone_id": "tentative",
+                            "tone_name": "Tentative"
+                        }
+                    ],
+                    "category_id": "language_tone",
+                    "category_name": "Language Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0.721,
+                            "tone_id": "openness_big5",
+                            "tone_name": "Openness"
+                        },
+                        {
+                            "score": 0.202,
+                            "tone_id": "conscientiousness_big5",
+                            "tone_name": "Conscientiousness"
+                        },
+                        {
+                            "score": 0.274,
+                            "tone_id": "extraversion_big5",
+                            "tone_name": "Extraversion"
+                        },
+                        {
+                            "score": 0.214,
+                            "tone_id": "agreeableness_big5",
+                            "tone_name": "Agreeableness"
+                        },
+                        {
+                            "score": 0.671,
+                            "tone_id": "emotional_range_big5",
+                            "tone_name": "Emotional Range"
+                        }
+                    ],
+                    "category_id": "social_tone",
+                    "category_name": "Social Tone"
+                }
+            ]
+        },
+        {
+            "sentence_id": 23,
+            "text": "No.",
+            "input_from": 2397,
+            "input_to": 2400,
+            "tone_categories": []
+        },
+        {
+            "sentence_id": 24,
+            "text": "They must get just as nigh the water as they possibly can without falling in.",
+            "input_from": 2401,
+            "input_to": 2478,
+            "tone_categories": [
+                {
+                    "tones": [
+                        {
+                            "score": 0.149916,
+                            "tone_id": "anger",
+                            "tone_name": "Anger"
+                        },
+                        {
+                            "score": 0.438289,
+                            "tone_id": "disgust",
+                            "tone_name": "Disgust"
+                        },
+                        {
+                            "score": 0.309294,
+                            "tone_id": "fear",
+                            "tone_name": "Fear"
+                        },
+                        {
+                            "score": 0.103366,
+                            "tone_id": "joy",
+                            "tone_name": "Joy"
+                        },
+                        {
+                            "score": 0.428773,
+                            "tone_id": "sadness",
+                            "tone_name": "Sadness"
+                        }
+                    ],
+                    "category_id": "emotion_tone",
+                    "category_name": "Emotion Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0,
+                            "tone_id": "analytical",
+                            "tone_name": "Analytical"
+                        },
+                        {
+                            "score": 0,
+                            "tone_id": "confident",
+                            "tone_name": "Confident"
+                        },
+                        {
+                            "score": 0.451,
+                            "tone_id": "tentative",
+                            "tone_name": "Tentative"
+                        }
+                    ],
+                    "category_id": "language_tone",
+                    "category_name": "Language Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0.556,
+                            "tone_id": "openness_big5",
+                            "tone_name": "Openness"
+                        },
+                        {
+                            "score": 0.076,
+                            "tone_id": "conscientiousness_big5",
+                            "tone_name": "Conscientiousness"
+                        },
+                        {
+                            "score": 0.546,
+                            "tone_id": "extraversion_big5",
+                            "tone_name": "Extraversion"
+                        },
+                        {
+                            "score": 0.511,
+                            "tone_id": "agreeableness_big5",
+                            "tone_name": "Agreeableness"
+                        },
+                        {
+                            "score": 0.826,
+                            "tone_id": "emotional_range_big5",
+                            "tone_name": "Emotional Range"
+                        }
+                    ],
+                    "category_id": "social_tone",
+                    "category_name": "Social Tone"
+                }
+            ]
+        },
+        {
+            "sentence_id": 25,
+            "text": "And there they stand-miles of them-leagues.",
+            "input_from": 2479,
+            "input_to": 2522,
+            "tone_categories": [
+                {
+                    "tones": [
+                        {
+                            "score": 0.195838,
+                            "tone_id": "anger",
+                            "tone_name": "Anger"
+                        },
+                        {
+                            "score": 0.609443,
+                            "tone_id": "disgust",
+                            "tone_name": "Disgust"
+                        },
+                        {
+                            "score": 0.237532,
+                            "tone_id": "fear",
+                            "tone_name": "Fear"
+                        },
+                        {
+                            "score": 0.218651,
+                            "tone_id": "joy",
+                            "tone_name": "Joy"
+                        },
+                        {
+                            "score": 0.238227,
+                            "tone_id": "sadness",
+                            "tone_name": "Sadness"
+                        }
+                    ],
+                    "category_id": "emotion_tone",
+                    "category_name": "Emotion Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0,
+                            "tone_id": "analytical",
+                            "tone_name": "Analytical"
+                        },
+                        {
+                            "score": 0,
+                            "tone_id": "confident",
+                            "tone_name": "Confident"
+                        },
+                        {
+                            "score": 0,
+                            "tone_id": "tentative",
+                            "tone_name": "Tentative"
+                        }
+                    ],
+                    "category_id": "language_tone",
+                    "category_name": "Language Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0.498,
+                            "tone_id": "openness_big5",
+                            "tone_name": "Openness"
+                        },
+                        {
+                            "score": 0.201,
+                            "tone_id": "conscientiousness_big5",
+                            "tone_name": "Conscientiousness"
+                        },
+                        {
+                            "score": 0.812,
+                            "tone_id": "extraversion_big5",
+                            "tone_name": "Extraversion"
+                        },
+                        {
+                            "score": 0.902,
+                            "tone_id": "agreeableness_big5",
+                            "tone_name": "Agreeableness"
+                        },
+                        {
+                            "score": 0.23,
+                            "tone_id": "emotional_range_big5",
+                            "tone_name": "Emotional Range"
+                        }
+                    ],
+                    "category_id": "social_tone",
+                    "category_name": "Social Tone"
+                }
+            ]
+        },
+        {
+            "sentence_id": 26,
+            "text": "Inlanders all, they come from lanes and alleys, streets and avenues-north, east, south, and west.",
+            "input_from": 2523,
+            "input_to": 2620,
+            "tone_categories": [
+                {
+                    "tones": [
+                        {
+                            "score": 0.20581,
+                            "tone_id": "anger",
+                            "tone_name": "Anger"
+                        },
+                        {
+                            "score": 0.242848,
+                            "tone_id": "disgust",
+                            "tone_name": "Disgust"
+                        },
+                        {
+                            "score": 0.156057,
+                            "tone_id": "fear",
+                            "tone_name": "Fear"
+                        },
+                        {
+                            "score": 0.317132,
+                            "tone_id": "joy",
+                            "tone_name": "Joy"
+                        },
+                        {
+                            "score": 0.284507,
+                            "tone_id": "sadness",
+                            "tone_name": "Sadness"
+                        }
+                    ],
+                    "category_id": "emotion_tone",
+                    "category_name": "Emotion Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0,
+                            "tone_id": "analytical",
+                            "tone_name": "Analytical"
+                        },
+                        {
+                            "score": 0.72,
+                            "tone_id": "confident",
+                            "tone_name": "Confident"
+                        },
+                        {
+                            "score": 0,
+                            "tone_id": "tentative",
+                            "tone_name": "Tentative"
+                        }
+                    ],
+                    "category_id": "language_tone",
+                    "category_name": "Language Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0.566,
+                            "tone_id": "openness_big5",
+                            "tone_name": "Openness"
+                        },
+                        {
+                            "score": 0.565,
+                            "tone_id": "conscientiousness_big5",
+                            "tone_name": "Conscientiousness"
+                        },
+                        {
+                            "score": 0.72,
+                            "tone_id": "extraversion_big5",
+                            "tone_name": "Extraversion"
+                        },
+                        {
+                            "score": 0.818,
+                            "tone_id": "agreeableness_big5",
+                            "tone_name": "Agreeableness"
+                        },
+                        {
+                            "score": 0.111,
+                            "tone_id": "emotional_range_big5",
+                            "tone_name": "Emotional Range"
+                        }
+                    ],
+                    "category_id": "social_tone",
+                    "category_name": "Social Tone"
+                }
+            ]
+        },
+        {
+            "sentence_id": 27,
+            "text": "Yet here they all unite.",
+            "input_from": 2621,
+            "input_to": 2645,
+            "tone_categories": [
+                {
+                    "tones": [
+                        {
+                            "score": 0.221384,
+                            "tone_id": "anger",
+                            "tone_name": "Anger"
+                        },
+                        {
+                            "score": 0.169253,
+                            "tone_id": "disgust",
+                            "tone_name": "Disgust"
+                        },
+                        {
+                            "score": 0.151174,
+                            "tone_id": "fear",
+                            "tone_name": "Fear"
+                        },
+                        {
+                            "score": 0.250741,
+                            "tone_id": "joy",
+                            "tone_name": "Joy"
+                        },
+                        {
+                            "score": 0.430384,
+                            "tone_id": "sadness",
+                            "tone_name": "Sadness"
+                        }
+                    ],
+                    "category_id": "emotion_tone",
+                    "category_name": "Emotion Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0,
+                            "tone_id": "analytical",
+                            "tone_name": "Analytical"
+                        },
+                        {
+                            "score": 0.987,
+                            "tone_id": "confident",
+                            "tone_name": "Confident"
+                        },
+                        {
+                            "score": 0,
+                            "tone_id": "tentative",
+                            "tone_name": "Tentative"
+                        }
+                    ],
+                    "category_id": "language_tone",
+                    "category_name": "Language Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0.277,
+                            "tone_id": "openness_big5",
+                            "tone_name": "Openness"
+                        },
+                        {
+                            "score": 0.267,
+                            "tone_id": "conscientiousness_big5",
+                            "tone_name": "Conscientiousness"
+                        },
+                        {
+                            "score": 0.932,
+                            "tone_id": "extraversion_big5",
+                            "tone_name": "Extraversion"
+                        },
+                        {
+                            "score": 0.954,
+                            "tone_id": "agreeableness_big5",
+                            "tone_name": "Agreeableness"
+                        },
+                        {
+                            "score": 0.287,
+                            "tone_id": "emotional_range_big5",
+                            "tone_name": "Emotional Range"
+                        }
+                    ],
+                    "category_id": "social_tone",
+                    "category_name": "Social Tone"
+                }
+            ]
+        },
+        {
+            "sentence_id": 28,
+            "text": "Tell me, does the magnetic virtue of the needles of the compasses of all those ships attract them thither?",
+            "input_from": 2646,
+            "input_to": 2752,
+            "tone_categories": [
+                {
+                    "tones": [
+                        {
+                            "score": 0.225617,
+                            "tone_id": "anger",
+                            "tone_name": "Anger"
+                        },
+                        {
+                            "score": 0.571378,
+                            "tone_id": "disgust",
+                            "tone_name": "Disgust"
+                        },
+                        {
+                            "score": 0.290246,
+                            "tone_id": "fear",
+                            "tone_name": "Fear"
+                        },
+                        {
+                            "score": 0.164151,
+                            "tone_id": "joy",
+                            "tone_name": "Joy"
+                        },
+                        {
+                            "score": 0.183171,
+                            "tone_id": "sadness",
+                            "tone_name": "Sadness"
+                        }
+                    ],
+                    "category_id": "emotion_tone",
+                    "category_name": "Emotion Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0,
+                            "tone_id": "analytical",
+                            "tone_name": "Analytical"
+                        },
+                        {
+                            "score": 0.597,
+                            "tone_id": "confident",
+                            "tone_name": "Confident"
+                        },
+                        {
+                            "score": 0,
+                            "tone_id": "tentative",
+                            "tone_name": "Tentative"
+                        }
+                    ],
+                    "category_id": "language_tone",
+                    "category_name": "Language Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0.465,
+                            "tone_id": "openness_big5",
+                            "tone_name": "Openness"
+                        },
+                        {
+                            "score": 0.524,
+                            "tone_id": "conscientiousness_big5",
+                            "tone_name": "Conscientiousness"
+                        },
+                        {
+                            "score": 0.823,
+                            "tone_id": "extraversion_big5",
+                            "tone_name": "Extraversion"
+                        },
+                        {
+                            "score": 0.429,
+                            "tone_id": "agreeableness_big5",
+                            "tone_name": "Agreeableness"
+                        },
+                        {
+                            "score": 0.364,
+                            "tone_id": "emotional_range_big5",
+                            "tone_name": "Emotional Range"
+                        }
+                    ],
+                    "category_id": "social_tone",
+                    "category_name": "Social Tone"
+                }
+            ]
+        },
+        {
+            "sentence_id": 29,
+            "text": "Once more.",
+            "input_from": 2753,
+            "input_to": 2763,
+            "tone_categories": []
+        },
+        {
+            "sentence_id": 30,
+            "text": "Say you are in the country; in some high land of lakes.",
+            "input_from": 2764,
+            "input_to": 2819,
+            "tone_categories": [
+                {
+                    "tones": [
+                        {
+                            "score": 0.141122,
+                            "tone_id": "anger",
+                            "tone_name": "Anger"
+                        },
+                        {
+                            "score": 0.421809,
+                            "tone_id": "disgust",
+                            "tone_name": "Disgust"
+                        },
+                        {
+                            "score": 0.361904,
+                            "tone_id": "fear",
+                            "tone_name": "Fear"
+                        },
+                        {
+                            "score": 0.202674,
+                            "tone_id": "joy",
+                            "tone_name": "Joy"
+                        },
+                        {
+                            "score": 0.359623,
+                            "tone_id": "sadness",
+                            "tone_name": "Sadness"
+                        }
+                    ],
+                    "category_id": "emotion_tone",
+                    "category_name": "Emotion Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0,
+                            "tone_id": "analytical",
+                            "tone_name": "Analytical"
+                        },
+                        {
+                            "score": 0,
+                            "tone_id": "confident",
+                            "tone_name": "Confident"
+                        },
+                        {
+                            "score": 0.614,
+                            "tone_id": "tentative",
+                            "tone_name": "Tentative"
+                        }
+                    ],
+                    "category_id": "language_tone",
+                    "category_name": "Language Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0.603,
+                            "tone_id": "openness_big5",
+                            "tone_name": "Openness"
+                        },
+                        {
+                            "score": 0.387,
+                            "tone_id": "conscientiousness_big5",
+                            "tone_name": "Conscientiousness"
+                        },
+                        {
+                            "score": 0.919,
+                            "tone_id": "extraversion_big5",
+                            "tone_name": "Extraversion"
+                        },
+                        {
+                            "score": 0.785,
+                            "tone_id": "agreeableness_big5",
+                            "tone_name": "Agreeableness"
+                        },
+                        {
+                            "score": 0.035,
+                            "tone_id": "emotional_range_big5",
+                            "tone_name": "Emotional Range"
+                        }
+                    ],
+                    "category_id": "social_tone",
+                    "category_name": "Social Tone"
+                }
+            ]
+        },
+        {
+            "sentence_id": 31,
+            "text": "Take almost any path you please, and ten to one it carries you down in a dale, and leaves you there by a pool in the stream.",
+            "input_from": 2820,
+            "input_to": 2944,
+            "tone_categories": [
+                {
+                    "tones": [
+                        {
+                            "score": 0.279927,
+                            "tone_id": "anger",
+                            "tone_name": "Anger"
+                        },
+                        {
+                            "score": 0.343172,
+                            "tone_id": "disgust",
+                            "tone_name": "Disgust"
+                        },
+                        {
+                            "score": 0.36336,
+                            "tone_id": "fear",
+                            "tone_name": "Fear"
+                        },
+                        {
+                            "score": 0.149495,
+                            "tone_id": "joy",
+                            "tone_name": "Joy"
+                        },
+                        {
+                            "score": 0.305648,
+                            "tone_id": "sadness",
+                            "tone_name": "Sadness"
+                        }
+                    ],
+                    "category_id": "emotion_tone",
+                    "category_name": "Emotion Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0,
+                            "tone_id": "analytical",
+                            "tone_name": "Analytical"
+                        },
+                        {
+                            "score": 0,
+                            "tone_id": "confident",
+                            "tone_name": "Confident"
+                        },
+                        {
+                            "score": 0.733,
+                            "tone_id": "tentative",
+                            "tone_name": "Tentative"
+                        }
+                    ],
+                    "category_id": "language_tone",
+                    "category_name": "Language Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0.412,
+                            "tone_id": "openness_big5",
+                            "tone_name": "Openness"
+                        },
+                        {
+                            "score": 0.649,
+                            "tone_id": "conscientiousness_big5",
+                            "tone_name": "Conscientiousness"
+                        },
+                        {
+                            "score": 0.748,
+                            "tone_id": "extraversion_big5",
+                            "tone_name": "Extraversion"
+                        },
+                        {
+                            "score": 0.876,
+                            "tone_id": "agreeableness_big5",
+                            "tone_name": "Agreeableness"
+                        },
+                        {
+                            "score": 0.03,
+                            "tone_id": "emotional_range_big5",
+                            "tone_name": "Emotional Range"
+                        }
+                    ],
+                    "category_id": "social_tone",
+                    "category_name": "Social Tone"
+                }
+            ]
+        },
+        {
+            "sentence_id": 32,
+            "text": "There is magic in it.",
+            "input_from": 2945,
+            "input_to": 2966,
+            "tone_categories": [
+                {
+                    "tones": [
+                        {
+                            "score": 0.151178,
+                            "tone_id": "anger",
+                            "tone_name": "Anger"
+                        },
+                        {
+                            "score": 0.362646,
+                            "tone_id": "disgust",
+                            "tone_name": "Disgust"
+                        },
+                        {
+                            "score": 0.405931,
+                            "tone_id": "fear",
+                            "tone_name": "Fear"
+                        },
+                        {
+                            "score": 0.202287,
+                            "tone_id": "joy",
+                            "tone_name": "Joy"
+                        },
+                        {
+                            "score": 0.323321,
+                            "tone_id": "sadness",
+                            "tone_name": "Sadness"
+                        }
+                    ],
+                    "category_id": "emotion_tone",
+                    "category_name": "Emotion Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0,
+                            "tone_id": "analytical",
+                            "tone_name": "Analytical"
+                        },
+                        {
+                            "score": 0,
+                            "tone_id": "confident",
+                            "tone_name": "Confident"
+                        },
+                        {
+                            "score": 0,
+                            "tone_id": "tentative",
+                            "tone_name": "Tentative"
+                        }
+                    ],
+                    "category_id": "language_tone",
+                    "category_name": "Language Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0.58,
+                            "tone_id": "openness_big5",
+                            "tone_name": "Openness"
+                        },
+                        {
+                            "score": 0.153,
+                            "tone_id": "conscientiousness_big5",
+                            "tone_name": "Conscientiousness"
+                        },
+                        {
+                            "score": 0.393,
+                            "tone_id": "extraversion_big5",
+                            "tone_name": "Extraversion"
+                        },
+                        {
+                            "score": 0.743,
+                            "tone_id": "agreeableness_big5",
+                            "tone_name": "Agreeableness"
+                        },
+                        {
+                            "score": 0.511,
+                            "tone_id": "emotional_range_big5",
+                            "tone_name": "Emotional Range"
+                        }
+                    ],
+                    "category_id": "social_tone",
+                    "category_name": "Social Tone"
+                }
+            ]
+        },
+        {
+            "sentence_id": 33,
+            "text": "Let the most absent-minded of men be plunged in his deepest reveries-stand that man on his legs, set his feet a-going, and he will infallibly lead you to water, if water there be in all that region.",
+            "input_from": 2967,
+            "input_to": 3165,
+            "tone_categories": [
+                {
+                    "tones": [
+                        {
+                            "score": 0.073153,
+                            "tone_id": "anger",
+                            "tone_name": "Anger"
+                        },
+                        {
+                            "score": 0.722682,
+                            "tone_id": "disgust",
+                            "tone_name": "Disgust"
+                        },
+                        {
+                            "score": 0.45649,
+                            "tone_id": "fear",
+                            "tone_name": "Fear"
+                        },
+                        {
+                            "score": 0.065335,
+                            "tone_id": "joy",
+                            "tone_name": "Joy"
+                        },
+                        {
+                            "score": 0.408581,
+                            "tone_id": "sadness",
+                            "tone_name": "Sadness"
+                        }
+                    ],
+                    "category_id": "emotion_tone",
+                    "category_name": "Emotion Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0.114,
+                            "tone_id": "analytical",
+                            "tone_name": "Analytical"
+                        },
+                        {
+                            "score": 0.255,
+                            "tone_id": "confident",
+                            "tone_name": "Confident"
+                        },
+                        {
+                            "score": 0,
+                            "tone_id": "tentative",
+                            "tone_name": "Tentative"
+                        }
+                    ],
+                    "category_id": "language_tone",
+                    "category_name": "Language Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0.459,
+                            "tone_id": "openness_big5",
+                            "tone_name": "Openness"
+                        },
+                        {
+                            "score": 0.229,
+                            "tone_id": "conscientiousness_big5",
+                            "tone_name": "Conscientiousness"
+                        },
+                        {
+                            "score": 0.9,
+                            "tone_id": "extraversion_big5",
+                            "tone_name": "Extraversion"
+                        },
+                        {
+                            "score": 0.784,
+                            "tone_id": "agreeableness_big5",
+                            "tone_name": "Agreeableness"
+                        },
+                        {
+                            "score": 0.309,
+                            "tone_id": "emotional_range_big5",
+                            "tone_name": "Emotional Range"
+                        }
+                    ],
+                    "category_id": "social_tone",
+                    "category_name": "Social Tone"
+                }
+            ]
+        },
+        {
+            "sentence_id": 34,
+            "text": "Should you ever be athirst in the great American desert, try this experiment, if your caravan happen to be supplied with a metaphysical professor.",
+            "input_from": 3166,
+            "input_to": 3312,
+            "tone_categories": [
+                {
+                    "tones": [
+                        {
+                            "score": 0.252295,
+                            "tone_id": "anger",
+                            "tone_name": "Anger"
+                        },
+                        {
+                            "score": 0.52585,
+                            "tone_id": "disgust",
+                            "tone_name": "Disgust"
+                        },
+                        {
+                            "score": 0.234371,
+                            "tone_id": "fear",
+                            "tone_name": "Fear"
+                        },
+                        {
+                            "score": 0.112877,
+                            "tone_id": "joy",
+                            "tone_name": "Joy"
+                        },
+                        {
+                            "score": 0.175748,
+                            "tone_id": "sadness",
+                            "tone_name": "Sadness"
+                        }
+                    ],
+                    "category_id": "emotion_tone",
+                    "category_name": "Emotion Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0.275,
+                            "tone_id": "analytical",
+                            "tone_name": "Analytical"
+                        },
+                        {
+                            "score": 0,
+                            "tone_id": "confident",
+                            "tone_name": "Confident"
+                        },
+                        {
+                            "score": 0.199,
+                            "tone_id": "tentative",
+                            "tone_name": "Tentative"
+                        }
+                    ],
+                    "category_id": "language_tone",
+                    "category_name": "Language Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0.661,
+                            "tone_id": "openness_big5",
+                            "tone_name": "Openness"
+                        },
+                        {
+                            "score": 0.392,
+                            "tone_id": "conscientiousness_big5",
+                            "tone_name": "Conscientiousness"
+                        },
+                        {
+                            "score": 0.591,
+                            "tone_id": "extraversion_big5",
+                            "tone_name": "Extraversion"
+                        },
+                        {
+                            "score": 0.412,
+                            "tone_id": "agreeableness_big5",
+                            "tone_name": "Agreeableness"
+                        },
+                        {
+                            "score": 0.389,
+                            "tone_id": "emotional_range_big5",
+                            "tone_name": "Emotional Range"
+                        }
+                    ],
+                    "category_id": "social_tone",
+                    "category_name": "Social Tone"
+                }
+            ]
+        },
+        {
+            "sentence_id": 35,
+            "text": "Yes, as every one knows, meditation and water are wedded for ever.",
+            "input_from": 3313,
+            "input_to": 3379,
+            "tone_categories": [
+                {
+                    "tones": [
+                        {
+                            "score": 0.174186,
+                            "tone_id": "anger",
+                            "tone_name": "Anger"
+                        },
+                        {
+                            "score": 0.248523,
+                            "tone_id": "disgust",
+                            "tone_name": "Disgust"
+                        },
+                        {
+                            "score": 0.148391,
+                            "tone_id": "fear",
+                            "tone_name": "Fear"
+                        },
+                        {
+                            "score": 0.25751,
+                            "tone_id": "joy",
+                            "tone_name": "Joy"
+                        },
+                        {
+                            "score": 0.475705,
+                            "tone_id": "sadness",
+                            "tone_name": "Sadness"
+                        }
+                    ],
+                    "category_id": "emotion_tone",
+                    "category_name": "Emotion Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0.675,
+                            "tone_id": "analytical",
+                            "tone_name": "Analytical"
+                        },
+                        {
+                            "score": 0.786,
+                            "tone_id": "confident",
+                            "tone_name": "Confident"
+                        },
+                        {
+                            "score": 0,
+                            "tone_id": "tentative",
+                            "tone_name": "Tentative"
+                        }
+                    ],
+                    "category_id": "language_tone",
+                    "category_name": "Language Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0.749,
+                            "tone_id": "openness_big5",
+                            "tone_name": "Openness"
+                        },
+                        {
+                            "score": 0.316,
+                            "tone_id": "conscientiousness_big5",
+                            "tone_name": "Conscientiousness"
+                        },
+                        {
+                            "score": 0.261,
+                            "tone_id": "extraversion_big5",
+                            "tone_name": "Extraversion"
+                        },
+                        {
+                            "score": 0.133,
+                            "tone_id": "agreeableness_big5",
+                            "tone_name": "Agreeableness"
+                        },
+                        {
+                            "score": 0.636,
+                            "tone_id": "emotional_range_big5",
+                            "tone_name": "Emotional Range"
+                        }
+                    ],
+                    "category_id": "social_tone",
+                    "category_name": "Social Tone"
+                }
+            ]
+        },
+        {
+            "sentence_id": 36,
+            "text": "But here is an artist.",
+            "input_from": 3380,
+            "input_to": 3402,
+            "tone_categories": [
+                {
+                    "tones": [
+                        {
+                            "score": 0.188722,
+                            "tone_id": "anger",
+                            "tone_name": "Anger"
+                        },
+                        {
+                            "score": 0.138485,
+                            "tone_id": "disgust",
+                            "tone_name": "Disgust"
+                        },
+                        {
+                            "score": 0.171406,
+                            "tone_id": "fear",
+                            "tone_name": "Fear"
+                        },
+                        {
+                            "score": 0.293563,
+                            "tone_id": "joy",
+                            "tone_name": "Joy"
+                        },
+                        {
+                            "score": 0.528097,
+                            "tone_id": "sadness",
+                            "tone_name": "Sadness"
+                        }
+                    ],
+                    "category_id": "emotion_tone",
+                    "category_name": "Emotion Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0,
+                            "tone_id": "analytical",
+                            "tone_name": "Analytical"
+                        },
+                        {
+                            "score": 0,
+                            "tone_id": "confident",
+                            "tone_name": "Confident"
+                        },
+                        {
+                            "score": 0,
+                            "tone_id": "tentative",
+                            "tone_name": "Tentative"
+                        }
+                    ],
+                    "category_id": "language_tone",
+                    "category_name": "Language Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0.615,
+                            "tone_id": "openness_big5",
+                            "tone_name": "Openness"
+                        },
+                        {
+                            "score": 0.03,
+                            "tone_id": "conscientiousness_big5",
+                            "tone_name": "Conscientiousness"
+                        },
+                        {
+                            "score": 0.393,
+                            "tone_id": "extraversion_big5",
+                            "tone_name": "Extraversion"
+                        },
+                        {
+                            "score": 0.552,
+                            "tone_id": "agreeableness_big5",
+                            "tone_name": "Agreeableness"
+                        },
+                        {
+                            "score": 0.844,
+                            "tone_id": "emotional_range_big5",
+                            "tone_name": "Emotional Range"
+                        }
+                    ],
+                    "category_id": "social_tone",
+                    "category_name": "Social Tone"
+                }
+            ]
+        },
+        {
+            "sentence_id": 37,
+            "text": "He desires to paint you the dreamiest, shadiest, quietest, most enchanting bit of romantic landscape in all the valley of the Saco.",
+            "input_from": 3403,
+            "input_to": 3534,
+            "tone_categories": [
+                {
+                    "tones": [
+                        {
+                            "score": 0.115039,
+                            "tone_id": "anger",
+                            "tone_name": "Anger"
+                        },
+                        {
+                            "score": 0.136932,
+                            "tone_id": "disgust",
+                            "tone_name": "Disgust"
+                        },
+                        {
+                            "score": 0.228761,
+                            "tone_id": "fear",
+                            "tone_name": "Fear"
+                        },
+                        {
+                            "score": 0.323535,
+                            "tone_id": "joy",
+                            "tone_name": "Joy"
+                        },
+                        {
+                            "score": 0.433443,
+                            "tone_id": "sadness",
+                            "tone_name": "Sadness"
+                        }
+                    ],
+                    "category_id": "emotion_tone",
+                    "category_name": "Emotion Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0,
+                            "tone_id": "analytical",
+                            "tone_name": "Analytical"
+                        },
+                        {
+                            "score": 0.493,
+                            "tone_id": "confident",
+                            "tone_name": "Confident"
+                        },
+                        {
+                            "score": 0,
+                            "tone_id": "tentative",
+                            "tone_name": "Tentative"
+                        }
+                    ],
+                    "category_id": "language_tone",
+                    "category_name": "Language Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0.735,
+                            "tone_id": "openness_big5",
+                            "tone_name": "Openness"
+                        },
+                        {
+                            "score": 0.761,
+                            "tone_id": "conscientiousness_big5",
+                            "tone_name": "Conscientiousness"
+                        },
+                        {
+                            "score": 0.804,
+                            "tone_id": "extraversion_big5",
+                            "tone_name": "Extraversion"
+                        },
+                        {
+                            "score": 0.545,
+                            "tone_id": "agreeableness_big5",
+                            "tone_name": "Agreeableness"
+                        },
+                        {
+                            "score": 0.136,
+                            "tone_id": "emotional_range_big5",
+                            "tone_name": "Emotional Range"
+                        }
+                    ],
+                    "category_id": "social_tone",
+                    "category_name": "Social Tone"
+                }
+            ]
+        },
+        {
+            "sentence_id": 38,
+            "text": "What is the chief element he employs?",
+            "input_from": 3535,
+            "input_to": 3572,
+            "tone_categories": [
+                {
+                    "tones": [
+                        {
+                            "score": 0.398249,
+                            "tone_id": "anger",
+                            "tone_name": "Anger"
+                        },
+                        {
+                            "score": 0.351877,
+                            "tone_id": "disgust",
+                            "tone_name": "Disgust"
+                        },
+                        {
+                            "score": 0.410105,
+                            "tone_id": "fear",
+                            "tone_name": "Fear"
+                        },
+                        {
+                            "score": 0.088988,
+                            "tone_id": "joy",
+                            "tone_name": "Joy"
+                        },
+                        {
+                            "score": 0.129349,
+                            "tone_id": "sadness",
+                            "tone_name": "Sadness"
+                        }
+                    ],
+                    "category_id": "emotion_tone",
+                    "category_name": "Emotion Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0,
+                            "tone_id": "analytical",
+                            "tone_name": "Analytical"
+                        },
+                        {
+                            "score": 0,
+                            "tone_id": "confident",
+                            "tone_name": "Confident"
+                        },
+                        {
+                            "score": 0,
+                            "tone_id": "tentative",
+                            "tone_name": "Tentative"
+                        }
+                    ],
+                    "category_id": "language_tone",
+                    "category_name": "Language Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0.372,
+                            "tone_id": "openness_big5",
+                            "tone_name": "Openness"
+                        },
+                        {
+                            "score": 0.519,
+                            "tone_id": "conscientiousness_big5",
+                            "tone_name": "Conscientiousness"
+                        },
+                        {
+                            "score": 0.351,
+                            "tone_id": "extraversion_big5",
+                            "tone_name": "Extraversion"
+                        },
+                        {
+                            "score": 0.423,
+                            "tone_id": "agreeableness_big5",
+                            "tone_name": "Agreeableness"
+                        },
+                        {
+                            "score": 0.278,
+                            "tone_id": "emotional_range_big5",
+                            "tone_name": "Emotional Range"
+                        }
+                    ],
+                    "category_id": "social_tone",
+                    "category_name": "Social Tone"
+                }
+            ]
+        },
+        {
+            "sentence_id": 39,
+            "text": "There stand his trees, each with a hollow trunk, as if a hermit and a crucifix were within; and here sleeps his meadow, and there sleep his cattle; and up from yonder cottage goes a sleepy smoke.",
+            "input_from": 3573,
+            "input_to": 3768,
+            "tone_categories": [
+                {
+                    "tones": [
+                        {
+                            "score": 0.265136,
+                            "tone_id": "anger",
+                            "tone_name": "Anger"
+                        },
+                        {
+                            "score": 0.796105,
+                            "tone_id": "disgust",
+                            "tone_name": "Disgust"
+                        },
+                        {
+                            "score": 0.075884,
+                            "tone_id": "fear",
+                            "tone_name": "Fear"
+                        },
+                        {
+                            "score": 0.126968,
+                            "tone_id": "joy",
+                            "tone_name": "Joy"
+                        },
+                        {
+                            "score": 0.210043,
+                            "tone_id": "sadness",
+                            "tone_name": "Sadness"
+                        }
+                    ],
+                    "category_id": "emotion_tone",
+                    "category_name": "Emotion Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0.114,
+                            "tone_id": "analytical",
+                            "tone_name": "Analytical"
+                        },
+                        {
+                            "score": 0,
+                            "tone_id": "confident",
+                            "tone_name": "Confident"
+                        },
+                        {
+                            "score": 0,
+                            "tone_id": "tentative",
+                            "tone_name": "Tentative"
+                        }
+                    ],
+                    "category_id": "language_tone",
+                    "category_name": "Language Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0.601,
+                            "tone_id": "openness_big5",
+                            "tone_name": "Openness"
+                        },
+                        {
+                            "score": 0.518,
+                            "tone_id": "conscientiousness_big5",
+                            "tone_name": "Conscientiousness"
+                        },
+                        {
+                            "score": 0.753,
+                            "tone_id": "extraversion_big5",
+                            "tone_name": "Extraversion"
+                        },
+                        {
+                            "score": 0.872,
+                            "tone_id": "agreeableness_big5",
+                            "tone_name": "Agreeableness"
+                        },
+                        {
+                            "score": 0.214,
+                            "tone_id": "emotional_range_big5",
+                            "tone_name": "Emotional Range"
+                        }
+                    ],
+                    "category_id": "social_tone",
+                    "category_name": "Social Tone"
+                }
+            ]
+        },
+        {
+            "sentence_id": 40,
+            "text": "Deep into distant woodlands winds a mazy way, reaching to overlapping spurs of mountains bathed in their hill-side blue.",
+            "input_from": 3769,
+            "input_to": 3889,
+            "tone_categories": [
+                {
+                    "tones": [
+                        {
+                            "score": 0.118054,
+                            "tone_id": "anger",
+                            "tone_name": "Anger"
+                        },
+                        {
+                            "score": 0.375256,
+                            "tone_id": "disgust",
+                            "tone_name": "Disgust"
+                        },
+                        {
+                            "score": 0.54878,
+                            "tone_id": "fear",
+                            "tone_name": "Fear"
+                        },
+                        {
+                            "score": 0.12193,
+                            "tone_id": "joy",
+                            "tone_name": "Joy"
+                        },
+                        {
+                            "score": 0.235122,
+                            "tone_id": "sadness",
+                            "tone_name": "Sadness"
+                        }
+                    ],
+                    "category_id": "emotion_tone",
+                    "category_name": "Emotion Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0,
+                            "tone_id": "analytical",
+                            "tone_name": "Analytical"
+                        },
+                        {
+                            "score": 0,
+                            "tone_id": "confident",
+                            "tone_name": "Confident"
+                        },
+                        {
+                            "score": 0,
+                            "tone_id": "tentative",
+                            "tone_name": "Tentative"
+                        }
+                    ],
+                    "category_id": "language_tone",
+                    "category_name": "Language Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0.773,
+                            "tone_id": "openness_big5",
+                            "tone_name": "Openness"
+                        },
+                        {
+                            "score": 0.711,
+                            "tone_id": "conscientiousness_big5",
+                            "tone_name": "Conscientiousness"
+                        },
+                        {
+                            "score": 0.6,
+                            "tone_id": "extraversion_big5",
+                            "tone_name": "Extraversion"
+                        },
+                        {
+                            "score": 0.578,
+                            "tone_id": "agreeableness_big5",
+                            "tone_name": "Agreeableness"
+                        },
+                        {
+                            "score": 0.185,
+                            "tone_id": "emotional_range_big5",
+                            "tone_name": "Emotional Range"
+                        }
+                    ],
+                    "category_id": "social_tone",
+                    "category_name": "Social Tone"
+                }
+            ]
+        },
+        {
+            "sentence_id": 41,
+            "text": "But though the picture lies thus tranced, and though this pine-tree shakes down its sighs like leaves upon this shepherd's head, yet all were vain, unless the shepherd's eye were fixed upon the magic stream before him.",
+            "input_from": 3890,
+            "input_to": 4108,
+            "tone_categories": [
+                {
+                    "tones": [
+                        {
+                            "score": 0.441053,
+                            "tone_id": "anger",
+                            "tone_name": "Anger"
+                        },
+                        {
+                            "score": 0.262616,
+                            "tone_id": "disgust",
+                            "tone_name": "Disgust"
+                        },
+                        {
+                            "score": 0.138243,
+                            "tone_id": "fear",
+                            "tone_name": "Fear"
+                        },
+                        {
+                            "score": 0.023707,
+                            "tone_id": "joy",
+                            "tone_name": "Joy"
+                        },
+                        {
+                            "score": 0.530394,
+                            "tone_id": "sadness",
+                            "tone_name": "Sadness"
+                        }
+                    ],
+                    "category_id": "emotion_tone",
+                    "category_name": "Emotion Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0.273,
+                            "tone_id": "analytical",
+                            "tone_name": "Analytical"
+                        },
+                        {
+                            "score": 0.11,
+                            "tone_id": "confident",
+                            "tone_name": "Confident"
+                        },
+                        {
+                            "score": 0,
+                            "tone_id": "tentative",
+                            "tone_name": "Tentative"
+                        }
+                    ],
+                    "category_id": "language_tone",
+                    "category_name": "Language Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0.43,
+                            "tone_id": "openness_big5",
+                            "tone_name": "Openness"
+                        },
+                        {
+                            "score": 0.166,
+                            "tone_id": "conscientiousness_big5",
+                            "tone_name": "Conscientiousness"
+                        },
+                        {
+                            "score": 0.771,
+                            "tone_id": "extraversion_big5",
+                            "tone_name": "Extraversion"
+                        },
+                        {
+                            "score": 0.595,
+                            "tone_id": "agreeableness_big5",
+                            "tone_name": "Agreeableness"
+                        },
+                        {
+                            "score": 0.739,
+                            "tone_id": "emotional_range_big5",
+                            "tone_name": "Emotional Range"
+                        }
+                    ],
+                    "category_id": "social_tone",
+                    "category_name": "Social Tone"
+                }
+            ]
+        },
+        {
+            "sentence_id": 42,
+            "text": "Go visit the Prairies in June, when for scores on scores of miles you wade knee-deep among Tiger-lilies-what is the one charm wanting?-Water-there is not a drop of water there!",
+            "input_from": 4109,
+            "input_to": 4285,
+            "tone_categories": [
+                {
+                    "tones": [
+                        {
+                            "score": 0.37904,
+                            "tone_id": "anger",
+                            "tone_name": "Anger"
+                        },
+                        {
+                            "score": 0.175941,
+                            "tone_id": "disgust",
+                            "tone_name": "Disgust"
+                        },
+                        {
+                            "score": 0.260338,
+                            "tone_id": "fear",
+                            "tone_name": "Fear"
+                        },
+                        {
+                            "score": 0.402414,
+                            "tone_id": "joy",
+                            "tone_name": "Joy"
+                        },
+                        {
+                            "score": 0.162226,
+                            "tone_id": "sadness",
+                            "tone_name": "Sadness"
+                        }
+                    ],
+                    "category_id": "emotion_tone",
+                    "category_name": "Emotion Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0,
+                            "tone_id": "analytical",
+                            "tone_name": "Analytical"
+                        },
+                        {
+                            "score": 0,
+                            "tone_id": "confident",
+                            "tone_name": "Confident"
+                        },
+                        {
+                            "score": 0,
+                            "tone_id": "tentative",
+                            "tone_name": "Tentative"
+                        }
+                    ],
+                    "category_id": "language_tone",
+                    "category_name": "Language Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0.528,
+                            "tone_id": "openness_big5",
+                            "tone_name": "Openness"
+                        },
+                        {
+                            "score": 0.558,
+                            "tone_id": "conscientiousness_big5",
+                            "tone_name": "Conscientiousness"
+                        },
+                        {
+                            "score": 0.567,
+                            "tone_id": "extraversion_big5",
+                            "tone_name": "Extraversion"
+                        },
+                        {
+                            "score": 0.67,
+                            "tone_id": "agreeableness_big5",
+                            "tone_name": "Agreeableness"
+                        },
+                        {
+                            "score": 0.148,
+                            "tone_id": "emotional_range_big5",
+                            "tone_name": "Emotional Range"
+                        }
+                    ],
+                    "category_id": "social_tone",
+                    "category_name": "Social Tone"
+                }
+            ]
+        },
+        {
+            "sentence_id": 43,
+            "text": "Were Niagara but a cataract of sand, would you travel your thousand miles to see it?",
+            "input_from": 4286,
+            "input_to": 4370,
+            "tone_categories": [
+                {
+                    "tones": [
+                        {
+                            "score": 0.033412,
+                            "tone_id": "anger",
+                            "tone_name": "Anger"
+                        },
+                        {
+                            "score": 0.429261,
+                            "tone_id": "disgust",
+                            "tone_name": "Disgust"
+                        },
+                        {
+                            "score": 0.434537,
+                            "tone_id": "fear",
+                            "tone_name": "Fear"
+                        },
+                        {
+                            "score": 0.380345,
+                            "tone_id": "joy",
+                            "tone_name": "Joy"
+                        },
+                        {
+                            "score": 0.262543,
+                            "tone_id": "sadness",
+                            "tone_name": "Sadness"
+                        }
+                    ],
+                    "category_id": "emotion_tone",
+                    "category_name": "Emotion Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0,
+                            "tone_id": "analytical",
+                            "tone_name": "Analytical"
+                        },
+                        {
+                            "score": 0,
+                            "tone_id": "confident",
+                            "tone_name": "Confident"
+                        },
+                        {
+                            "score": 0,
+                            "tone_id": "tentative",
+                            "tone_name": "Tentative"
+                        }
+                    ],
+                    "category_id": "language_tone",
+                    "category_name": "Language Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0.139,
+                            "tone_id": "openness_big5",
+                            "tone_name": "Openness"
+                        },
+                        {
+                            "score": 0.067,
+                            "tone_id": "conscientiousness_big5",
+                            "tone_name": "Conscientiousness"
+                        },
+                        {
+                            "score": 0.756,
+                            "tone_id": "extraversion_big5",
+                            "tone_name": "Extraversion"
+                        },
+                        {
+                            "score": 0.768,
+                            "tone_id": "agreeableness_big5",
+                            "tone_name": "Agreeableness"
+                        },
+                        {
+                            "score": 0.568,
+                            "tone_id": "emotional_range_big5",
+                            "tone_name": "Emotional Range"
+                        }
+                    ],
+                    "category_id": "social_tone",
+                    "category_name": "Social Tone"
+                }
+            ]
+        },
+        {
+            "sentence_id": 44,
+            "text": "Why did the poor poet of Tennessee, upon suddenly receiving two handfuls of silver, deliberate whether to buy him a coat, which he sadly needed, or invest his money in a pedestrian trip to Rockaway Beach?",
+            "input_from": 4371,
+            "input_to": 4575,
+            "tone_categories": [
+                {
+                    "tones": [
+                        {
+                            "score": 0.267462,
+                            "tone_id": "anger",
+                            "tone_name": "Anger"
+                        },
+                        {
+                            "score": 0.61645,
+                            "tone_id": "disgust",
+                            "tone_name": "Disgust"
+                        },
+                        {
+                            "score": 0.060459,
+                            "tone_id": "fear",
+                            "tone_name": "Fear"
+                        },
+                        {
+                            "score": 0.083649,
+                            "tone_id": "joy",
+                            "tone_name": "Joy"
+                        },
+                        {
+                            "score": 0.46912,
+                            "tone_id": "sadness",
+                            "tone_name": "Sadness"
+                        }
+                    ],
+                    "category_id": "emotion_tone",
+                    "category_name": "Emotion Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0.019,
+                            "tone_id": "analytical",
+                            "tone_name": "Analytical"
+                        },
+                        {
+                            "score": 0,
+                            "tone_id": "confident",
+                            "tone_name": "Confident"
+                        },
+                        {
+                            "score": 0.065,
+                            "tone_id": "tentative",
+                            "tone_name": "Tentative"
+                        }
+                    ],
+                    "category_id": "language_tone",
+                    "category_name": "Language Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0.641,
+                            "tone_id": "openness_big5",
+                            "tone_name": "Openness"
+                        },
+                        {
+                            "score": 0.446,
+                            "tone_id": "conscientiousness_big5",
+                            "tone_name": "Conscientiousness"
+                        },
+                        {
+                            "score": 0.433,
+                            "tone_id": "extraversion_big5",
+                            "tone_name": "Extraversion"
+                        },
+                        {
+                            "score": 0.277,
+                            "tone_id": "agreeableness_big5",
+                            "tone_name": "Agreeableness"
+                        },
+                        {
+                            "score": 0.39,
+                            "tone_id": "emotional_range_big5",
+                            "tone_name": "Emotional Range"
+                        }
+                    ],
+                    "category_id": "social_tone",
+                    "category_name": "Social Tone"
+                }
+            ]
+        },
+        {
+            "sentence_id": 45,
+            "text": "Why is almost every robust healthy boy with a robust healthy soul in him, at some time or other crazy to go to sea?",
+            "input_from": 4576,
+            "input_to": 4691,
+            "tone_categories": [
+                {
+                    "tones": [
+                        {
+                            "score": 0.222434,
+                            "tone_id": "anger",
+                            "tone_name": "Anger"
+                        },
+                        {
+                            "score": 0.151632,
+                            "tone_id": "disgust",
+                            "tone_name": "Disgust"
+                        },
+                        {
+                            "score": 0.146582,
+                            "tone_id": "fear",
+                            "tone_name": "Fear"
+                        },
+                        {
+                            "score": 0.199168,
+                            "tone_id": "joy",
+                            "tone_name": "Joy"
+                        },
+                        {
+                            "score": 0.371779,
+                            "tone_id": "sadness",
+                            "tone_name": "Sadness"
+                        }
+                    ],
+                    "category_id": "emotion_tone",
+                    "category_name": "Emotion Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0,
+                            "tone_id": "analytical",
+                            "tone_name": "Analytical"
+                        },
+                        {
+                            "score": 0,
+                            "tone_id": "confident",
+                            "tone_name": "Confident"
+                        },
+                        {
+                            "score": 0.614,
+                            "tone_id": "tentative",
+                            "tone_name": "Tentative"
+                        }
+                    ],
+                    "category_id": "language_tone",
+                    "category_name": "Language Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0.671,
+                            "tone_id": "openness_big5",
+                            "tone_name": "Openness"
+                        },
+                        {
+                            "score": 0.173,
+                            "tone_id": "conscientiousness_big5",
+                            "tone_name": "Conscientiousness"
+                        },
+                        {
+                            "score": 0.692,
+                            "tone_id": "extraversion_big5",
+                            "tone_name": "Extraversion"
+                        },
+                        {
+                            "score": 0.379,
+                            "tone_id": "agreeableness_big5",
+                            "tone_name": "Agreeableness"
+                        },
+                        {
+                            "score": 0.772,
+                            "tone_id": "emotional_range_big5",
+                            "tone_name": "Emotional Range"
+                        }
+                    ],
+                    "category_id": "social_tone",
+                    "category_name": "Social Tone"
+                }
+            ]
+        },
+        {
+            "sentence_id": 46,
+            "text": "Why upon your first voyage as a passenger, did you yourself feel such a mystical vibration, when first told that you and your ship were now out of sight of land?",
+            "input_from": 4692,
+            "input_to": 4853,
+            "tone_categories": [
+                {
+                    "tones": [
+                        {
+                            "score": 0.289226,
+                            "tone_id": "anger",
+                            "tone_name": "Anger"
+                        },
+                        {
+                            "score": 0.403452,
+                            "tone_id": "disgust",
+                            "tone_name": "Disgust"
+                        },
+                        {
+                            "score": 0.388116,
+                            "tone_id": "fear",
+                            "tone_name": "Fear"
+                        },
+                        {
+                            "score": 0.148897,
+                            "tone_id": "joy",
+                            "tone_name": "Joy"
+                        },
+                        {
+                            "score": 0.177373,
+                            "tone_id": "sadness",
+                            "tone_name": "Sadness"
+                        }
+                    ],
+                    "category_id": "emotion_tone",
+                    "category_name": "Emotion Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0,
+                            "tone_id": "analytical",
+                            "tone_name": "Analytical"
+                        },
+                        {
+                            "score": 0,
+                            "tone_id": "confident",
+                            "tone_name": "Confident"
+                        },
+                        {
+                            "score": 0.099,
+                            "tone_id": "tentative",
+                            "tone_name": "Tentative"
+                        }
+                    ],
+                    "category_id": "language_tone",
+                    "category_name": "Language Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0.175,
+                            "tone_id": "openness_big5",
+                            "tone_name": "Openness"
+                        },
+                        {
+                            "score": 0.446,
+                            "tone_id": "conscientiousness_big5",
+                            "tone_name": "Conscientiousness"
+                        },
+                        {
+                            "score": 0.872,
+                            "tone_id": "extraversion_big5",
+                            "tone_name": "Extraversion"
+                        },
+                        {
+                            "score": 0.875,
+                            "tone_id": "agreeableness_big5",
+                            "tone_name": "Agreeableness"
+                        },
+                        {
+                            "score": 0.031,
+                            "tone_id": "emotional_range_big5",
+                            "tone_name": "Emotional Range"
+                        }
+                    ],
+                    "category_id": "social_tone",
+                    "category_name": "Social Tone"
+                }
+            ]
+        },
+        {
+            "sentence_id": 47,
+            "text": "Why did the old Persians hold the sea holy?",
+            "input_from": 4854,
+            "input_to": 4897,
+            "tone_categories": [
+                {
+                    "tones": [
+                        {
+                            "score": 0.156871,
+                            "tone_id": "anger",
+                            "tone_name": "Anger"
+                        },
+                        {
+                            "score": 0.440361,
+                            "tone_id": "disgust",
+                            "tone_name": "Disgust"
+                        },
+                        {
+                            "score": 0.372559,
+                            "tone_id": "fear",
+                            "tone_name": "Fear"
+                        },
+                        {
+                            "score": 0.076162,
+                            "tone_id": "joy",
+                            "tone_name": "Joy"
+                        },
+                        {
+                            "score": 0.261716,
+                            "tone_id": "sadness",
+                            "tone_name": "Sadness"
+                        }
+                    ],
+                    "category_id": "emotion_tone",
+                    "category_name": "Emotion Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0,
+                            "tone_id": "analytical",
+                            "tone_name": "Analytical"
+                        },
+                        {
+                            "score": 0,
+                            "tone_id": "confident",
+                            "tone_name": "Confident"
+                        },
+                        {
+                            "score": 0,
+                            "tone_id": "tentative",
+                            "tone_name": "Tentative"
+                        }
+                    ],
+                    "category_id": "language_tone",
+                    "category_name": "Language Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0.531,
+                            "tone_id": "openness_big5",
+                            "tone_name": "Openness"
+                        },
+                        {
+                            "score": 0.286,
+                            "tone_id": "conscientiousness_big5",
+                            "tone_name": "Conscientiousness"
+                        },
+                        {
+                            "score": 0.138,
+                            "tone_id": "extraversion_big5",
+                            "tone_name": "Extraversion"
+                        },
+                        {
+                            "score": 0.128,
+                            "tone_id": "agreeableness_big5",
+                            "tone_name": "Agreeableness"
+                        },
+                        {
+                            "score": 0.879,
+                            "tone_id": "emotional_range_big5",
+                            "tone_name": "Emotional Range"
+                        }
+                    ],
+                    "category_id": "social_tone",
+                    "category_name": "Social Tone"
+                }
+            ]
+        },
+        {
+            "sentence_id": 48,
+            "text": "Why did the Greeks give it a separate deity, and own brother of Jove?",
+            "input_from": 4898,
+            "input_to": 4967,
+            "tone_categories": [
+                {
+                    "tones": [
+                        {
+                            "score": 0.372514,
+                            "tone_id": "anger",
+                            "tone_name": "Anger"
+                        },
+                        {
+                            "score": 0.425748,
+                            "tone_id": "disgust",
+                            "tone_name": "Disgust"
+                        },
+                        {
+                            "score": 0.326713,
+                            "tone_id": "fear",
+                            "tone_name": "Fear"
+                        },
+                        {
+                            "score": 0.097709,
+                            "tone_id": "joy",
+                            "tone_name": "Joy"
+                        },
+                        {
+                            "score": 0.306402,
+                            "tone_id": "sadness",
+                            "tone_name": "Sadness"
+                        }
+                    ],
+                    "category_id": "emotion_tone",
+                    "category_name": "Emotion Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0,
+                            "tone_id": "analytical",
+                            "tone_name": "Analytical"
+                        },
+                        {
+                            "score": 0,
+                            "tone_id": "confident",
+                            "tone_name": "Confident"
+                        },
+                        {
+                            "score": 0,
+                            "tone_id": "tentative",
+                            "tone_name": "Tentative"
+                        }
+                    ],
+                    "category_id": "language_tone",
+                    "category_name": "Language Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0.652,
+                            "tone_id": "openness_big5",
+                            "tone_name": "Openness"
+                        },
+                        {
+                            "score": 0.508,
+                            "tone_id": "conscientiousness_big5",
+                            "tone_name": "Conscientiousness"
+                        },
+                        {
+                            "score": 0.517,
+                            "tone_id": "extraversion_big5",
+                            "tone_name": "Extraversion"
+                        },
+                        {
+                            "score": 0.384,
+                            "tone_id": "agreeableness_big5",
+                            "tone_name": "Agreeableness"
+                        },
+                        {
+                            "score": 0.498,
+                            "tone_id": "emotional_range_big5",
+                            "tone_name": "Emotional Range"
+                        }
+                    ],
+                    "category_id": "social_tone",
+                    "category_name": "Social Tone"
+                }
+            ]
+        },
+        {
+            "sentence_id": 49,
+            "text": "Surely all this is not without meaning.",
+            "input_from": 4968,
+            "input_to": 5007,
+            "tone_categories": [
+                {
+                    "tones": [
+                        {
+                            "score": 0.237539,
+                            "tone_id": "anger",
+                            "tone_name": "Anger"
+                        },
+                        {
+                            "score": 0.227237,
+                            "tone_id": "disgust",
+                            "tone_name": "Disgust"
+                        },
+                        {
+                            "score": 0.376581,
+                            "tone_id": "fear",
+                            "tone_name": "Fear"
+                        },
+                        {
+                            "score": 0.069574,
+                            "tone_id": "joy",
+                            "tone_name": "Joy"
+                        },
+                        {
+                            "score": 0.540447,
+                            "tone_id": "sadness",
+                            "tone_name": "Sadness"
+                        }
+                    ],
+                    "category_id": "emotion_tone",
+                    "category_name": "Emotion Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0.886,
+                            "tone_id": "analytical",
+                            "tone_name": "Analytical"
+                        },
+                        {
+                            "score": 0.997,
+                            "tone_id": "confident",
+                            "tone_name": "Confident"
+                        },
+                        {
+                            "score": 0,
+                            "tone_id": "tentative",
+                            "tone_name": "Tentative"
+                        }
+                    ],
+                    "category_id": "language_tone",
+                    "category_name": "Language Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0.401,
+                            "tone_id": "openness_big5",
+                            "tone_name": "Openness"
+                        },
+                        {
+                            "score": 0.001,
+                            "tone_id": "conscientiousness_big5",
+                            "tone_name": "Conscientiousness"
+                        },
+                        {
+                            "score": 0.832,
+                            "tone_id": "extraversion_big5",
+                            "tone_name": "Extraversion"
+                        },
+                        {
+                            "score": 0.376,
+                            "tone_id": "agreeableness_big5",
+                            "tone_name": "Agreeableness"
+                        },
+                        {
+                            "score": 0.992,
+                            "tone_id": "emotional_range_big5",
+                            "tone_name": "Emotional Range"
+                        }
+                    ],
+                    "category_id": "social_tone",
+                    "category_name": "Social Tone"
+                }
+            ]
+        },
+        {
+            "sentence_id": 50,
+            "text": "And still deeper the meaning of that story of Narcissus, who because he could not grasp the tormenting, mild image he saw in the fountain, plunged into it and was drowned.",
+            "input_from": 5008,
+            "input_to": 5179,
+            "tone_categories": [
+                {
+                    "tones": [
+                        {
+                            "score": 0.079256,
+                            "tone_id": "anger",
+                            "tone_name": "Anger"
+                        },
+                        {
+                            "score": 0.671545,
+                            "tone_id": "disgust",
+                            "tone_name": "Disgust"
+                        },
+                        {
+                            "score": 0.535755,
+                            "tone_id": "fear",
+                            "tone_name": "Fear"
+                        },
+                        {
+                            "score": 0.023619,
+                            "tone_id": "joy",
+                            "tone_name": "Joy"
+                        },
+                        {
+                            "score": 0.420106,
+                            "tone_id": "sadness",
+                            "tone_name": "Sadness"
+                        }
+                    ],
+                    "category_id": "emotion_tone",
+                    "category_name": "Emotion Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0.732,
+                            "tone_id": "analytical",
+                            "tone_name": "Analytical"
+                        },
+                        {
+                            "score": 0,
+                            "tone_id": "confident",
+                            "tone_name": "Confident"
+                        },
+                        {
+                            "score": 0.449,
+                            "tone_id": "tentative",
+                            "tone_name": "Tentative"
+                        }
+                    ],
+                    "category_id": "language_tone",
+                    "category_name": "Language Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0.708,
+                            "tone_id": "openness_big5",
+                            "tone_name": "Openness"
+                        },
+                        {
+                            "score": 0.133,
+                            "tone_id": "conscientiousness_big5",
+                            "tone_name": "Conscientiousness"
+                        },
+                        {
+                            "score": 0.591,
+                            "tone_id": "extraversion_big5",
+                            "tone_name": "Extraversion"
+                        },
+                        {
+                            "score": 0.445,
+                            "tone_id": "agreeableness_big5",
+                            "tone_name": "Agreeableness"
+                        },
+                        {
+                            "score": 0.739,
+                            "tone_id": "emotional_range_big5",
+                            "tone_name": "Emotional Range"
+                        }
+                    ],
+                    "category_id": "social_tone",
+                    "category_name": "Social Tone"
+                }
+            ]
+        },
+        {
+            "sentence_id": 51,
+            "text": "But that same image, we ourselves see in all rivers and oceans.",
+            "input_from": 5180,
+            "input_to": 5243,
+            "tone_categories": [
+                {
+                    "tones": [
+                        {
+                            "score": 0.066081,
+                            "tone_id": "anger",
+                            "tone_name": "Anger"
+                        },
+                        {
+                            "score": 0.227092,
+                            "tone_id": "disgust",
+                            "tone_name": "Disgust"
+                        },
+                        {
+                            "score": 0.2573,
+                            "tone_id": "fear",
+                            "tone_name": "Fear"
+                        },
+                        {
+                            "score": 0.269542,
+                            "tone_id": "joy",
+                            "tone_name": "Joy"
+                        },
+                        {
+                            "score": 0.654919,
+                            "tone_id": "sadness",
+                            "tone_name": "Sadness"
+                        }
+                    ],
+                    "category_id": "emotion_tone",
+                    "category_name": "Emotion Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0,
+                            "tone_id": "analytical",
+                            "tone_name": "Analytical"
+                        },
+                        {
+                            "score": 0.786,
+                            "tone_id": "confident",
+                            "tone_name": "Confident"
+                        },
+                        {
+                            "score": 0,
+                            "tone_id": "tentative",
+                            "tone_name": "Tentative"
+                        }
+                    ],
+                    "category_id": "language_tone",
+                    "category_name": "Language Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0.128,
+                            "tone_id": "openness_big5",
+                            "tone_name": "Openness"
+                        },
+                        {
+                            "score": 0.016,
+                            "tone_id": "conscientiousness_big5",
+                            "tone_name": "Conscientiousness"
+                        },
+                        {
+                            "score": 0.935,
+                            "tone_id": "extraversion_big5",
+                            "tone_name": "Extraversion"
+                        },
+                        {
+                            "score": 0.954,
+                            "tone_id": "agreeableness_big5",
+                            "tone_name": "Agreeableness"
+                        },
+                        {
+                            "score": 0.961,
+                            "tone_id": "emotional_range_big5",
+                            "tone_name": "Emotional Range"
+                        }
+                    ],
+                    "category_id": "social_tone",
+                    "category_name": "Social Tone"
+                }
+            ]
+        },
+        {
+            "sentence_id": 52,
+            "text": "It is the image of the ungraspable phantom of life; and this is the key to it all.",
+            "input_from": 5244,
+            "input_to": 5326,
+            "tone_categories": [
+                {
+                    "tones": [
+                        {
+                            "score": 0.046707,
+                            "tone_id": "anger",
+                            "tone_name": "Anger"
+                        },
+                        {
+                            "score": 0.140698,
+                            "tone_id": "disgust",
+                            "tone_name": "Disgust"
+                        },
+                        {
+                            "score": 0.645008,
+                            "tone_id": "fear",
+                            "tone_name": "Fear"
+                        },
+                        {
+                            "score": 0.165148,
+                            "tone_id": "joy",
+                            "tone_name": "Joy"
+                        },
+                        {
+                            "score": 0.333413,
+                            "tone_id": "sadness",
+                            "tone_name": "Sadness"
+                        }
+                    ],
+                    "category_id": "emotion_tone",
+                    "category_name": "Emotion Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0,
+                            "tone_id": "analytical",
+                            "tone_name": "Analytical"
+                        },
+                        {
+                            "score": 0.6,
+                            "tone_id": "confident",
+                            "tone_name": "Confident"
+                        },
+                        {
+                            "score": 0,
+                            "tone_id": "tentative",
+                            "tone_name": "Tentative"
+                        }
+                    ],
+                    "category_id": "language_tone",
+                    "category_name": "Language Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0.956,
+                            "tone_id": "openness_big5",
+                            "tone_name": "Openness"
+                        },
+                        {
+                            "score": 0.789,
+                            "tone_id": "conscientiousness_big5",
+                            "tone_name": "Conscientiousness"
+                        },
+                        {
+                            "score": 0.367,
+                            "tone_id": "extraversion_big5",
+                            "tone_name": "Extraversion"
+                        },
+                        {
+                            "score": 0.193,
+                            "tone_id": "agreeableness_big5",
+                            "tone_name": "Agreeableness"
+                        },
+                        {
+                            "score": 0.238,
+                            "tone_id": "emotional_range_big5",
+                            "tone_name": "Emotional Range"
+                        }
+                    ],
+                    "category_id": "social_tone",
+                    "category_name": "Social Tone"
+                }
+            ]
+        },
+        {
+            "sentence_id": 53,
+            "text": "Now, when I say that I am in the habit of going to sea whenever I begin to grow hazy about the eyes, and begin to be over conscious of my lungs, I do not mean to have it inferred that I ever go to sea as a passenger.",
+            "input_from": 5327,
+            "input_to": 5543,
+            "tone_categories": [
+                {
+                    "tones": [
+                        {
+                            "score": 0.405999,
+                            "tone_id": "anger",
+                            "tone_name": "Anger"
+                        },
+                        {
+                            "score": 0.206239,
+                            "tone_id": "disgust",
+                            "tone_name": "Disgust"
+                        },
+                        {
+                            "score": 0.216264,
+                            "tone_id": "fear",
+                            "tone_name": "Fear"
+                        },
+                        {
+                            "score": 0.299023,
+                            "tone_id": "joy",
+                            "tone_name": "Joy"
+                        },
+                        {
+                            "score": 0.319107,
+                            "tone_id": "sadness",
+                            "tone_name": "Sadness"
+                        }
+                    ],
+                    "category_id": "emotion_tone",
+                    "category_name": "Emotion Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0.275,
+                            "tone_id": "analytical",
+                            "tone_name": "Analytical"
+                        },
+                        {
+                            "score": 0,
+                            "tone_id": "confident",
+                            "tone_name": "Confident"
+                        },
+                        {
+                            "score": 0.196,
+                            "tone_id": "tentative",
+                            "tone_name": "Tentative"
+                        }
+                    ],
+                    "category_id": "language_tone",
+                    "category_name": "Language Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0.281,
+                            "tone_id": "openness_big5",
+                            "tone_name": "Openness"
+                        },
+                        {
+                            "score": 0.405,
+                            "tone_id": "conscientiousness_big5",
+                            "tone_name": "Conscientiousness"
+                        },
+                        {
+                            "score": 0.476,
+                            "tone_id": "extraversion_big5",
+                            "tone_name": "Extraversion"
+                        },
+                        {
+                            "score": 0.52,
+                            "tone_id": "agreeableness_big5",
+                            "tone_name": "Agreeableness"
+                        },
+                        {
+                            "score": 0.853,
+                            "tone_id": "emotional_range_big5",
+                            "tone_name": "Emotional Range"
+                        }
+                    ],
+                    "category_id": "social_tone",
+                    "category_name": "Social Tone"
+                }
+            ]
+        },
+        {
+            "sentence_id": 54,
+            "text": "For to go as a passenger you must needs have a purse, and a purse is but a rag unless you have something in it.",
+            "input_from": 5544,
+            "input_to": 5655,
+            "tone_categories": [
+                {
+                    "tones": [
+                        {
+                            "score": 0.242366,
+                            "tone_id": "anger",
+                            "tone_name": "Anger"
+                        },
+                        {
+                            "score": 0.313293,
+                            "tone_id": "disgust",
+                            "tone_name": "Disgust"
+                        },
+                        {
+                            "score": 0.391356,
+                            "tone_id": "fear",
+                            "tone_name": "Fear"
+                        },
+                        {
+                            "score": 0.202589,
+                            "tone_id": "joy",
+                            "tone_name": "Joy"
+                        },
+                        {
+                            "score": 0.276341,
+                            "tone_id": "sadness",
+                            "tone_name": "Sadness"
+                        }
+                    ],
+                    "category_id": "emotion_tone",
+                    "category_name": "Emotion Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0.053,
+                            "tone_id": "analytical",
+                            "tone_name": "Analytical"
+                        },
+                        {
+                            "score": 0,
+                            "tone_id": "confident",
+                            "tone_name": "Confident"
+                        },
+                        {
+                            "score": 0,
+                            "tone_id": "tentative",
+                            "tone_name": "Tentative"
+                        }
+                    ],
+                    "category_id": "language_tone",
+                    "category_name": "Language Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0.442,
+                            "tone_id": "openness_big5",
+                            "tone_name": "Openness"
+                        },
+                        {
+                            "score": 0.16,
+                            "tone_id": "conscientiousness_big5",
+                            "tone_name": "Conscientiousness"
+                        },
+                        {
+                            "score": 0.627,
+                            "tone_id": "extraversion_big5",
+                            "tone_name": "Extraversion"
+                        },
+                        {
+                            "score": 0.465,
+                            "tone_id": "agreeableness_big5",
+                            "tone_name": "Agreeableness"
+                        },
+                        {
+                            "score": 0.598,
+                            "tone_id": "emotional_range_big5",
+                            "tone_name": "Emotional Range"
+                        }
+                    ],
+                    "category_id": "social_tone",
+                    "category_name": "Social Tone"
+                }
+            ]
+        },
+        {
+            "sentence_id": 55,
+            "text": "Besides, passengers get sea-sick-grow quarrelsome-don't sleep of nights-do not enjoy themselves much, as a general thing;-no, I never go as a passenger; nor, though I am something of a salt, do I ever go to sea as a Commodore, or a Captain, or a Cook.",
+            "input_from": 5656,
+            "input_to": 5907,
+            "tone_categories": [
+                {
+                    "tones": [
+                        {
+                            "score": 0.393608,
+                            "tone_id": "anger",
+                            "tone_name": "Anger"
+                        },
+                        {
+                            "score": 0.510843,
+                            "tone_id": "disgust",
+                            "tone_name": "Disgust"
+                        },
+                        {
+                            "score": 0.296177,
+                            "tone_id": "fear",
+                            "tone_name": "Fear"
+                        },
+                        {
+                            "score": 0.071568,
+                            "tone_id": "joy",
+                            "tone_name": "Joy"
+                        },
+                        {
+                            "score": 0.302687,
+                            "tone_id": "sadness",
+                            "tone_name": "Sadness"
+                        }
+                    ],
+                    "category_id": "emotion_tone",
+                    "category_name": "Emotion Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0.066,
+                            "tone_id": "analytical",
+                            "tone_name": "Analytical"
+                        },
+                        {
+                            "score": 0,
+                            "tone_id": "confident",
+                            "tone_name": "Confident"
+                        },
+                        {
+                            "score": 0.772,
+                            "tone_id": "tentative",
+                            "tone_name": "Tentative"
+                        }
+                    ],
+                    "category_id": "language_tone",
+                    "category_name": "Language Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0.436,
+                            "tone_id": "openness_big5",
+                            "tone_name": "Openness"
+                        },
+                        {
+                            "score": 0.229,
+                            "tone_id": "conscientiousness_big5",
+                            "tone_name": "Conscientiousness"
+                        },
+                        {
+                            "score": 0.349,
+                            "tone_id": "extraversion_big5",
+                            "tone_name": "Extraversion"
+                        },
+                        {
+                            "score": 0.313,
+                            "tone_id": "agreeableness_big5",
+                            "tone_name": "Agreeableness"
+                        },
+                        {
+                            "score": 0.826,
+                            "tone_id": "emotional_range_big5",
+                            "tone_name": "Emotional Range"
+                        }
+                    ],
+                    "category_id": "social_tone",
+                    "category_name": "Social Tone"
+                }
+            ]
+        },
+        {
+            "sentence_id": 56,
+            "text": "I abandon the glory and distinction of such offices to those who like them.",
+            "input_from": 5908,
+            "input_to": 5983,
+            "tone_categories": [
+                {
+                    "tones": [
+                        {
+                            "score": 0.179585,
+                            "tone_id": "anger",
+                            "tone_name": "Anger"
+                        },
+                        {
+                            "score": 0.479747,
+                            "tone_id": "disgust",
+                            "tone_name": "Disgust"
+                        },
+                        {
+                            "score": 0.424013,
+                            "tone_id": "fear",
+                            "tone_name": "Fear"
+                        },
+                        {
+                            "score": 0.246049,
+                            "tone_id": "joy",
+                            "tone_name": "Joy"
+                        },
+                        {
+                            "score": 0.1726,
+                            "tone_id": "sadness",
+                            "tone_name": "Sadness"
+                        }
+                    ],
+                    "category_id": "emotion_tone",
+                    "category_name": "Emotion Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0,
+                            "tone_id": "analytical",
+                            "tone_name": "Analytical"
+                        },
+                        {
+                            "score": 0,
+                            "tone_id": "confident",
+                            "tone_name": "Confident"
+                        },
+                        {
+                            "score": 0.289,
+                            "tone_id": "tentative",
+                            "tone_name": "Tentative"
+                        }
+                    ],
+                    "category_id": "language_tone",
+                    "category_name": "Language Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0.153,
+                            "tone_id": "openness_big5",
+                            "tone_name": "Openness"
+                        },
+                        {
+                            "score": 0.276,
+                            "tone_id": "conscientiousness_big5",
+                            "tone_name": "Conscientiousness"
+                        },
+                        {
+                            "score": 0.762,
+                            "tone_id": "extraversion_big5",
+                            "tone_name": "Extraversion"
+                        },
+                        {
+                            "score": 0.847,
+                            "tone_id": "agreeableness_big5",
+                            "tone_name": "Agreeableness"
+                        },
+                        {
+                            "score": 0.888,
+                            "tone_id": "emotional_range_big5",
+                            "tone_name": "Emotional Range"
+                        }
+                    ],
+                    "category_id": "social_tone",
+                    "category_name": "Social Tone"
+                }
+            ]
+        },
+        {
+            "sentence_id": 57,
+            "text": "For my part, I abominate all honourable respectable toils, trials, and tribulations of every kind whatsoever.",
+            "input_from": 5984,
+            "input_to": 6093,
+            "tone_categories": [
+                {
+                    "tones": [
+                        {
+                            "score": 0.357501,
+                            "tone_id": "anger",
+                            "tone_name": "Anger"
+                        },
+                        {
+                            "score": 0.34783,
+                            "tone_id": "disgust",
+                            "tone_name": "Disgust"
+                        },
+                        {
+                            "score": 0.29798,
+                            "tone_id": "fear",
+                            "tone_name": "Fear"
+                        },
+                        {
+                            "score": 0.095727,
+                            "tone_id": "joy",
+                            "tone_name": "Joy"
+                        },
+                        {
+                            "score": 0.332466,
+                            "tone_id": "sadness",
+                            "tone_name": "Sadness"
+                        }
+                    ],
+                    "category_id": "emotion_tone",
+                    "category_name": "Emotion Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0,
+                            "tone_id": "analytical",
+                            "tone_name": "Analytical"
+                        },
+                        {
+                            "score": 0.847,
+                            "tone_id": "confident",
+                            "tone_name": "Confident"
+                        },
+                        {
+                            "score": 0,
+                            "tone_id": "tentative",
+                            "tone_name": "Tentative"
+                        }
+                    ],
+                    "category_id": "language_tone",
+                    "category_name": "Language Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0.352,
+                            "tone_id": "openness_big5",
+                            "tone_name": "Openness"
+                        },
+                        {
+                            "score": 0.402,
+                            "tone_id": "conscientiousness_big5",
+                            "tone_name": "Conscientiousness"
+                        },
+                        {
+                            "score": 0.368,
+                            "tone_id": "extraversion_big5",
+                            "tone_name": "Extraversion"
+                        },
+                        {
+                            "score": 0.441,
+                            "tone_id": "agreeableness_big5",
+                            "tone_name": "Agreeableness"
+                        },
+                        {
+                            "score": 0.932,
+                            "tone_id": "emotional_range_big5",
+                            "tone_name": "Emotional Range"
+                        }
+                    ],
+                    "category_id": "social_tone",
+                    "category_name": "Social Tone"
+                }
+            ]
+        },
+        {
+            "sentence_id": 58,
+            "text": "It is quite as much as I can do to take care of myself, without taking care of ships, barques, brigs, schooners, and what not.",
+            "input_from": 6094,
+            "input_to": 6220,
+            "tone_categories": [
+                {
+                    "tones": [
+                        {
+                            "score": 0.311786,
+                            "tone_id": "anger",
+                            "tone_name": "Anger"
+                        },
+                        {
+                            "score": 0.246754,
+                            "tone_id": "disgust",
+                            "tone_name": "Disgust"
+                        },
+                        {
+                            "score": 0.205102,
+                            "tone_id": "fear",
+                            "tone_name": "Fear"
+                        },
+                        {
+                            "score": 0.310913,
+                            "tone_id": "joy",
+                            "tone_name": "Joy"
+                        },
+                        {
+                            "score": 0.413132,
+                            "tone_id": "sadness",
+                            "tone_name": "Sadness"
+                        }
+                    ],
+                    "category_id": "emotion_tone",
+                    "category_name": "Emotion Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0,
+                            "tone_id": "analytical",
+                            "tone_name": "Analytical"
+                        },
+                        {
+                            "score": 0,
+                            "tone_id": "confident",
+                            "tone_name": "Confident"
+                        },
+                        {
+                            "score": 0,
+                            "tone_id": "tentative",
+                            "tone_name": "Tentative"
+                        }
+                    ],
+                    "category_id": "language_tone",
+                    "category_name": "Language Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0.223,
+                            "tone_id": "openness_big5",
+                            "tone_name": "Openness"
+                        },
+                        {
+                            "score": 0.179,
+                            "tone_id": "conscientiousness_big5",
+                            "tone_name": "Conscientiousness"
+                        },
+                        {
+                            "score": 0.352,
+                            "tone_id": "extraversion_big5",
+                            "tone_name": "Extraversion"
+                        },
+                        {
+                            "score": 0.507,
+                            "tone_id": "agreeableness_big5",
+                            "tone_name": "Agreeableness"
+                        },
+                        {
+                            "score": 0.909,
+                            "tone_id": "emotional_range_big5",
+                            "tone_name": "Emotional Range"
+                        }
+                    ],
+                    "category_id": "social_tone",
+                    "category_name": "Social Tone"
+                }
+            ]
+        },
+        {
+            "sentence_id": 59,
+            "text": "And as for going as cook,-though I confess there is considerable glory in that, a cook being a sort of officer on ship-board-yet, somehow, I never fancied broiling fowls;-though once broiled, judiciously buttered, and judgmatically salted and peppered, there is no one who will speak more respectfully, not to say reverentially, of a broiled fowl than I will.",
+            "input_from": 6221,
+            "input_to": 6580,
+            "tone_categories": [
+                {
+                    "tones": [
+                        {
+                            "score": 0.366891,
+                            "tone_id": "anger",
+                            "tone_name": "Anger"
+                        },
+                        {
+                            "score": 0.435328,
+                            "tone_id": "disgust",
+                            "tone_name": "Disgust"
+                        },
+                        {
+                            "score": 0.256416,
+                            "tone_id": "fear",
+                            "tone_name": "Fear"
+                        },
+                        {
+                            "score": 0.037071,
+                            "tone_id": "joy",
+                            "tone_name": "Joy"
+                        },
+                        {
+                            "score": 0.473926,
+                            "tone_id": "sadness",
+                            "tone_name": "Sadness"
+                        }
+                    ],
+                    "category_id": "emotion_tone",
+                    "category_name": "Emotion Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0,
+                            "tone_id": "analytical",
+                            "tone_name": "Analytical"
+                        },
+                        {
+                            "score": 0,
+                            "tone_id": "confident",
+                            "tone_name": "Confident"
+                        },
+                        {
+                            "score": 0,
+                            "tone_id": "tentative",
+                            "tone_name": "Tentative"
+                        }
+                    ],
+                    "category_id": "language_tone",
+                    "category_name": "Language Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0.487,
+                            "tone_id": "openness_big5",
+                            "tone_name": "Openness"
+                        },
+                        {
+                            "score": 0.25,
+                            "tone_id": "conscientiousness_big5",
+                            "tone_name": "Conscientiousness"
+                        },
+                        {
+                            "score": 0.564,
+                            "tone_id": "extraversion_big5",
+                            "tone_name": "Extraversion"
+                        },
+                        {
+                            "score": 0.453,
+                            "tone_id": "agreeableness_big5",
+                            "tone_name": "Agreeableness"
+                        },
+                        {
+                            "score": 0.73,
+                            "tone_id": "emotional_range_big5",
+                            "tone_name": "Emotional Range"
+                        }
+                    ],
+                    "category_id": "social_tone",
+                    "category_name": "Social Tone"
+                }
+            ]
+        },
+        {
+            "sentence_id": 60,
+            "text": "It is out of the idolatrous dotings of the old Egyptians upon broiled ibis and roasted river horse, that you see the mummies of those creatures in their huge bake-houses the pyramids.",
+            "input_from": 6581,
+            "input_to": 6764,
+            "tone_categories": [
+                {
+                    "tones": [
+                        {
+                            "score": 0.068849,
+                            "tone_id": "anger",
+                            "tone_name": "Anger"
+                        },
+                        {
+                            "score": 0.670484,
+                            "tone_id": "disgust",
+                            "tone_name": "Disgust"
+                        },
+                        {
+                            "score": 0.565229,
+                            "tone_id": "fear",
+                            "tone_name": "Fear"
+                        },
+                        {
+                            "score": 0.072999,
+                            "tone_id": "joy",
+                            "tone_name": "Joy"
+                        },
+                        {
+                            "score": 0.194397,
+                            "tone_id": "sadness",
+                            "tone_name": "Sadness"
+                        }
+                    ],
+                    "category_id": "emotion_tone",
+                    "category_name": "Emotion Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0,
+                            "tone_id": "analytical",
+                            "tone_name": "Analytical"
+                        },
+                        {
+                            "score": 0,
+                            "tone_id": "confident",
+                            "tone_name": "Confident"
+                        },
+                        {
+                            "score": 0,
+                            "tone_id": "tentative",
+                            "tone_name": "Tentative"
+                        }
+                    ],
+                    "category_id": "language_tone",
+                    "category_name": "Language Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0.713,
+                            "tone_id": "openness_big5",
+                            "tone_name": "Openness"
+                        },
+                        {
+                            "score": 0.521,
+                            "tone_id": "conscientiousness_big5",
+                            "tone_name": "Conscientiousness"
+                        },
+                        {
+                            "score": 0.694,
+                            "tone_id": "extraversion_big5",
+                            "tone_name": "Extraversion"
+                        },
+                        {
+                            "score": 0.546,
+                            "tone_id": "agreeableness_big5",
+                            "tone_name": "Agreeableness"
+                        },
+                        {
+                            "score": 0.136,
+                            "tone_id": "emotional_range_big5",
+                            "tone_name": "Emotional Range"
+                        }
+                    ],
+                    "category_id": "social_tone",
+                    "category_name": "Social Tone"
+                }
+            ]
+        },
+        {
+            "sentence_id": 61,
+            "text": "No, when I go to sea, I go as a simple sailor, right before the mast, plumb down into the forecastle, aloft there to the royal mast-head.",
+            "input_from": 6765,
+            "input_to": 6902,
+            "tone_categories": [
+                {
+                    "tones": [
+                        {
+                            "score": 0.202455,
+                            "tone_id": "anger",
+                            "tone_name": "Anger"
+                        },
+                        {
+                            "score": 0.368053,
+                            "tone_id": "disgust",
+                            "tone_name": "Disgust"
+                        },
+                        {
+                            "score": 0.487951,
+                            "tone_id": "fear",
+                            "tone_name": "Fear"
+                        },
+                        {
+                            "score": 0.116903,
+                            "tone_id": "joy",
+                            "tone_name": "Joy"
+                        },
+                        {
+                            "score": 0.240054,
+                            "tone_id": "sadness",
+                            "tone_name": "Sadness"
+                        }
+                    ],
+                    "category_id": "emotion_tone",
+                    "category_name": "Emotion Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0,
+                            "tone_id": "analytical",
+                            "tone_name": "Analytical"
+                        },
+                        {
+                            "score": 0,
+                            "tone_id": "confident",
+                            "tone_name": "Confident"
+                        },
+                        {
+                            "score": 0,
+                            "tone_id": "tentative",
+                            "tone_name": "Tentative"
+                        }
+                    ],
+                    "category_id": "language_tone",
+                    "category_name": "Language Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0.63,
+                            "tone_id": "openness_big5",
+                            "tone_name": "Openness"
+                        },
+                        {
+                            "score": 0.761,
+                            "tone_id": "conscientiousness_big5",
+                            "tone_name": "Conscientiousness"
+                        },
+                        {
+                            "score": 0.23,
+                            "tone_id": "extraversion_big5",
+                            "tone_name": "Extraversion"
+                        },
+                        {
+                            "score": 0.425,
+                            "tone_id": "agreeableness_big5",
+                            "tone_name": "Agreeableness"
+                        },
+                        {
+                            "score": 0.493,
+                            "tone_id": "emotional_range_big5",
+                            "tone_name": "Emotional Range"
+                        }
+                    ],
+                    "category_id": "social_tone",
+                    "category_name": "Social Tone"
+                }
+            ]
+        },
+        {
+            "sentence_id": 62,
+            "text": "True, they rather order me about some, and make me jump from spar to spar, like a grasshopper in a May meadow.",
+            "input_from": 6903,
+            "input_to": 7013,
+            "tone_categories": [
+                {
+                    "tones": [
+                        {
+                            "score": 0.114608,
+                            "tone_id": "anger",
+                            "tone_name": "Anger"
+                        },
+                        {
+                            "score": 0.180568,
+                            "tone_id": "disgust",
+                            "tone_name": "Disgust"
+                        },
+                        {
+                            "score": 0.127396,
+                            "tone_id": "fear",
+                            "tone_name": "Fear"
+                        },
+                        {
+                            "score": 0.552524,
+                            "tone_id": "joy",
+                            "tone_name": "Joy"
+                        },
+                        {
+                            "score": 0.21591,
+                            "tone_id": "sadness",
+                            "tone_name": "Sadness"
+                        }
+                    ],
+                    "category_id": "emotion_tone",
+                    "category_name": "Emotion Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0,
+                            "tone_id": "analytical",
+                            "tone_name": "Analytical"
+                        },
+                        {
+                            "score": 0,
+                            "tone_id": "confident",
+                            "tone_name": "Confident"
+                        },
+                        {
+                            "score": 0.913,
+                            "tone_id": "tentative",
+                            "tone_name": "Tentative"
+                        }
+                    ],
+                    "category_id": "language_tone",
+                    "category_name": "Language Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0.392,
+                            "tone_id": "openness_big5",
+                            "tone_name": "Openness"
+                        },
+                        {
+                            "score": 0.35,
+                            "tone_id": "conscientiousness_big5",
+                            "tone_name": "Conscientiousness"
+                        },
+                        {
+                            "score": 0.573,
+                            "tone_id": "extraversion_big5",
+                            "tone_name": "Extraversion"
+                        },
+                        {
+                            "score": 0.659,
+                            "tone_id": "agreeableness_big5",
+                            "tone_name": "Agreeableness"
+                        },
+                        {
+                            "score": 0.814,
+                            "tone_id": "emotional_range_big5",
+                            "tone_name": "Emotional Range"
+                        }
+                    ],
+                    "category_id": "social_tone",
+                    "category_name": "Social Tone"
+                }
+            ]
+        },
+        {
+            "sentence_id": 63,
+            "text": "And at first, this sort of thing is unpleasant enough.",
+            "input_from": 7014,
+            "input_to": 7068,
+            "tone_categories": [
+                {
+                    "tones": [
+                        {
+                            "score": 0.172106,
+                            "tone_id": "anger",
+                            "tone_name": "Anger"
+                        },
+                        {
+                            "score": 0.323635,
+                            "tone_id": "disgust",
+                            "tone_name": "Disgust"
+                        },
+                        {
+                            "score": 0.405992,
+                            "tone_id": "fear",
+                            "tone_name": "Fear"
+                        },
+                        {
+                            "score": 0.168903,
+                            "tone_id": "joy",
+                            "tone_name": "Joy"
+                        },
+                        {
+                            "score": 0.287174,
+                            "tone_id": "sadness",
+                            "tone_name": "Sadness"
+                        }
+                    ],
+                    "category_id": "emotion_tone",
+                    "category_name": "Emotion Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0,
+                            "tone_id": "analytical",
+                            "tone_name": "Analytical"
+                        },
+                        {
+                            "score": 0,
+                            "tone_id": "confident",
+                            "tone_name": "Confident"
+                        },
+                        {
+                            "score": 0.715,
+                            "tone_id": "tentative",
+                            "tone_name": "Tentative"
+                        }
+                    ],
+                    "category_id": "language_tone",
+                    "category_name": "Language Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0.885,
+                            "tone_id": "openness_big5",
+                            "tone_name": "Openness"
+                        },
+                        {
+                            "score": 0.218,
+                            "tone_id": "conscientiousness_big5",
+                            "tone_name": "Conscientiousness"
+                        },
+                        {
+                            "score": 0.059,
+                            "tone_id": "extraversion_big5",
+                            "tone_name": "Extraversion"
+                        },
+                        {
+                            "score": 0.19,
+                            "tone_id": "agreeableness_big5",
+                            "tone_name": "Agreeableness"
+                        },
+                        {
+                            "score": 0.894,
+                            "tone_id": "emotional_range_big5",
+                            "tone_name": "Emotional Range"
+                        }
+                    ],
+                    "category_id": "social_tone",
+                    "category_name": "Social Tone"
+                }
+            ]
+        },
+        {
+            "sentence_id": 64,
+            "text": "It touches one's sense of honour, particularly if you come of an old established family in the land, the Van Rensselaers, or Randolphs, or Hardicanutes.",
+            "input_from": 7069,
+            "input_to": 7221,
+            "tone_categories": [
+                {
+                    "tones": [
+                        {
+                            "score": 0.245789,
+                            "tone_id": "anger",
+                            "tone_name": "Anger"
+                        },
+                        {
+                            "score": 0.355261,
+                            "tone_id": "disgust",
+                            "tone_name": "Disgust"
+                        },
+                        {
+                            "score": 0.290643,
+                            "tone_id": "fear",
+                            "tone_name": "Fear"
+                        },
+                        {
+                            "score": 0.112017,
+                            "tone_id": "joy",
+                            "tone_name": "Joy"
+                        },
+                        {
+                            "score": 0.277867,
+                            "tone_id": "sadness",
+                            "tone_name": "Sadness"
+                        }
+                    ],
+                    "category_id": "emotion_tone",
+                    "category_name": "Emotion Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0.866,
+                            "tone_id": "analytical",
+                            "tone_name": "Analytical"
+                        },
+                        {
+                            "score": 0,
+                            "tone_id": "confident",
+                            "tone_name": "Confident"
+                        },
+                        {
+                            "score": 0.571,
+                            "tone_id": "tentative",
+                            "tone_name": "Tentative"
+                        }
+                    ],
+                    "category_id": "language_tone",
+                    "category_name": "Language Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0.495,
+                            "tone_id": "openness_big5",
+                            "tone_name": "Openness"
+                        },
+                        {
+                            "score": 0.291,
+                            "tone_id": "conscientiousness_big5",
+                            "tone_name": "Conscientiousness"
+                        },
+                        {
+                            "score": 0.557,
+                            "tone_id": "extraversion_big5",
+                            "tone_name": "Extraversion"
+                        },
+                        {
+                            "score": 0.608,
+                            "tone_id": "agreeableness_big5",
+                            "tone_name": "Agreeableness"
+                        },
+                        {
+                            "score": 0.671,
+                            "tone_id": "emotional_range_big5",
+                            "tone_name": "Emotional Range"
+                        }
+                    ],
+                    "category_id": "social_tone",
+                    "category_name": "Social Tone"
+                }
+            ]
+        },
+        {
+            "sentence_id": 65,
+            "text": "And more than all, if just previous to putting your hand into the tar-pot, you have been lording it as a country schoolmaster, making the tallest boys stand in awe of you.",
+            "input_from": 7222,
+            "input_to": 7393,
+            "tone_categories": [
+                {
+                    "tones": [
+                        {
+                            "score": 0.107358,
+                            "tone_id": "anger",
+                            "tone_name": "Anger"
+                        },
+                        {
+                            "score": 0.727051,
+                            "tone_id": "disgust",
+                            "tone_name": "Disgust"
+                        },
+                        {
+                            "score": 0.242276,
+                            "tone_id": "fear",
+                            "tone_name": "Fear"
+                        },
+                        {
+                            "score": 0.116783,
+                            "tone_id": "joy",
+                            "tone_name": "Joy"
+                        },
+                        {
+                            "score": 0.176322,
+                            "tone_id": "sadness",
+                            "tone_name": "Sadness"
+                        }
+                    ],
+                    "category_id": "emotion_tone",
+                    "category_name": "Emotion Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0.155,
+                            "tone_id": "analytical",
+                            "tone_name": "Analytical"
+                        },
+                        {
+                            "score": 0.08,
+                            "tone_id": "confident",
+                            "tone_name": "Confident"
+                        },
+                        {
+                            "score": 0,
+                            "tone_id": "tentative",
+                            "tone_name": "Tentative"
+                        }
+                    ],
+                    "category_id": "language_tone",
+                    "category_name": "Language Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0.612,
+                            "tone_id": "openness_big5",
+                            "tone_name": "Openness"
+                        },
+                        {
+                            "score": 0.35,
+                            "tone_id": "conscientiousness_big5",
+                            "tone_name": "Conscientiousness"
+                        },
+                        {
+                            "score": 0.806,
+                            "tone_id": "extraversion_big5",
+                            "tone_name": "Extraversion"
+                        },
+                        {
+                            "score": 0.569,
+                            "tone_id": "agreeableness_big5",
+                            "tone_name": "Agreeableness"
+                        },
+                        {
+                            "score": 0.213,
+                            "tone_id": "emotional_range_big5",
+                            "tone_name": "Emotional Range"
+                        }
+                    ],
+                    "category_id": "social_tone",
+                    "category_name": "Social Tone"
+                }
+            ]
+        },
+        {
+            "sentence_id": 66,
+            "text": "The transition is a keen one, I assure you, from a schoolmaster to a sailor, and requires a strong decoction of Seneca and the Stoics to enable you to grin and bear it.",
+            "input_from": 7394,
+            "input_to": 7562,
+            "tone_categories": [
+                {
+                    "tones": [
+                        {
+                            "score": 0.381463,
+                            "tone_id": "anger",
+                            "tone_name": "Anger"
+                        },
+                        {
+                            "score": 0.493127,
+                            "tone_id": "disgust",
+                            "tone_name": "Disgust"
+                        },
+                        {
+                            "score": 0.524356,
+                            "tone_id": "fear",
+                            "tone_name": "Fear"
+                        },
+                        {
+                            "score": 0.061184,
+                            "tone_id": "joy",
+                            "tone_name": "Joy"
+                        },
+                        {
+                            "score": 0.233586,
+                            "tone_id": "sadness",
+                            "tone_name": "Sadness"
+                        }
+                    ],
+                    "category_id": "emotion_tone",
+                    "category_name": "Emotion Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0.155,
+                            "tone_id": "analytical",
+                            "tone_name": "Analytical"
+                        },
+                        {
+                            "score": 0.298,
+                            "tone_id": "confident",
+                            "tone_name": "Confident"
+                        },
+                        {
+                            "score": 0,
+                            "tone_id": "tentative",
+                            "tone_name": "Tentative"
+                        }
+                    ],
+                    "category_id": "language_tone",
+                    "category_name": "Language Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0.583,
+                            "tone_id": "openness_big5",
+                            "tone_name": "Openness"
+                        },
+                        {
+                            "score": 0.916,
+                            "tone_id": "conscientiousness_big5",
+                            "tone_name": "Conscientiousness"
+                        },
+                        {
+                            "score": 0.746,
+                            "tone_id": "extraversion_big5",
+                            "tone_name": "Extraversion"
+                        },
+                        {
+                            "score": 0.729,
+                            "tone_id": "agreeableness_big5",
+                            "tone_name": "Agreeableness"
+                        },
+                        {
+                            "score": 0.109,
+                            "tone_id": "emotional_range_big5",
+                            "tone_name": "Emotional Range"
+                        }
+                    ],
+                    "category_id": "social_tone",
+                    "category_name": "Social Tone"
+                }
+            ]
+        },
+        {
+            "sentence_id": 67,
+            "text": "But even this wears off in time.",
+            "input_from": 7563,
+            "input_to": 7595,
+            "tone_categories": [
+                {
+                    "tones": [
+                        {
+                            "score": 0.15969,
+                            "tone_id": "anger",
+                            "tone_name": "Anger"
+                        },
+                        {
+                            "score": 0.501692,
+                            "tone_id": "disgust",
+                            "tone_name": "Disgust"
+                        },
+                        {
+                            "score": 0.184826,
+                            "tone_id": "fear",
+                            "tone_name": "Fear"
+                        },
+                        {
+                            "score": 0.114453,
+                            "tone_id": "joy",
+                            "tone_name": "Joy"
+                        },
+                        {
+                            "score": 0.347395,
+                            "tone_id": "sadness",
+                            "tone_name": "Sadness"
+                        }
+                    ],
+                    "category_id": "emotion_tone",
+                    "category_name": "Emotion Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0,
+                            "tone_id": "analytical",
+                            "tone_name": "Analytical"
+                        },
+                        {
+                            "score": 0,
+                            "tone_id": "confident",
+                            "tone_name": "Confident"
+                        },
+                        {
+                            "score": 0.841,
+                            "tone_id": "tentative",
+                            "tone_name": "Tentative"
+                        }
+                    ],
+                    "category_id": "language_tone",
+                    "category_name": "Language Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0.603,
+                            "tone_id": "openness_big5",
+                            "tone_name": "Openness"
+                        },
+                        {
+                            "score": 0.01,
+                            "tone_id": "conscientiousness_big5",
+                            "tone_name": "Conscientiousness"
+                        },
+                        {
+                            "score": 0.297,
+                            "tone_id": "extraversion_big5",
+                            "tone_name": "Extraversion"
+                        },
+                        {
+                            "score": 0.847,
+                            "tone_id": "agreeableness_big5",
+                            "tone_name": "Agreeableness"
+                        },
+                        {
+                            "score": 0.97,
+                            "tone_id": "emotional_range_big5",
+                            "tone_name": "Emotional Range"
+                        }
+                    ],
+                    "category_id": "social_tone",
+                    "category_name": "Social Tone"
+                }
+            ]
+        },
+        {
+            "sentence_id": 68,
+            "text": "What of it, if some old hunks of a sea-captain orders me to get a broom and sweep down the decks?",
+            "input_from": 7596,
+            "input_to": 7693,
+            "tone_categories": [
+                {
+                    "tones": [
+                        {
+                            "score": 0.349233,
+                            "tone_id": "anger",
+                            "tone_name": "Anger"
+                        },
+                        {
+                            "score": 0.150259,
+                            "tone_id": "disgust",
+                            "tone_name": "Disgust"
+                        },
+                        {
+                            "score": 0.448867,
+                            "tone_id": "fear",
+                            "tone_name": "Fear"
+                        },
+                        {
+                            "score": 0.14003,
+                            "tone_id": "joy",
+                            "tone_name": "Joy"
+                        },
+                        {
+                            "score": 0.233611,
+                            "tone_id": "sadness",
+                            "tone_name": "Sadness"
+                        }
+                    ],
+                    "category_id": "emotion_tone",
+                    "category_name": "Emotion Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0.364,
+                            "tone_id": "analytical",
+                            "tone_name": "Analytical"
+                        },
+                        {
+                            "score": 0,
+                            "tone_id": "confident",
+                            "tone_name": "Confident"
+                        },
+                        {
+                            "score": 0.284,
+                            "tone_id": "tentative",
+                            "tone_name": "Tentative"
+                        }
+                    ],
+                    "category_id": "language_tone",
+                    "category_name": "Language Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0.791,
+                            "tone_id": "openness_big5",
+                            "tone_name": "Openness"
+                        },
+                        {
+                            "score": 0.498,
+                            "tone_id": "conscientiousness_big5",
+                            "tone_name": "Conscientiousness"
+                        },
+                        {
+                            "score": 0.153,
+                            "tone_id": "extraversion_big5",
+                            "tone_name": "Extraversion"
+                        },
+                        {
+                            "score": 0.275,
+                            "tone_id": "agreeableness_big5",
+                            "tone_name": "Agreeableness"
+                        },
+                        {
+                            "score": 0.685,
+                            "tone_id": "emotional_range_big5",
+                            "tone_name": "Emotional Range"
+                        }
+                    ],
+                    "category_id": "social_tone",
+                    "category_name": "Social Tone"
+                }
+            ]
+        },
+        {
+            "sentence_id": 69,
+            "text": "What does that indignity amount to, weighed, I mean, in the scales of the New Testament?",
+            "input_from": 7694,
+            "input_to": 7782,
+            "tone_categories": [
+                {
+                    "tones": [
+                        {
+                            "score": 0.114981,
+                            "tone_id": "anger",
+                            "tone_name": "Anger"
+                        },
+                        {
+                            "score": 0.341251,
+                            "tone_id": "disgust",
+                            "tone_name": "Disgust"
+                        },
+                        {
+                            "score": 0.232329,
+                            "tone_id": "fear",
+                            "tone_name": "Fear"
+                        },
+                        {
+                            "score": 0.372385,
+                            "tone_id": "joy",
+                            "tone_name": "Joy"
+                        },
+                        {
+                            "score": 0.282898,
+                            "tone_id": "sadness",
+                            "tone_name": "Sadness"
+                        }
+                    ],
+                    "category_id": "emotion_tone",
+                    "category_name": "Emotion Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0,
+                            "tone_id": "analytical",
+                            "tone_name": "Analytical"
+                        },
+                        {
+                            "score": 0,
+                            "tone_id": "confident",
+                            "tone_name": "Confident"
+                        },
+                        {
+                            "score": 0,
+                            "tone_id": "tentative",
+                            "tone_name": "Tentative"
+                        }
+                    ],
+                    "category_id": "language_tone",
+                    "category_name": "Language Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0.815,
+                            "tone_id": "openness_big5",
+                            "tone_name": "Openness"
+                        },
+                        {
+                            "score": 0.571,
+                            "tone_id": "conscientiousness_big5",
+                            "tone_name": "Conscientiousness"
+                        },
+                        {
+                            "score": 0.329,
+                            "tone_id": "extraversion_big5",
+                            "tone_name": "Extraversion"
+                        },
+                        {
+                            "score": 0.18,
+                            "tone_id": "agreeableness_big5",
+                            "tone_name": "Agreeableness"
+                        },
+                        {
+                            "score": 0.68,
+                            "tone_id": "emotional_range_big5",
+                            "tone_name": "Emotional Range"
+                        }
+                    ],
+                    "category_id": "social_tone",
+                    "category_name": "Social Tone"
+                }
+            ]
+        },
+        {
+            "sentence_id": 70,
+            "text": "Do you think the archangel Gabriel thinks anything the less of me, because I promptly and respectfully obey that old hunks in that particular instance?",
+            "input_from": 7783,
+            "input_to": 7934,
+            "tone_categories": [
+                {
+                    "tones": [
+                        {
+                            "score": 0.117679,
+                            "tone_id": "anger",
+                            "tone_name": "Anger"
+                        },
+                        {
+                            "score": 0.425065,
+                            "tone_id": "disgust",
+                            "tone_name": "Disgust"
+                        },
+                        {
+                            "score": 0.606104,
+                            "tone_id": "fear",
+                            "tone_name": "Fear"
+                        },
+                        {
+                            "score": 0.040868,
+                            "tone_id": "joy",
+                            "tone_name": "Joy"
+                        },
+                        {
+                            "score": 0.459945,
+                            "tone_id": "sadness",
+                            "tone_name": "Sadness"
+                        }
+                    ],
+                    "category_id": "emotion_tone",
+                    "category_name": "Emotion Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0.821,
+                            "tone_id": "analytical",
+                            "tone_name": "Analytical"
+                        },
+                        {
+                            "score": 0,
+                            "tone_id": "confident",
+                            "tone_name": "Confident"
+                        },
+                        {
+                            "score": 0.196,
+                            "tone_id": "tentative",
+                            "tone_name": "Tentative"
+                        }
+                    ],
+                    "category_id": "language_tone",
+                    "category_name": "Language Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0.326,
+                            "tone_id": "openness_big5",
+                            "tone_name": "Openness"
+                        },
+                        {
+                            "score": 0.266,
+                            "tone_id": "conscientiousness_big5",
+                            "tone_name": "Conscientiousness"
+                        },
+                        {
+                            "score": 0.39,
+                            "tone_id": "extraversion_big5",
+                            "tone_name": "Extraversion"
+                        },
+                        {
+                            "score": 0.412,
+                            "tone_id": "agreeableness_big5",
+                            "tone_name": "Agreeableness"
+                        },
+                        {
+                            "score": 0.846,
+                            "tone_id": "emotional_range_big5",
+                            "tone_name": "Emotional Range"
+                        }
+                    ],
+                    "category_id": "social_tone",
+                    "category_name": "Social Tone"
+                }
+            ]
+        },
+        {
+            "sentence_id": 71,
+            "text": "Who ain't a slave?",
+            "input_from": 7935,
+            "input_to": 7953,
+            "tone_categories": [
+                {
+                    "tones": [
+                        {
+                            "score": 0.243072,
+                            "tone_id": "anger",
+                            "tone_name": "Anger"
+                        },
+                        {
+                            "score": 0.332116,
+                            "tone_id": "disgust",
+                            "tone_name": "Disgust"
+                        },
+                        {
+                            "score": 0.450842,
+                            "tone_id": "fear",
+                            "tone_name": "Fear"
+                        },
+                        {
+                            "score": 0.11269,
+                            "tone_id": "joy",
+                            "tone_name": "Joy"
+                        },
+                        {
+                            "score": 0.202439,
+                            "tone_id": "sadness",
+                            "tone_name": "Sadness"
+                        }
+                    ],
+                    "category_id": "emotion_tone",
+                    "category_name": "Emotion Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0,
+                            "tone_id": "analytical",
+                            "tone_name": "Analytical"
+                        },
+                        {
+                            "score": 0,
+                            "tone_id": "confident",
+                            "tone_name": "Confident"
+                        },
+                        {
+                            "score": 0,
+                            "tone_id": "tentative",
+                            "tone_name": "Tentative"
+                        }
+                    ],
+                    "category_id": "language_tone",
+                    "category_name": "Language Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0.9,
+                            "tone_id": "openness_big5",
+                            "tone_name": "Openness"
+                        },
+                        {
+                            "score": 0.932,
+                            "tone_id": "conscientiousness_big5",
+                            "tone_name": "Conscientiousness"
+                        },
+                        {
+                            "score": 0.606,
+                            "tone_id": "extraversion_big5",
+                            "tone_name": "Extraversion"
+                        },
+                        {
+                            "score": 0.194,
+                            "tone_id": "agreeableness_big5",
+                            "tone_name": "Agreeableness"
+                        },
+                        {
+                            "score": 0.061,
+                            "tone_id": "emotional_range_big5",
+                            "tone_name": "Emotional Range"
+                        }
+                    ],
+                    "category_id": "social_tone",
+                    "category_name": "Social Tone"
+                }
+            ]
+        },
+        {
+            "sentence_id": 72,
+            "text": "Tell me that.",
+            "input_from": 7954,
+            "input_to": 7967,
+            "tone_categories": []
+        },
+        {
+            "sentence_id": 73,
+            "text": "Well, then, however the old sea-captains may order me about-however they may thump and punch me about, I have the satisfaction of knowing that it is all right; that everybody else is one way or other served in much the same way-either in a physical or metaphysical point of view, that is; and so the universal thump is passed round, and all hands should rub each other's shoulder-blades, and be content.",
+            "input_from": 7968,
+            "input_to": 8371,
+            "tone_categories": [
+                {
+                    "tones": [
+                        {
+                            "score": 0.600225,
+                            "tone_id": "anger",
+                            "tone_name": "Anger"
+                        },
+                        {
+                            "score": 0.188614,
+                            "tone_id": "disgust",
+                            "tone_name": "Disgust"
+                        },
+                        {
+                            "score": 0.342122,
+                            "tone_id": "fear",
+                            "tone_name": "Fear"
+                        },
+                        {
+                            "score": 0.051428,
+                            "tone_id": "joy",
+                            "tone_name": "Joy"
+                        },
+                        {
+                            "score": 0.309914,
+                            "tone_id": "sadness",
+                            "tone_name": "Sadness"
+                        }
+                    ],
+                    "category_id": "emotion_tone",
+                    "category_name": "Emotion Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0.296,
+                            "tone_id": "analytical",
+                            "tone_name": "Analytical"
+                        },
+                        {
+                            "score": 0,
+                            "tone_id": "confident",
+                            "tone_name": "Confident"
+                        },
+                        {
+                            "score": 0.005,
+                            "tone_id": "tentative",
+                            "tone_name": "Tentative"
+                        }
+                    ],
+                    "category_id": "language_tone",
+                    "category_name": "Language Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0.566,
+                            "tone_id": "openness_big5",
+                            "tone_name": "Openness"
+                        },
+                        {
+                            "score": 0.261,
+                            "tone_id": "conscientiousness_big5",
+                            "tone_name": "Conscientiousness"
+                        },
+                        {
+                            "score": 0.455,
+                            "tone_id": "extraversion_big5",
+                            "tone_name": "Extraversion"
+                        },
+                        {
+                            "score": 0.372,
+                            "tone_id": "agreeableness_big5",
+                            "tone_name": "Agreeableness"
+                        },
+                        {
+                            "score": 0.792,
+                            "tone_id": "emotional_range_big5",
+                            "tone_name": "Emotional Range"
+                        }
+                    ],
+                    "category_id": "social_tone",
+                    "category_name": "Social Tone"
+                }
+            ]
+        },
+        {
+            "sentence_id": 74,
+            "text": "Again, I always go to sea as a sailor, because they make a point of paying me for my trouble, whereas they never pay passengers a single penny that I ever heard of.",
+            "input_from": 8372,
+            "input_to": 8536,
+            "tone_categories": [
+                {
+                    "tones": [
+                        {
+                            "score": 0.399134,
+                            "tone_id": "anger",
+                            "tone_name": "Anger"
+                        },
+                        {
+                            "score": 0.426051,
+                            "tone_id": "disgust",
+                            "tone_name": "Disgust"
+                        },
+                        {
+                            "score": 0.191353,
+                            "tone_id": "fear",
+                            "tone_name": "Fear"
+                        },
+                        {
+                            "score": 0.133474,
+                            "tone_id": "joy",
+                            "tone_name": "Joy"
+                        },
+                        {
+                            "score": 0.336895,
+                            "tone_id": "sadness",
+                            "tone_name": "Sadness"
+                        }
+                    ],
+                    "category_id": "emotion_tone",
+                    "category_name": "Emotion Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0.69,
+                            "tone_id": "analytical",
+                            "tone_name": "Analytical"
+                        },
+                        {
+                            "score": 0.659,
+                            "tone_id": "confident",
+                            "tone_name": "Confident"
+                        },
+                        {
+                            "score": 0,
+                            "tone_id": "tentative",
+                            "tone_name": "Tentative"
+                        }
+                    ],
+                    "category_id": "language_tone",
+                    "category_name": "Language Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0.195,
+                            "tone_id": "openness_big5",
+                            "tone_name": "Openness"
+                        },
+                        {
+                            "score": 0.23,
+                            "tone_id": "conscientiousness_big5",
+                            "tone_name": "Conscientiousness"
+                        },
+                        {
+                            "score": 0.499,
+                            "tone_id": "extraversion_big5",
+                            "tone_name": "Extraversion"
+                        },
+                        {
+                            "score": 0.371,
+                            "tone_id": "agreeableness_big5",
+                            "tone_name": "Agreeableness"
+                        },
+                        {
+                            "score": 0.895,
+                            "tone_id": "emotional_range_big5",
+                            "tone_name": "Emotional Range"
+                        }
+                    ],
+                    "category_id": "social_tone",
+                    "category_name": "Social Tone"
+                }
+            ]
+        },
+        {
+            "sentence_id": 75,
+            "text": "On the contrary, passengers themselves must pay.",
+            "input_from": 8537,
+            "input_to": 8585,
+            "tone_categories": [
+                {
+                    "tones": [
+                        {
+                            "score": 0.176823,
+                            "tone_id": "anger",
+                            "tone_name": "Anger"
+                        },
+                        {
+                            "score": 0.441884,
+                            "tone_id": "disgust",
+                            "tone_name": "Disgust"
+                        },
+                        {
+                            "score": 0.245443,
+                            "tone_id": "fear",
+                            "tone_name": "Fear"
+                        },
+                        {
+                            "score": 0.135024,
+                            "tone_id": "joy",
+                            "tone_name": "Joy"
+                        },
+                        {
+                            "score": 0.265692,
+                            "tone_id": "sadness",
+                            "tone_name": "Sadness"
+                        }
+                    ],
+                    "category_id": "emotion_tone",
+                    "category_name": "Emotion Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0.984,
+                            "tone_id": "analytical",
+                            "tone_name": "Analytical"
+                        },
+                        {
+                            "score": 0.723,
+                            "tone_id": "confident",
+                            "tone_name": "Confident"
+                        },
+                        {
+                            "score": 0,
+                            "tone_id": "tentative",
+                            "tone_name": "Tentative"
+                        }
+                    ],
+                    "category_id": "language_tone",
+                    "category_name": "Language Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0.242,
+                            "tone_id": "openness_big5",
+                            "tone_name": "Openness"
+                        },
+                        {
+                            "score": 0.433,
+                            "tone_id": "conscientiousness_big5",
+                            "tone_name": "Conscientiousness"
+                        },
+                        {
+                            "score": 0.501,
+                            "tone_id": "extraversion_big5",
+                            "tone_name": "Extraversion"
+                        },
+                        {
+                            "score": 0.655,
+                            "tone_id": "agreeableness_big5",
+                            "tone_name": "Agreeableness"
+                        },
+                        {
+                            "score": 0.155,
+                            "tone_id": "emotional_range_big5",
+                            "tone_name": "Emotional Range"
+                        }
+                    ],
+                    "category_id": "social_tone",
+                    "category_name": "Social Tone"
+                }
+            ]
+        },
+        {
+            "sentence_id": 76,
+            "text": "And there is all the difference in the world between paying and being paid.",
+            "input_from": 8586,
+            "input_to": 8661,
+            "tone_categories": [
+                {
+                    "tones": [
+                        {
+                            "score": 0.20078,
+                            "tone_id": "anger",
+                            "tone_name": "Anger"
+                        },
+                        {
+                            "score": 0.215978,
+                            "tone_id": "disgust",
+                            "tone_name": "Disgust"
+                        },
+                        {
+                            "score": 0.097787,
+                            "tone_id": "fear",
+                            "tone_name": "Fear"
+                        },
+                        {
+                            "score": 0.302586,
+                            "tone_id": "joy",
+                            "tone_name": "Joy"
+                        },
+                        {
+                            "score": 0.483807,
+                            "tone_id": "sadness",
+                            "tone_name": "Sadness"
+                        }
+                    ],
+                    "category_id": "emotion_tone",
+                    "category_name": "Emotion Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0,
+                            "tone_id": "analytical",
+                            "tone_name": "Analytical"
+                        },
+                        {
+                            "score": 0.723,
+                            "tone_id": "confident",
+                            "tone_name": "Confident"
+                        },
+                        {
+                            "score": 0,
+                            "tone_id": "tentative",
+                            "tone_name": "Tentative"
+                        }
+                    ],
+                    "category_id": "language_tone",
+                    "category_name": "Language Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0.967,
+                            "tone_id": "openness_big5",
+                            "tone_name": "Openness"
+                        },
+                        {
+                            "score": 0.475,
+                            "tone_id": "conscientiousness_big5",
+                            "tone_name": "Conscientiousness"
+                        },
+                        {
+                            "score": 0.14,
+                            "tone_id": "extraversion_big5",
+                            "tone_name": "Extraversion"
+                        },
+                        {
+                            "score": 0.392,
+                            "tone_id": "agreeableness_big5",
+                            "tone_name": "Agreeableness"
+                        },
+                        {
+                            "score": 0.224,
+                            "tone_id": "emotional_range_big5",
+                            "tone_name": "Emotional Range"
+                        }
+                    ],
+                    "category_id": "social_tone",
+                    "category_name": "Social Tone"
+                }
+            ]
+        },
+        {
+            "sentence_id": 77,
+            "text": "The act of paying is perhaps the most uncomfortable infliction that the two orchard thieves entailed upon us.",
+            "input_from": 8662,
+            "input_to": 8771,
+            "tone_categories": [
+                {
+                    "tones": [
+                        {
+                            "score": 0.272819,
+                            "tone_id": "anger",
+                            "tone_name": "Anger"
+                        },
+                        {
+                            "score": 0.637609,
+                            "tone_id": "disgust",
+                            "tone_name": "Disgust"
+                        },
+                        {
+                            "score": 0.45609,
+                            "tone_id": "fear",
+                            "tone_name": "Fear"
+                        },
+                        {
+                            "score": 0.038838,
+                            "tone_id": "joy",
+                            "tone_name": "Joy"
+                        },
+                        {
+                            "score": 0.143311,
+                            "tone_id": "sadness",
+                            "tone_name": "Sadness"
+                        }
+                    ],
+                    "category_id": "emotion_tone",
+                    "category_name": "Emotion Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0,
+                            "tone_id": "analytical",
+                            "tone_name": "Analytical"
+                        },
+                        {
+                            "score": 0,
+                            "tone_id": "confident",
+                            "tone_name": "Confident"
+                        },
+                        {
+                            "score": 0.346,
+                            "tone_id": "tentative",
+                            "tone_name": "Tentative"
+                        }
+                    ],
+                    "category_id": "language_tone",
+                    "category_name": "Language Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0.667,
+                            "tone_id": "openness_big5",
+                            "tone_name": "Openness"
+                        },
+                        {
+                            "score": 0.494,
+                            "tone_id": "conscientiousness_big5",
+                            "tone_name": "Conscientiousness"
+                        },
+                        {
+                            "score": 0.286,
+                            "tone_id": "extraversion_big5",
+                            "tone_name": "Extraversion"
+                        },
+                        {
+                            "score": 0.288,
+                            "tone_id": "agreeableness_big5",
+                            "tone_name": "Agreeableness"
+                        },
+                        {
+                            "score": 0.525,
+                            "tone_id": "emotional_range_big5",
+                            "tone_name": "Emotional Range"
+                        }
+                    ],
+                    "category_id": "social_tone",
+                    "category_name": "Social Tone"
+                }
+            ]
+        },
+        {
+            "sentence_id": 78,
+            "text": "But BEING PAID,-what will compare with it?",
+            "input_from": 8772,
+            "input_to": 8814,
+            "tone_categories": [
+                {
+                    "tones": [
+                        {
+                            "score": 0.129291,
+                            "tone_id": "anger",
+                            "tone_name": "Anger"
+                        },
+                        {
+                            "score": 0.168215,
+                            "tone_id": "disgust",
+                            "tone_name": "Disgust"
+                        },
+                        {
+                            "score": 0.505291,
+                            "tone_id": "fear",
+                            "tone_name": "Fear"
+                        },
+                        {
+                            "score": 0.172874,
+                            "tone_id": "joy",
+                            "tone_name": "Joy"
+                        },
+                        {
+                            "score": 0.445413,
+                            "tone_id": "sadness",
+                            "tone_name": "Sadness"
+                        }
+                    ],
+                    "category_id": "emotion_tone",
+                    "category_name": "Emotion Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0.978,
+                            "tone_id": "analytical",
+                            "tone_name": "Analytical"
+                        },
+                        {
+                            "score": 0,
+                            "tone_id": "confident",
+                            "tone_name": "Confident"
+                        },
+                        {
+                            "score": 0,
+                            "tone_id": "tentative",
+                            "tone_name": "Tentative"
+                        }
+                    ],
+                    "category_id": "language_tone",
+                    "category_name": "Language Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0.525,
+                            "tone_id": "openness_big5",
+                            "tone_name": "Openness"
+                        },
+                        {
+                            "score": 0.027,
+                            "tone_id": "conscientiousness_big5",
+                            "tone_name": "Conscientiousness"
+                        },
+                        {
+                            "score": 0.07,
+                            "tone_id": "extraversion_big5",
+                            "tone_name": "Extraversion"
+                        },
+                        {
+                            "score": 0.214,
+                            "tone_id": "agreeableness_big5",
+                            "tone_name": "Agreeableness"
+                        },
+                        {
+                            "score": 0.957,
+                            "tone_id": "emotional_range_big5",
+                            "tone_name": "Emotional Range"
+                        }
+                    ],
+                    "category_id": "social_tone",
+                    "category_name": "Social Tone"
+                }
+            ]
+        },
+        {
+            "sentence_id": 79,
+            "text": "The urbane activity with which a man receives money is really marvellous, considering that we so earnestly believe money to be the root of all earthly ills, and that on no account can a monied man enter heaven.",
+            "input_from": 8815,
+            "input_to": 9025,
+            "tone_categories": [
+                {
+                    "tones": [
+                        {
+                            "score": 0.258157,
+                            "tone_id": "anger",
+                            "tone_name": "Anger"
+                        },
+                        {
+                            "score": 0.362913,
+                            "tone_id": "disgust",
+                            "tone_name": "Disgust"
+                        },
+                        {
+                            "score": 0.209787,
+                            "tone_id": "fear",
+                            "tone_name": "Fear"
+                        },
+                        {
+                            "score": 0.224406,
+                            "tone_id": "joy",
+                            "tone_name": "Joy"
+                        },
+                        {
+                            "score": 0.206747,
+                            "tone_id": "sadness",
+                            "tone_name": "Sadness"
+                        }
+                    ],
+                    "category_id": "emotion_tone",
+                    "category_name": "Emotion Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0,
+                            "tone_id": "analytical",
+                            "tone_name": "Analytical"
+                        },
+                        {
+                            "score": 0,
+                            "tone_id": "confident",
+                            "tone_name": "Confident"
+                        },
+                        {
+                            "score": 0,
+                            "tone_id": "tentative",
+                            "tone_name": "Tentative"
+                        }
+                    ],
+                    "category_id": "language_tone",
+                    "category_name": "Language Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0.623,
+                            "tone_id": "openness_big5",
+                            "tone_name": "Openness"
+                        },
+                        {
+                            "score": 0.284,
+                            "tone_id": "conscientiousness_big5",
+                            "tone_name": "Conscientiousness"
+                        },
+                        {
+                            "score": 0.637,
+                            "tone_id": "extraversion_big5",
+                            "tone_name": "Extraversion"
+                        },
+                        {
+                            "score": 0.265,
+                            "tone_id": "agreeableness_big5",
+                            "tone_name": "Agreeableness"
+                        },
+                        {
+                            "score": 0.563,
+                            "tone_id": "emotional_range_big5",
+                            "tone_name": "Emotional Range"
+                        }
+                    ],
+                    "category_id": "social_tone",
+                    "category_name": "Social Tone"
+                }
+            ]
+        },
+        {
+            "sentence_id": 80,
+            "text": "Ah! how cheerfully we consign ourselves to perdition!",
+            "input_from": 9026,
+            "input_to": 9079,
+            "tone_categories": [
+                {
+                    "tones": [
+                        {
+                            "score": 0.326175,
+                            "tone_id": "anger",
+                            "tone_name": "Anger"
+                        },
+                        {
+                            "score": 0.279526,
+                            "tone_id": "disgust",
+                            "tone_name": "Disgust"
+                        },
+                        {
+                            "score": 0.280562,
+                            "tone_id": "fear",
+                            "tone_name": "Fear"
+                        },
+                        {
+                            "score": 0.081405,
+                            "tone_id": "joy",
+                            "tone_name": "Joy"
+                        },
+                        {
+                            "score": 0.159875,
+                            "tone_id": "sadness",
+                            "tone_name": "Sadness"
+                        }
+                    ],
+                    "category_id": "emotion_tone",
+                    "category_name": "Emotion Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0,
+                            "tone_id": "analytical",
+                            "tone_name": "Analytical"
+                        },
+                        {
+                            "score": 0,
+                            "tone_id": "confident",
+                            "tone_name": "Confident"
+                        },
+                        {
+                            "score": 0,
+                            "tone_id": "tentative",
+                            "tone_name": "Tentative"
+                        }
+                    ],
+                    "category_id": "language_tone",
+                    "category_name": "Language Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0.031,
+                            "tone_id": "openness_big5",
+                            "tone_name": "Openness"
+                        },
+                        {
+                            "score": 0.18,
+                            "tone_id": "conscientiousness_big5",
+                            "tone_name": "Conscientiousness"
+                        },
+                        {
+                            "score": 0.959,
+                            "tone_id": "extraversion_big5",
+                            "tone_name": "Extraversion"
+                        },
+                        {
+                            "score": 0.979,
+                            "tone_id": "agreeableness_big5",
+                            "tone_name": "Agreeableness"
+                        },
+                        {
+                            "score": 0.862,
+                            "tone_id": "emotional_range_big5",
+                            "tone_name": "Emotional Range"
+                        }
+                    ],
+                    "category_id": "social_tone",
+                    "category_name": "Social Tone"
+                }
+            ]
+        },
+        {
+            "sentence_id": 81,
+            "text": "Finally, I always go to sea as a sailor, because of the wholesome exercise and pure air of the fore-castle deck.",
+            "input_from": 9080,
+            "input_to": 9192,
+            "tone_categories": [
+                {
+                    "tones": [
+                        {
+                            "score": 0.10393,
+                            "tone_id": "anger",
+                            "tone_name": "Anger"
+                        },
+                        {
+                            "score": 0.110797,
+                            "tone_id": "disgust",
+                            "tone_name": "Disgust"
+                        },
+                        {
+                            "score": 0.194602,
+                            "tone_id": "fear",
+                            "tone_name": "Fear"
+                        },
+                        {
+                            "score": 0.691458,
+                            "tone_id": "joy",
+                            "tone_name": "Joy"
+                        },
+                        {
+                            "score": 0.203747,
+                            "tone_id": "sadness",
+                            "tone_name": "Sadness"
+                        }
+                    ],
+                    "category_id": "emotion_tone",
+                    "category_name": "Emotion Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0.563,
+                            "tone_id": "analytical",
+                            "tone_name": "Analytical"
+                        },
+                        {
+                            "score": 0.543,
+                            "tone_id": "confident",
+                            "tone_name": "Confident"
+                        },
+                        {
+                            "score": 0,
+                            "tone_id": "tentative",
+                            "tone_name": "Tentative"
+                        }
+                    ],
+                    "category_id": "language_tone",
+                    "category_name": "Language Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0.775,
+                            "tone_id": "openness_big5",
+                            "tone_name": "Openness"
+                        },
+                        {
+                            "score": 0.663,
+                            "tone_id": "conscientiousness_big5",
+                            "tone_name": "Conscientiousness"
+                        },
+                        {
+                            "score": 0.283,
+                            "tone_id": "extraversion_big5",
+                            "tone_name": "Extraversion"
+                        },
+                        {
+                            "score": 0.19,
+                            "tone_id": "agreeableness_big5",
+                            "tone_name": "Agreeableness"
+                        },
+                        {
+                            "score": 0.655,
+                            "tone_id": "emotional_range_big5",
+                            "tone_name": "Emotional Range"
+                        }
+                    ],
+                    "category_id": "social_tone",
+                    "category_name": "Social Tone"
+                }
+            ]
+        },
+        {
+            "sentence_id": 82,
+            "text": "For as in this world, head winds are far more prevalent than winds from astern (that is, if you never violate the Pythagorean maxim), so for the most part the Commodore on the quarter-deck gets his atmosphere at second hand from the sailors on the forecastle.",
+            "input_from": 9193,
+            "input_to": 9452,
+            "tone_categories": [
+                {
+                    "tones": [
+                        {
+                            "score": 0.190926,
+                            "tone_id": "anger",
+                            "tone_name": "Anger"
+                        },
+                        {
+                            "score": 0.563901,
+                            "tone_id": "disgust",
+                            "tone_name": "Disgust"
+                        },
+                        {
+                            "score": 0.379399,
+                            "tone_id": "fear",
+                            "tone_name": "Fear"
+                        },
+                        {
+                            "score": 0.039081,
+                            "tone_id": "joy",
+                            "tone_name": "Joy"
+                        },
+                        {
+                            "score": 0.386472,
+                            "tone_id": "sadness",
+                            "tone_name": "Sadness"
+                        }
+                    ],
+                    "category_id": "emotion_tone",
+                    "category_name": "Emotion Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0.066,
+                            "tone_id": "analytical",
+                            "tone_name": "Analytical"
+                        },
+                        {
+                            "score": 0.167,
+                            "tone_id": "confident",
+                            "tone_name": "Confident"
+                        },
+                        {
+                            "score": 0,
+                            "tone_id": "tentative",
+                            "tone_name": "Tentative"
+                        }
+                    ],
+                    "category_id": "language_tone",
+                    "category_name": "Language Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0.835,
+                            "tone_id": "openness_big5",
+                            "tone_name": "Openness"
+                        },
+                        {
+                            "score": 0.569,
+                            "tone_id": "conscientiousness_big5",
+                            "tone_name": "Conscientiousness"
+                        },
+                        {
+                            "score": 0.551,
+                            "tone_id": "extraversion_big5",
+                            "tone_name": "Extraversion"
+                        },
+                        {
+                            "score": 0.391,
+                            "tone_id": "agreeableness_big5",
+                            "tone_name": "Agreeableness"
+                        },
+                        {
+                            "score": 0.166,
+                            "tone_id": "emotional_range_big5",
+                            "tone_name": "Emotional Range"
+                        }
+                    ],
+                    "category_id": "social_tone",
+                    "category_name": "Social Tone"
+                }
+            ]
+        },
+        {
+            "sentence_id": 83,
+            "text": "He thinks he breathes it first; but not so.",
+            "input_from": 9453,
+            "input_to": 9496,
+            "tone_categories": [
+                {
+                    "tones": [
+                        {
+                            "score": 0.146976,
+                            "tone_id": "anger",
+                            "tone_name": "Anger"
+                        },
+                        {
+                            "score": 0.264925,
+                            "tone_id": "disgust",
+                            "tone_name": "Disgust"
+                        },
+                        {
+                            "score": 0.429378,
+                            "tone_id": "fear",
+                            "tone_name": "Fear"
+                        },
+                        {
+                            "score": 0.140581,
+                            "tone_id": "joy",
+                            "tone_name": "Joy"
+                        },
+                        {
+                            "score": 0.474616,
+                            "tone_id": "sadness",
+                            "tone_name": "Sadness"
+                        }
+                    ],
+                    "category_id": "emotion_tone",
+                    "category_name": "Emotion Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0.779,
+                            "tone_id": "analytical",
+                            "tone_name": "Analytical"
+                        },
+                        {
+                            "score": 0,
+                            "tone_id": "confident",
+                            "tone_name": "Confident"
+                        },
+                        {
+                            "score": 0,
+                            "tone_id": "tentative",
+                            "tone_name": "Tentative"
+                        }
+                    ],
+                    "category_id": "language_tone",
+                    "category_name": "Language Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0.032,
+                            "tone_id": "openness_big5",
+                            "tone_name": "Openness"
+                        },
+                        {
+                            "score": 0.035,
+                            "tone_id": "conscientiousness_big5",
+                            "tone_name": "Conscientiousness"
+                        },
+                        {
+                            "score": 0.763,
+                            "tone_id": "extraversion_big5",
+                            "tone_name": "Extraversion"
+                        },
+                        {
+                            "score": 0.927,
+                            "tone_id": "agreeableness_big5",
+                            "tone_name": "Agreeableness"
+                        },
+                        {
+                            "score": 0.925,
+                            "tone_id": "emotional_range_big5",
+                            "tone_name": "Emotional Range"
+                        }
+                    ],
+                    "category_id": "social_tone",
+                    "category_name": "Social Tone"
+                }
+            ]
+        },
+        {
+            "sentence_id": 84,
+            "text": "In much the same way do the commonalty lead their leaders in many other things, at the same time that the leaders little suspect it.",
+            "input_from": 9497,
+            "input_to": 9629,
+            "tone_categories": [
+                {
+                    "tones": [
+                        {
+                            "score": 0.223986,
+                            "tone_id": "anger",
+                            "tone_name": "Anger"
+                        },
+                        {
+                            "score": 0.530082,
+                            "tone_id": "disgust",
+                            "tone_name": "Disgust"
+                        },
+                        {
+                            "score": 0.343833,
+                            "tone_id": "fear",
+                            "tone_name": "Fear"
+                        },
+                        {
+                            "score": 0.063121,
+                            "tone_id": "joy",
+                            "tone_name": "Joy"
+                        },
+                        {
+                            "score": 0.278164,
+                            "tone_id": "sadness",
+                            "tone_name": "Sadness"
+                        }
+                    ],
+                    "category_id": "emotion_tone",
+                    "category_name": "Emotion Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0.257,
+                            "tone_id": "analytical",
+                            "tone_name": "Analytical"
+                        },
+                        {
+                            "score": 0,
+                            "tone_id": "confident",
+                            "tone_name": "Confident"
+                        },
+                        {
+                            "score": 0.571,
+                            "tone_id": "tentative",
+                            "tone_name": "Tentative"
+                        }
+                    ],
+                    "category_id": "language_tone",
+                    "category_name": "Language Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0.899,
+                            "tone_id": "openness_big5",
+                            "tone_name": "Openness"
+                        },
+                        {
+                            "score": 0.752,
+                            "tone_id": "conscientiousness_big5",
+                            "tone_name": "Conscientiousness"
+                        },
+                        {
+                            "score": 0.411,
+                            "tone_id": "extraversion_big5",
+                            "tone_name": "Extraversion"
+                        },
+                        {
+                            "score": 0.255,
+                            "tone_id": "agreeableness_big5",
+                            "tone_name": "Agreeableness"
+                        },
+                        {
+                            "score": 0.23,
+                            "tone_id": "emotional_range_big5",
+                            "tone_name": "Emotional Range"
+                        }
+                    ],
+                    "category_id": "social_tone",
+                    "category_name": "Social Tone"
+                }
+            ]
+        },
+        {
+            "sentence_id": 85,
+            "text": "But wherefore it was that after having repeatedly smelt the sea as a merchant sailor, I should now take it into my head to go on a whaling voyage; this the invisible police officer of the Fates, who has the constant surveillance of me, and secretly dogs me, and influences me in some unaccountable way-he can better answer than any one else.",
+            "input_from": 9630,
+            "input_to": 9971,
+            "tone_categories": [
+                {
+                    "tones": [
+                        {
+                            "score": 0.421184,
+                            "tone_id": "anger",
+                            "tone_name": "Anger"
+                        },
+                        {
+                            "score": 0.707532,
+                            "tone_id": "disgust",
+                            "tone_name": "Disgust"
+                        },
+                        {
+                            "score": 0.530845,
+                            "tone_id": "fear",
+                            "tone_name": "Fear"
+                        },
+                        {
+                            "score": 0.014768,
+                            "tone_id": "joy",
+                            "tone_name": "Joy"
+                        },
+                        {
+                            "score": 0.092379,
+                            "tone_id": "sadness",
+                            "tone_name": "Sadness"
+                        }
+                    ],
+                    "category_id": "emotion_tone",
+                    "category_name": "Emotion Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0.688,
+                            "tone_id": "analytical",
+                            "tone_name": "Analytical"
+                        },
+                        {
+                            "score": 0,
+                            "tone_id": "confident",
+                            "tone_name": "Confident"
+                        },
+                        {
+                            "score": 0.008,
+                            "tone_id": "tentative",
+                            "tone_name": "Tentative"
+                        }
+                    ],
+                    "category_id": "language_tone",
+                    "category_name": "Language Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0.506,
+                            "tone_id": "openness_big5",
+                            "tone_name": "Openness"
+                        },
+                        {
+                            "score": 0.429,
+                            "tone_id": "conscientiousness_big5",
+                            "tone_name": "Conscientiousness"
+                        },
+                        {
+                            "score": 0.239,
+                            "tone_id": "extraversion_big5",
+                            "tone_name": "Extraversion"
+                        },
+                        {
+                            "score": 0.422,
+                            "tone_id": "agreeableness_big5",
+                            "tone_name": "Agreeableness"
+                        },
+                        {
+                            "score": 0.808,
+                            "tone_id": "emotional_range_big5",
+                            "tone_name": "Emotional Range"
+                        }
+                    ],
+                    "category_id": "social_tone",
+                    "category_name": "Social Tone"
+                }
+            ]
+        },
+        {
+            "sentence_id": 86,
+            "text": "And, doubtless, my going on this whaling voyage, formed part of the grand programme of Providence that was drawn up a long time ago.",
+            "input_from": 9972,
+            "input_to": 10104,
+            "tone_categories": [
+                {
+                    "tones": [
+                        {
+                            "score": 0.259643,
+                            "tone_id": "anger",
+                            "tone_name": "Anger"
+                        },
+                        {
+                            "score": 0.433288,
+                            "tone_id": "disgust",
+                            "tone_name": "Disgust"
+                        },
+                        {
+                            "score": 0.221091,
+                            "tone_id": "fear",
+                            "tone_name": "Fear"
+                        },
+                        {
+                            "score": 0.234673,
+                            "tone_id": "joy",
+                            "tone_name": "Joy"
+                        },
+                        {
+                            "score": 0.23225,
+                            "tone_id": "sadness",
+                            "tone_name": "Sadness"
+                        }
+                    ],
+                    "category_id": "emotion_tone",
+                    "category_name": "Emotion Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0,
+                            "tone_id": "analytical",
+                            "tone_name": "Analytical"
+                        },
+                        {
+                            "score": 0,
+                            "tone_id": "confident",
+                            "tone_name": "Confident"
+                        },
+                        {
+                            "score": 0.199,
+                            "tone_id": "tentative",
+                            "tone_name": "Tentative"
+                        }
+                    ],
+                    "category_id": "language_tone",
+                    "category_name": "Language Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0.509,
+                            "tone_id": "openness_big5",
+                            "tone_name": "Openness"
+                        },
+                        {
+                            "score": 0.569,
+                            "tone_id": "conscientiousness_big5",
+                            "tone_name": "Conscientiousness"
+                        },
+                        {
+                            "score": 0.443,
+                            "tone_id": "extraversion_big5",
+                            "tone_name": "Extraversion"
+                        },
+                        {
+                            "score": 0.581,
+                            "tone_id": "agreeableness_big5",
+                            "tone_name": "Agreeableness"
+                        },
+                        {
+                            "score": 0.565,
+                            "tone_id": "emotional_range_big5",
+                            "tone_name": "Emotional Range"
+                        }
+                    ],
+                    "category_id": "social_tone",
+                    "category_name": "Social Tone"
+                }
+            ]
+        },
+        {
+            "sentence_id": 87,
+            "text": "It came in as a sort of brief interlude and solo between more extensive performances.",
+            "input_from": 10105,
+            "input_to": 10190,
+            "tone_categories": [
+                {
+                    "tones": [
+                        {
+                            "score": 0.220237,
+                            "tone_id": "anger",
+                            "tone_name": "Anger"
+                        },
+                        {
+                            "score": 0.488841,
+                            "tone_id": "disgust",
+                            "tone_name": "Disgust"
+                        },
+                        {
+                            "score": 0.346516,
+                            "tone_id": "fear",
+                            "tone_name": "Fear"
+                        },
+                        {
+                            "score": 0.32806,
+                            "tone_id": "joy",
+                            "tone_name": "Joy"
+                        },
+                        {
+                            "score": 0.174339,
+                            "tone_id": "sadness",
+                            "tone_name": "Sadness"
+                        }
+                    ],
+                    "category_id": "emotion_tone",
+                    "category_name": "Emotion Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0,
+                            "tone_id": "analytical",
+                            "tone_name": "Analytical"
+                        },
+                        {
+                            "score": 0,
+                            "tone_id": "confident",
+                            "tone_name": "Confident"
+                        },
+                        {
+                            "score": 0.451,
+                            "tone_id": "tentative",
+                            "tone_name": "Tentative"
+                        }
+                    ],
+                    "category_id": "language_tone",
+                    "category_name": "Language Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0.922,
+                            "tone_id": "openness_big5",
+                            "tone_name": "Openness"
+                        },
+                        {
+                            "score": 0.534,
+                            "tone_id": "conscientiousness_big5",
+                            "tone_name": "Conscientiousness"
+                        },
+                        {
+                            "score": 0.24,
+                            "tone_id": "extraversion_big5",
+                            "tone_name": "Extraversion"
+                        },
+                        {
+                            "score": 0.432,
+                            "tone_id": "agreeableness_big5",
+                            "tone_name": "Agreeableness"
+                        },
+                        {
+                            "score": 0.536,
+                            "tone_id": "emotional_range_big5",
+                            "tone_name": "Emotional Range"
+                        }
+                    ],
+                    "category_id": "social_tone",
+                    "category_name": "Social Tone"
+                }
+            ]
+        },
+        {
+            "sentence_id": 88,
+            "text": "I take it that this part of the bill must have run something like this:\n\"GRAND CONTESTED ELECTION FOR THE PRESIDENCY OF THE UNITED STATES.",
+            "input_from": 10191,
+            "input_to": 10329,
+            "tone_categories": [
+                {
+                    "tones": [
+                        {
+                            "score": 0.118164,
+                            "tone_id": "anger",
+                            "tone_name": "Anger"
+                        },
+                        {
+                            "score": 0.52867,
+                            "tone_id": "disgust",
+                            "tone_name": "Disgust"
+                        },
+                        {
+                            "score": 0.454139,
+                            "tone_id": "fear",
+                            "tone_name": "Fear"
+                        },
+                        {
+                            "score": 0.167206,
+                            "tone_id": "joy",
+                            "tone_name": "Joy"
+                        },
+                        {
+                            "score": 0.198501,
+                            "tone_id": "sadness",
+                            "tone_name": "Sadness"
+                        }
+                    ],
+                    "category_id": "emotion_tone",
+                    "category_name": "Emotion Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0,
+                            "tone_id": "analytical",
+                            "tone_name": "Analytical"
+                        },
+                        {
+                            "score": 0,
+                            "tone_id": "confident",
+                            "tone_name": "Confident"
+                        },
+                        {
+                            "score": 0.065,
+                            "tone_id": "tentative",
+                            "tone_name": "Tentative"
+                        }
+                    ],
+                    "category_id": "language_tone",
+                    "category_name": "Language Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0.374,
+                            "tone_id": "openness_big5",
+                            "tone_name": "Openness"
+                        },
+                        {
+                            "score": 0.345,
+                            "tone_id": "conscientiousness_big5",
+                            "tone_name": "Conscientiousness"
+                        },
+                        {
+                            "score": 0.446,
+                            "tone_id": "extraversion_big5",
+                            "tone_name": "Extraversion"
+                        },
+                        {
+                            "score": 0.536,
+                            "tone_id": "agreeableness_big5",
+                            "tone_name": "Agreeableness"
+                        },
+                        {
+                            "score": 0.739,
+                            "tone_id": "emotional_range_big5",
+                            "tone_name": "Emotional Range"
+                        }
+                    ],
+                    "category_id": "social_tone",
+                    "category_name": "Social Tone"
+                }
+            ]
+        },
+        {
+            "sentence_id": 89,
+            "text": "\"WHALING VOYAGE BY ONE ISHMAEL.",
+            "input_from": 10330,
+            "input_to": 10361,
+            "tone_categories": [
+                {
+                    "tones": [
+                        {
+                            "score": 0.242882,
+                            "tone_id": "anger",
+                            "tone_name": "Anger"
+                        },
+                        {
+                            "score": 0.212707,
+                            "tone_id": "disgust",
+                            "tone_name": "Disgust"
+                        },
+                        {
+                            "score": 0.251869,
+                            "tone_id": "fear",
+                            "tone_name": "Fear"
+                        },
+                        {
+                            "score": 0.217312,
+                            "tone_id": "joy",
+                            "tone_name": "Joy"
+                        },
+                        {
+                            "score": 0.219939,
+                            "tone_id": "sadness",
+                            "tone_name": "Sadness"
+                        }
+                    ],
+                    "category_id": "emotion_tone",
+                    "category_name": "Emotion Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0,
+                            "tone_id": "analytical",
+                            "tone_name": "Analytical"
+                        },
+                        {
+                            "score": 0,
+                            "tone_id": "confident",
+                            "tone_name": "Confident"
+                        },
+                        {
+                            "score": 0,
+                            "tone_id": "tentative",
+                            "tone_name": "Tentative"
+                        }
+                    ],
+                    "category_id": "language_tone",
+                    "category_name": "Language Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0.912,
+                            "tone_id": "openness_big5",
+                            "tone_name": "Openness"
+                        },
+                        {
+                            "score": 0.571,
+                            "tone_id": "conscientiousness_big5",
+                            "tone_name": "Conscientiousness"
+                        },
+                        {
+                            "score": 0.035,
+                            "tone_id": "extraversion_big5",
+                            "tone_name": "Extraversion"
+                        },
+                        {
+                            "score": 0.119,
+                            "tone_id": "agreeableness_big5",
+                            "tone_name": "Agreeableness"
+                        },
+                        {
+                            "score": 0.401,
+                            "tone_id": "emotional_range_big5",
+                            "tone_name": "Emotional Range"
+                        }
+                    ],
+                    "category_id": "social_tone",
+                    "category_name": "Social Tone"
+                }
+            ]
+        },
+        {
+            "sentence_id": 90,
+            "text": "\"BLOODY BATTLE IN AFFGHANISTAN.\"",
+            "input_from": 10362,
+            "input_to": 10394,
+            "tone_categories": [
+                {
+                    "tones": [
+                        {
+                            "score": 0.467411,
+                            "tone_id": "anger",
+                            "tone_name": "Anger"
+                        },
+                        {
+                            "score": 0.387246,
+                            "tone_id": "disgust",
+                            "tone_name": "Disgust"
+                        },
+                        {
+                            "score": 0.297422,
+                            "tone_id": "fear",
+                            "tone_name": "Fear"
+                        },
+                        {
+                            "score": 0.040942,
+                            "tone_id": "joy",
+                            "tone_name": "Joy"
+                        },
+                        {
+                            "score": 0.214117,
+                            "tone_id": "sadness",
+                            "tone_name": "Sadness"
+                        }
+                    ],
+                    "category_id": "emotion_tone",
+                    "category_name": "Emotion Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0,
+                            "tone_id": "analytical",
+                            "tone_name": "Analytical"
+                        },
+                        {
+                            "score": 0,
+                            "tone_id": "confident",
+                            "tone_name": "Confident"
+                        },
+                        {
+                            "score": 0,
+                            "tone_id": "tentative",
+                            "tone_name": "Tentative"
+                        }
+                    ],
+                    "category_id": "language_tone",
+                    "category_name": "Language Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0.981,
+                            "tone_id": "openness_big5",
+                            "tone_name": "Openness"
+                        },
+                        {
+                            "score": 0.571,
+                            "tone_id": "conscientiousness_big5",
+                            "tone_name": "Conscientiousness"
+                        },
+                        {
+                            "score": 0.89,
+                            "tone_id": "extraversion_big5",
+                            "tone_name": "Extraversion"
+                        },
+                        {
+                            "score": 0.743,
+                            "tone_id": "agreeableness_big5",
+                            "tone_name": "Agreeableness"
+                        },
+                        {
+                            "score": 0.401,
+                            "tone_id": "emotional_range_big5",
+                            "tone_name": "Emotional Range"
+                        }
+                    ],
+                    "category_id": "social_tone",
+                    "category_name": "Social Tone"
+                }
+            ]
+        },
+        {
+            "sentence_id": 91,
+            "text": "Though I cannot tell why it was exactly that those stage managers, the Fates, put me down for this shabby part of a whaling voyage, when others were set down for magnificent parts in high tragedies, and short and easy parts in genteel comedies, and jolly parts in farces-though I cannot tell why this was exactly; yet, now that I recall all the circumstances, I think I can see a little into the springs and motives which being cunningly presented to me under various disguises, induced me to set about performing the part I did, besides cajoling me into the delusion that it was a choice resulting from my own unbiased freewill and discriminating judgment.",
+            "input_from": 10395,
+            "input_to": 11052,
+            "tone_categories": [
+                {
+                    "tones": [
+                        {
+                            "score": 0.530573,
+                            "tone_id": "anger",
+                            "tone_name": "Anger"
+                        },
+                        {
+                            "score": 0.305188,
+                            "tone_id": "disgust",
+                            "tone_name": "Disgust"
+                        },
+                        {
+                            "score": 0.287743,
+                            "tone_id": "fear",
+                            "tone_name": "Fear"
+                        },
+                        {
+                            "score": 0.049307,
+                            "tone_id": "joy",
+                            "tone_name": "Joy"
+                        },
+                        {
+                            "score": 0.240543,
+                            "tone_id": "sadness",
+                            "tone_name": "Sadness"
+                        }
+                    ],
+                    "category_id": "emotion_tone",
+                    "category_name": "Emotion Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0.255,
+                            "tone_id": "analytical",
+                            "tone_name": "Analytical"
+                        },
+                        {
+                            "score": 0.167,
+                            "tone_id": "confident",
+                            "tone_name": "Confident"
+                        },
+                        {
+                            "score": 0,
+                            "tone_id": "tentative",
+                            "tone_name": "Tentative"
+                        }
+                    ],
+                    "category_id": "language_tone",
+                    "category_name": "Language Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0.438,
+                            "tone_id": "openness_big5",
+                            "tone_name": "Openness"
+                        },
+                        {
+                            "score": 0.321,
+                            "tone_id": "conscientiousness_big5",
+                            "tone_name": "Conscientiousness"
+                        },
+                        {
+                            "score": 0.433,
+                            "tone_id": "extraversion_big5",
+                            "tone_name": "Extraversion"
+                        },
+                        {
+                            "score": 0.506,
+                            "tone_id": "agreeableness_big5",
+                            "tone_name": "Agreeableness"
+                        },
+                        {
+                            "score": 0.827,
+                            "tone_id": "emotional_range_big5",
+                            "tone_name": "Emotional Range"
+                        }
+                    ],
+                    "category_id": "social_tone",
+                    "category_name": "Social Tone"
+                }
+            ]
+        },
+        {
+            "sentence_id": 92,
+            "text": "Chief among these motives was the overwhelming idea of the great whale himself.",
+            "input_from": 11053,
+            "input_to": 11132,
+            "tone_categories": [
+                {
+                    "tones": [
+                        {
+                            "score": 0.07347,
+                            "tone_id": "anger",
+                            "tone_name": "Anger"
+                        },
+                        {
+                            "score": 0.348998,
+                            "tone_id": "disgust",
+                            "tone_name": "Disgust"
+                        },
+                        {
+                            "score": 0.403245,
+                            "tone_id": "fear",
+                            "tone_name": "Fear"
+                        },
+                        {
+                            "score": 0.326948,
+                            "tone_id": "joy",
+                            "tone_name": "Joy"
+                        },
+                        {
+                            "score": 0.136145,
+                            "tone_id": "sadness",
+                            "tone_name": "Sadness"
+                        }
+                    ],
+                    "category_id": "emotion_tone",
+                    "category_name": "Emotion Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0,
+                            "tone_id": "analytical",
+                            "tone_name": "Analytical"
+                        },
+                        {
+                            "score": 0,
+                            "tone_id": "confident",
+                            "tone_name": "Confident"
+                        },
+                        {
+                            "score": 0,
+                            "tone_id": "tentative",
+                            "tone_name": "Tentative"
+                        }
+                    ],
+                    "category_id": "language_tone",
+                    "category_name": "Language Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0.768,
+                            "tone_id": "openness_big5",
+                            "tone_name": "Openness"
+                        },
+                        {
+                            "score": 0.22,
+                            "tone_id": "conscientiousness_big5",
+                            "tone_name": "Conscientiousness"
+                        },
+                        {
+                            "score": 0.265,
+                            "tone_id": "extraversion_big5",
+                            "tone_name": "Extraversion"
+                        },
+                        {
+                            "score": 0.218,
+                            "tone_id": "agreeableness_big5",
+                            "tone_name": "Agreeableness"
+                        },
+                        {
+                            "score": 0.833,
+                            "tone_id": "emotional_range_big5",
+                            "tone_name": "Emotional Range"
+                        }
+                    ],
+                    "category_id": "social_tone",
+                    "category_name": "Social Tone"
+                }
+            ]
+        },
+        {
+            "sentence_id": 93,
+            "text": "Such a portentous and mysterious monster roused all my curiosity.",
+            "input_from": 11133,
+            "input_to": 11198,
+            "tone_categories": [
+                {
+                    "tones": [
+                        {
+                            "score": 0.287072,
+                            "tone_id": "anger",
+                            "tone_name": "Anger"
+                        },
+                        {
+                            "score": 0.045712,
+                            "tone_id": "disgust",
+                            "tone_name": "Disgust"
+                        },
+                        {
+                            "score": 0.428996,
+                            "tone_id": "fear",
+                            "tone_name": "Fear"
+                        },
+                        {
+                            "score": 0.280744,
+                            "tone_id": "joy",
+                            "tone_name": "Joy"
+                        },
+                        {
+                            "score": 0.139453,
+                            "tone_id": "sadness",
+                            "tone_name": "Sadness"
+                        }
+                    ],
+                    "category_id": "emotion_tone",
+                    "category_name": "Emotion Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0,
+                            "tone_id": "analytical",
+                            "tone_name": "Analytical"
+                        },
+                        {
+                            "score": 0.879,
+                            "tone_id": "confident",
+                            "tone_name": "Confident"
+                        },
+                        {
+                            "score": 0,
+                            "tone_id": "tentative",
+                            "tone_name": "Tentative"
+                        }
+                    ],
+                    "category_id": "language_tone",
+                    "category_name": "Language Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0.669,
+                            "tone_id": "openness_big5",
+                            "tone_name": "Openness"
+                        },
+                        {
+                            "score": 0.556,
+                            "tone_id": "conscientiousness_big5",
+                            "tone_name": "Conscientiousness"
+                        },
+                        {
+                            "score": 0.409,
+                            "tone_id": "extraversion_big5",
+                            "tone_name": "Extraversion"
+                        },
+                        {
+                            "score": 0.235,
+                            "tone_id": "agreeableness_big5",
+                            "tone_name": "Agreeableness"
+                        },
+                        {
+                            "score": 0.78,
+                            "tone_id": "emotional_range_big5",
+                            "tone_name": "Emotional Range"
+                        }
+                    ],
+                    "category_id": "social_tone",
+                    "category_name": "Social Tone"
+                }
+            ]
+        },
+        {
+            "sentence_id": 94,
+            "text": "Then the wild and distant seas where he rolled his island bulk; the undeliverable, nameless perils of the whale; these, with all the attending marvels of a thousand Patagonian sights and sounds, helped to sway me to my wish.",
+            "input_from": 11199,
+            "input_to": 11423,
+            "tone_categories": [
+                {
+                    "tones": [
+                        {
+                            "score": 0.201321,
+                            "tone_id": "anger",
+                            "tone_name": "Anger"
+                        },
+                        {
+                            "score": 0.413132,
+                            "tone_id": "disgust",
+                            "tone_name": "Disgust"
+                        },
+                        {
+                            "score": 0.328442,
+                            "tone_id": "fear",
+                            "tone_name": "Fear"
+                        },
+                        {
+                            "score": 0.040351,
+                            "tone_id": "joy",
+                            "tone_name": "Joy"
+                        },
+                        {
+                            "score": 0.432223,
+                            "tone_id": "sadness",
+                            "tone_name": "Sadness"
+                        }
+                    ],
+                    "category_id": "emotion_tone",
+                    "category_name": "Emotion Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0.014,
+                            "tone_id": "analytical",
+                            "tone_name": "Analytical"
+                        },
+                        {
+                            "score": 0.235,
+                            "tone_id": "confident",
+                            "tone_name": "Confident"
+                        },
+                        {
+                            "score": 0,
+                            "tone_id": "tentative",
+                            "tone_name": "Tentative"
+                        }
+                    ],
+                    "category_id": "language_tone",
+                    "category_name": "Language Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0.601,
+                            "tone_id": "openness_big5",
+                            "tone_name": "Openness"
+                        },
+                        {
+                            "score": 0.517,
+                            "tone_id": "conscientiousness_big5",
+                            "tone_name": "Conscientiousness"
+                        },
+                        {
+                            "score": 0.566,
+                            "tone_id": "extraversion_big5",
+                            "tone_name": "Extraversion"
+                        },
+                        {
+                            "score": 0.531,
+                            "tone_id": "agreeableness_big5",
+                            "tone_name": "Agreeableness"
+                        },
+                        {
+                            "score": 0.385,
+                            "tone_id": "emotional_range_big5",
+                            "tone_name": "Emotional Range"
+                        }
+                    ],
+                    "category_id": "social_tone",
+                    "category_name": "Social Tone"
+                }
+            ]
+        },
+        {
+            "sentence_id": 95,
+            "text": "With other men, perhaps, such things would not have been inducements; but as for me, I am tormented with an everlasting itch for things remote.",
+            "input_from": 11424,
+            "input_to": 11567,
+            "tone_categories": [
+                {
+                    "tones": [
+                        {
+                            "score": 0.47654,
+                            "tone_id": "anger",
+                            "tone_name": "Anger"
+                        },
+                        {
+                            "score": 0.418817,
+                            "tone_id": "disgust",
+                            "tone_name": "Disgust"
+                        },
+                        {
+                            "score": 0.133762,
+                            "tone_id": "fear",
+                            "tone_name": "Fear"
+                        },
+                        {
+                            "score": 0.08858,
+                            "tone_id": "joy",
+                            "tone_name": "Joy"
+                        },
+                        {
+                            "score": 0.419193,
+                            "tone_id": "sadness",
+                            "tone_name": "Sadness"
+                        }
+                    ],
+                    "category_id": "emotion_tone",
+                    "category_name": "Emotion Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0.257,
+                            "tone_id": "analytical",
+                            "tone_name": "Analytical"
+                        },
+                        {
+                            "score": 0,
+                            "tone_id": "confident",
+                            "tone_name": "Confident"
+                        },
+                        {
+                            "score": 0.196,
+                            "tone_id": "tentative",
+                            "tone_name": "Tentative"
+                        }
+                    ],
+                    "category_id": "language_tone",
+                    "category_name": "Language Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0.447,
+                            "tone_id": "openness_big5",
+                            "tone_name": "Openness"
+                        },
+                        {
+                            "score": 0.057,
+                            "tone_id": "conscientiousness_big5",
+                            "tone_name": "Conscientiousness"
+                        },
+                        {
+                            "score": 0.497,
+                            "tone_id": "extraversion_big5",
+                            "tone_name": "Extraversion"
+                        },
+                        {
+                            "score": 0.378,
+                            "tone_id": "agreeableness_big5",
+                            "tone_name": "Agreeableness"
+                        },
+                        {
+                            "score": 0.956,
+                            "tone_id": "emotional_range_big5",
+                            "tone_name": "Emotional Range"
+                        }
+                    ],
+                    "category_id": "social_tone",
+                    "category_name": "Social Tone"
+                }
+            ]
+        },
+        {
+            "sentence_id": 96,
+            "text": "I love to sail forbidden seas, and land on barbarous coasts.",
+            "input_from": 11568,
+            "input_to": 11628,
+            "tone_categories": [
+                {
+                    "tones": [
+                        {
+                            "score": 0.099477,
+                            "tone_id": "anger",
+                            "tone_name": "Anger"
+                        },
+                        {
+                            "score": 0.164791,
+                            "tone_id": "disgust",
+                            "tone_name": "Disgust"
+                        },
+                        {
+                            "score": 0.149077,
+                            "tone_id": "fear",
+                            "tone_name": "Fear"
+                        },
+                        {
+                            "score": 0.425919,
+                            "tone_id": "joy",
+                            "tone_name": "Joy"
+                        },
+                        {
+                            "score": 0.384697,
+                            "tone_id": "sadness",
+                            "tone_name": "Sadness"
+                        }
+                    ],
+                    "category_id": "emotion_tone",
+                    "category_name": "Emotion Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0,
+                            "tone_id": "analytical",
+                            "tone_name": "Analytical"
+                        },
+                        {
+                            "score": 0,
+                            "tone_id": "confident",
+                            "tone_name": "Confident"
+                        },
+                        {
+                            "score": 0,
+                            "tone_id": "tentative",
+                            "tone_name": "Tentative"
+                        }
+                    ],
+                    "category_id": "language_tone",
+                    "category_name": "Language Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0.232,
+                            "tone_id": "openness_big5",
+                            "tone_name": "Openness"
+                        },
+                        {
+                            "score": 0.295,
+                            "tone_id": "conscientiousness_big5",
+                            "tone_name": "Conscientiousness"
+                        },
+                        {
+                            "score": 0.829,
+                            "tone_id": "extraversion_big5",
+                            "tone_name": "Extraversion"
+                        },
+                        {
+                            "score": 0.739,
+                            "tone_id": "agreeableness_big5",
+                            "tone_name": "Agreeableness"
+                        },
+                        {
+                            "score": 0.876,
+                            "tone_id": "emotional_range_big5",
+                            "tone_name": "Emotional Range"
+                        }
+                    ],
+                    "category_id": "social_tone",
+                    "category_name": "Social Tone"
+                }
+            ]
+        },
+        {
+            "sentence_id": 97,
+            "text": "Not ignoring what is good, I am quick to perceive a horror, and could still be social with it-would they let me-since it is but well to be on friendly terms with all the inmates of the place one lodges in.",
+            "input_from": 11629,
+            "input_to": 11834,
+            "tone_categories": [
+                {
+                    "tones": [
+                        {
+                            "score": 0.267446,
+                            "tone_id": "anger",
+                            "tone_name": "Anger"
+                        },
+                        {
+                            "score": 0.220281,
+                            "tone_id": "disgust",
+                            "tone_name": "Disgust"
+                        },
+                        {
+                            "score": 0.345987,
+                            "tone_id": "fear",
+                            "tone_name": "Fear"
+                        },
+                        {
+                            "score": 0.061857,
+                            "tone_id": "joy",
+                            "tone_name": "Joy"
+                        },
+                        {
+                            "score": 0.226209,
+                            "tone_id": "sadness",
+                            "tone_name": "Sadness"
+                        }
+                    ],
+                    "category_id": "emotion_tone",
+                    "category_name": "Emotion Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0,
+                            "tone_id": "analytical",
+                            "tone_name": "Analytical"
+                        },
+                        {
+                            "score": 0,
+                            "tone_id": "confident",
+                            "tone_name": "Confident"
+                        },
+                        {
+                            "score": 0,
+                            "tone_id": "tentative",
+                            "tone_name": "Tentative"
+                        }
+                    ],
+                    "category_id": "language_tone",
+                    "category_name": "Language Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0.591,
+                            "tone_id": "openness_big5",
+                            "tone_name": "Openness"
+                        },
+                        {
+                            "score": 0.184,
+                            "tone_id": "conscientiousness_big5",
+                            "tone_name": "Conscientiousness"
+                        },
+                        {
+                            "score": 0.514,
+                            "tone_id": "extraversion_big5",
+                            "tone_name": "Extraversion"
+                        },
+                        {
+                            "score": 0.39,
+                            "tone_id": "agreeableness_big5",
+                            "tone_name": "Agreeableness"
+                        },
+                        {
+                            "score": 0.825,
+                            "tone_id": "emotional_range_big5",
+                            "tone_name": "Emotional Range"
+                        }
+                    ],
+                    "category_id": "social_tone",
+                    "category_name": "Social Tone"
+                }
+            ]
+        },
+        {
+            "sentence_id": 98,
+            "text": "By reason of these things, then, the whaling voyage was welcome; the great flood-gates of the wonder-world swung open, and in the wild conceits that swayed me to my purpose, two and two there floated into my inmost soul, endless processions of the whale, and, mid most of them all, one grand hooded phantom, like a snow hill in the air.",
+            "input_from": 11835,
+            "input_to": 12171,
+            "tone_categories": [
+                {
+                    "tones": [
+                        {
+                            "score": 0.096855,
+                            "tone_id": "anger",
+                            "tone_name": "Anger"
+                        },
+                        {
+                            "score": 0.111949,
+                            "tone_id": "disgust",
+                            "tone_name": "Disgust"
+                        },
+                        {
+                            "score": 0.630888,
+                            "tone_id": "fear",
+                            "tone_name": "Fear"
+                        },
+                        {
+                            "score": 0.172567,
+                            "tone_id": "joy",
+                            "tone_name": "Joy"
+                        },
+                        {
+                            "score": 0.180281,
+                            "tone_id": "sadness",
+                            "tone_name": "Sadness"
+                        }
+                    ],
+                    "category_id": "emotion_tone",
+                    "category_name": "Emotion Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0.275,
+                            "tone_id": "analytical",
+                            "tone_name": "Analytical"
+                        },
+                        {
+                            "score": 0.031,
+                            "tone_id": "confident",
+                            "tone_name": "Confident"
+                        },
+                        {
+                            "score": 0,
+                            "tone_id": "tentative",
+                            "tone_name": "Tentative"
+                        }
+                    ],
+                    "category_id": "language_tone",
+                    "category_name": "Language Tone"
+                },
+                {
+                    "tones": [
+                        {
+                            "score": 0.711,
+                            "tone_id": "openness_big5",
+                            "tone_name": "Openness"
+                        },
+                        {
+                            "score": 0.498,
+                            "tone_id": "conscientiousness_big5",
+                            "tone_name": "Conscientiousness"
+                        },
+                        {
+                            "score": 0.427,
+                            "tone_id": "extraversion_big5",
+                            "tone_name": "Extraversion"
+                        },
+                        {
+                            "score": 0.432,
+                            "tone_id": "agreeableness_big5",
+                            "tone_name": "Agreeableness"
+                        },
+                        {
+                            "score": 0.662,
+                            "tone_id": "emotional_range_big5",
+                            "tone_name": "Emotional Range"
+                        }
+                    ],
+                    "category_id": "social_tone",
+                    "category_name": "Social Tone"
+                }
+            ]
+        }
+    ]
+}

--- a/test/test_tone_analyzer_v3.py
+++ b/test/test_tone_analyzer_v3.py
@@ -17,7 +17,7 @@ def test_success():
                   content_type='application/json')
 
     with open(os.path.join(os.path.dirname(__file__), '../resources/personality.txt')) as tone_text:
-        tone_analyzer = watson_developer_cloud.ToneAnalyzerV3(
+        tone_analyzer = watson_developer_cloud.ToneAnalyzerV3("2016-05-19",
             username="username", password="password")
         tone_analyzer.tone(tone_text.read())
 
@@ -40,11 +40,10 @@ def test_with_args():
                   body=tone_response, status=200,
                   content_type='application/json')
 
-    params = { 'tones': 'social', 'sentences': 'false' }
     with open(os.path.join(os.path.dirname(__file__), '../resources/personality.txt')) as tone_text:
-        tone_analyzer = watson_developer_cloud.ToneAnalyzerV3(
+        tone_analyzer = watson_developer_cloud.ToneAnalyzerV3("2016-05-19",
             username="username", password="password")
-        tone_analyzer.tone(tone_text.read(), params=params)
+        tone_analyzer.tone(tone_text.read(), tones="social", sentences=False)
 
 
     assert responses.calls[0].request.url.split('?')[0] == tone_url 

--- a/test/test_tone_analyzer_v3.py
+++ b/test/test_tone_analyzer_v3.py
@@ -47,7 +47,6 @@ def test_with_args():
         tone_analyzer.tone(tone_text.read(), params=params)
 
 
-    print responses.calls[0].request.url
     assert responses.calls[0].request.url.split('?')[0] == tone_url 
     # Compare args. Order is not deterministic!
     actualArgs = {}

--- a/test/test_tone_analyzer_v3.py
+++ b/test/test_tone_analyzer_v3.py
@@ -1,0 +1,53 @@
+import responses
+import watson_developer_cloud
+import os
+
+
+@responses.activate
+## Simple test, just calling tone() with some text
+def test_success():
+    tone_url = 'https://gateway.watsonplatform.net/tone-analyzer/api/v3/tone'
+    tone_args = '?version=2016-05-19'
+    tone_response = None
+    with open(os.path.join(os.path.dirname(__file__), '../resources/tone_response.json')) as response_json:
+        tone_response = response_json.read()
+
+    responses.add(responses.POST, tone_url,
+                  body=tone_response, status=200,
+                  content_type='application/json')
+
+    with open(os.path.join(os.path.dirname(__file__), '../resources/personality.txt')) as tone_text:
+        tone_analyzer = watson_developer_cloud.ToneAnalyzerV3(
+            username="username", password="password")
+        tone_analyzer.tone(tone_text.read())
+
+    assert responses.calls[0].request.url == tone_url + tone_args
+    assert responses.calls[0].response.text == tone_response
+
+    assert len(responses.calls) == 1
+
+
+@responses.activate
+## Invoking tone() with some modifiers given in 'params': specific tones requested, and sentences skipped
+def test_with_args():
+    tone_url = 'https://gateway.watsonplatform.net/tone-analyzer/api/v3/tone'
+    tone_args = '?version=2016-05-19&tones=social&sentences=false'
+    tone_response = None
+    with open(os.path.join(os.path.dirname(__file__), '../resources/tone_response.json')) as response_json:
+        tone_response = response_json.read()
+
+    responses.add(responses.POST, tone_url,
+                  body=tone_response, status=200,
+                  content_type='application/json')
+
+    params = { 'tones': 'social', 'sentences': 'false' }
+    with open(os.path.join(os.path.dirname(__file__), '../resources/personality.txt')) as tone_text:
+        tone_analyzer = watson_developer_cloud.ToneAnalyzerV3(
+            username="username", password="password")
+        tone_analyzer.tone(tone_text.read(), params=params)
+
+    #print responses.calls[0].request.url
+    assert responses.calls[0].request.url == tone_url + tone_args
+    assert responses.calls[0].response.text == tone_response
+
+    assert len(responses.calls) == 1

--- a/test/test_tone_analyzer_v3.py
+++ b/test/test_tone_analyzer_v3.py
@@ -31,7 +31,7 @@ def test_success():
 ## Invoking tone() with some modifiers given in 'params': specific tones requested, and sentences skipped
 def test_with_args():
     tone_url = 'https://gateway.watsonplatform.net/tone-analyzer/api/v3/tone'
-    tone_args = '?version=2016-05-19&tones=social&sentences=false'
+    tone_args = { 'version': '2016-05-19', 'tones': 'social', 'sentences': 'false' }
     tone_response = None
     with open(os.path.join(os.path.dirname(__file__), '../resources/tone_response.json')) as response_json:
         tone_response = response_json.read()
@@ -46,8 +46,13 @@ def test_with_args():
             username="username", password="password")
         tone_analyzer.tone(tone_text.read(), params=params)
 
-    #print responses.calls[0].request.url
-    assert responses.calls[0].request.url == tone_url + tone_args
-    assert responses.calls[0].response.text == tone_response
 
+    print responses.calls[0].request.url
+    assert responses.calls[0].request.url.split('?')[0] == tone_url 
+    # Compare args. Order is not deterministic!
+    actualArgs = {}
+    for arg in responses.calls[0].request.url.split('?')[1].split('&'):
+        actualArgs[arg.split('=')[0]] = arg.split('=')[1]
+    assert actualArgs == tone_args
+    assert responses.calls[0].response.text == tone_response
     assert len(responses.calls) == 1

--- a/watson_developer_cloud/tone_analyzer_v3.py
+++ b/watson_developer_cloud/tone_analyzer_v3.py
@@ -19,7 +19,6 @@ The v3 Tone Analyzer service
 
 
 from watson_developer_cloud.watson_developer_cloud_service import WatsonDeveloperCloudService
-import copy
 
 class ToneAnalyzerV3(WatsonDeveloperCloudService):
     default_url = 'https://gateway.watsonplatform.net/tone-analyzer/api'

--- a/watson_developer_cloud/tone_analyzer_v3.py
+++ b/watson_developer_cloud/tone_analyzer_v3.py
@@ -39,11 +39,11 @@ class ToneAnalyzerV3(WatsonDeveloperCloudService):
         :param sentences: If "false", sentence-level analysis is omitted
         :param tones: Can be one or more of 'social', 'language', 'emotion'; comma-separated.
         """
-        queryArgs = {}
-        queryArgs['version'] = self.version
+        params = {}
+        params['version'] = self.version
         if tones is not None:
-            queryArgs['tones'] = tones
+            params['tones'] = tones
         if sentences is not None:
-            queryArgs['sentences'] = str(sentences).lower() # Cast boolean to "false" / "true"
+            params['sentences'] = str(sentences).lower() # Cast boolean to "false" / "true"
         data = {'text': text}
-        return self.request(method='POST', url='/v3/tone', params=queryArgs, json=data, accept_json=True)
+        return self.request(method='POST', url='/v3/tone', params=params, json=data, accept_json=True)

--- a/watson_developer_cloud/tone_analyzer_v3.py
+++ b/watson_developer_cloud/tone_analyzer_v3.py
@@ -19,24 +19,25 @@ The v3 Tone Analyzer service
 
 
 from watson_developer_cloud.watson_developer_cloud_service import WatsonDeveloperCloudService
-
+import copy
 
 class ToneAnalyzerV3(WatsonDeveloperCloudService):
     default_url = 'https://gateway.watsonplatform.net/tone-analyzer/api'
-    latest_version = '2016-02-11'
+    latest_version = '2016-05-19'
 
-    def __init__(self, version, url=default_url, username=None, password=None, use_vcap_services=True):
+    def __init__(self, version=latest_version, url=default_url, username=None, password=None, use_vcap_services=True):
         WatsonDeveloperCloudService.__init__(
             self, 'tone_analyzer', url, username, password, use_vcap_services)
         self.version = version
 
-    def tone(self, text):
+    def tone(self, text, params=None):
         """
         The tone API is the main API call: it analyzes the "tone" of a piece of text. The message is analyzed from
         several tones (social tone, emotional tone, writing tone), and for each of them various traits are derived
         (such as conscientiousness, agreeableness, openness).
         :param text: Text to analyze
         """
-        params = {'version': self.version}
+        args = copy.copy(params) if params is not None else {}
+        args['version'] = self.version
         data = {'text': text}
-        return self.request(method='POST', url='/v3/tone', params=params, json=data, accept_json=True)
+        return self.request(method='POST', url='/v3/tone', params=args, json=data, accept_json=True)

--- a/watson_developer_cloud/tone_analyzer_v3.py
+++ b/watson_developer_cloud/tone_analyzer_v3.py
@@ -25,19 +25,25 @@ class ToneAnalyzerV3(WatsonDeveloperCloudService):
     default_url = 'https://gateway.watsonplatform.net/tone-analyzer/api'
     latest_version = '2016-05-19'
 
-    def __init__(self, version=latest_version, url=default_url, username=None, password=None, use_vcap_services=True):
+    def __init__(self, version, url=default_url, username=None, password=None, use_vcap_services=True):
         WatsonDeveloperCloudService.__init__(
             self, 'tone_analyzer', url, username, password, use_vcap_services)
         self.version = version
 
-    def tone(self, text, params=None):
+    def tone(self, text, tones=None, sentences=None):
         """
         The tone API is the main API call: it analyzes the "tone" of a piece of text. The message is analyzed from
         several tones (social tone, emotional tone, writing tone), and for each of them various traits are derived
         (such as conscientiousness, agreeableness, openness).
         :param text: Text to analyze
+        :param sentences: If "false", sentence-level analysis is omitted
+        :param tones: Can be one or more of 'social', 'language', 'emotion'; comma-separated.
         """
-        args = copy.copy(params) if params is not None else {}
-        args['version'] = self.version
+        queryArgs = {}
+        queryArgs['version'] = self.version
+        if tones is not None:
+            queryArgs['tones'] = tones
+        if sentences is not None:
+            queryArgs['sentences'] = str(sentences).lower() # Cast boolean to "false" / "true"
         data = {'text': text}
-        return self.request(method='POST', url='/v3/tone', params=args, json=data, accept_json=True)
+        return self.request(method='POST', url='/v3/tone', params=queryArgs, json=data, accept_json=True)


### PR DESCRIPTION
This updates the latest minor API version, and allows passing a 'params' argument (to specify for example sentences=false or tones=social args).

It also adds 2 testcases for Tone; there was none. 