### PR TITLE
[retrieve-and-rank] Remove parameter from delete_collection fixes #86

### DIFF
--- a/watson_developer_cloud/retrieve_and_rank_v1.py
+++ b/watson_developer_cloud/retrieve_and_rank_v1.py
@@ -68,7 +68,7 @@ class RetrieveAndRankV1(WatsonDeveloperCloudService):
         return self.request(method='POST', url='/v1/solr_clusters/{0}/solr/admin/collections'.format(solr_cluster_id),
                             params=params, accept_json=True)
 
-    def delete_collection(self, solr_cluster_id, collection_name):
+    def delete_collection(self, solr_cluster_id, collection_name, config_name=None):
         params = {'name': collection_name, 'action': 'DELETE', 'wt': 'json'}
         return self.request(method='POST', url='/v1/solr_clusters/{0}/solr/admin/collections'.format(solr_cluster_id),
                             params=params, accept_json=True)

--- a/watson_developer_cloud/retrieve_and_rank_v1.py
+++ b/watson_developer_cloud/retrieve_and_rank_v1.py
@@ -68,7 +68,7 @@ class RetrieveAndRankV1(WatsonDeveloperCloudService):
         return self.request(method='POST', url='/v1/solr_clusters/{0}/solr/admin/collections'.format(solr_cluster_id),
                             params=params, accept_json=True)
 
-    def delete_collection(self, solr_cluster_id, collection_name, config_name):
+    def delete_collection(self, solr_cluster_id, collection_name):
         params = {'name': collection_name, 'action': 'DELETE', 'wt': 'json'}
         return self.request(method='POST', url='/v1/solr_clusters/{0}/solr/admin/collections'.format(solr_cluster_id),
                             params=params, accept_json=True)


### PR DESCRIPTION
Make optional a parameter from the `delete_collection` method in the retrieve and rank service