### PR TITLE
[text to speech] update examples

### DIFF
--- a/examples/text_to_speech_v1.py
+++ b/examples/text_to_speech_v1.py
@@ -11,7 +11,7 @@ text_to_speech = TextToSpeechV1(
 print(json.dumps(text_to_speech.voices(), indent=2))
 
 with open(join(dirname(__file__), '../resources/output.wav'), 'wb') as audio_file:
-    audio_file.write(text_to_speech.synthesize('Hello world!'))
+    audio_file.write(text_to_speech.synthesize('Hello world!',accept='audio/wav',voice="en-US_AllisonVoice"))
 
 print(json.dumps(text_to_speech.pronunciation('Watson', pronunciation_format='spr'), indent=2))
 

--- a/examples/text_to_speech_v1.py
+++ b/examples/text_to_speech_v1.py
@@ -11,7 +11,7 @@ text_to_speech = TextToSpeechV1(
 print(json.dumps(text_to_speech.voices(), indent=2))
 
 with open(join(dirname(__file__), '../resources/output.wav'), 'wb') as audio_file:
-    audio_file.write(text_to_speech.synthesize('Hello world!',accept='audio/wav',voice="en-US_AllisonVoice"))
+    audio_file.write(text_to_speech.synthesize('Hello world!', accept='audio/wav', voice="en-US_AllisonVoice"))
 
 print(json.dumps(text_to_speech.pronunciation('Watson', pronunciation_format='spr'), indent=2))
 

--- a/watson_developer_cloud/text_to_speech_v1.py
+++ b/watson_developer_cloud/text_to_speech_v1.py
@@ -34,7 +34,7 @@ class TextToSpeechV1(WatsonDeveloperCloudService):
 
     def synthesize(self, text, voice=None, accept=None, customization_id=None):
         """
-        Returns the get HTTP response by doing a GET to /synthesize with text, voice, accept
+        Returns the get HTTP response by doing a POST to /synthesize with text, voice, accept
         """
         params = {'voice': voice, 'accept': accept, 'customization_id': customization_id}
         data = {'text': text}


### PR DESCRIPTION
Two minor changes:

In examples/text_to_speech_V1.py, the synthesize example creates "output.wav" but Watson defaults to an OGG file. I've added "accept='audio/wav' " and added a voice

In watson_developer_cloud/text_to_speech_v1.py I've corrected the comment from GET to POST