### PR TITLE
[R&R] Remove type checking in cluster creation fix #87

### DIFF
--- a/watson_developer_cloud/retrieve_and_rank_v1.py
+++ b/watson_developer_cloud/retrieve_and_rank_v1.py
@@ -32,7 +32,7 @@ class RetrieveAndRankV1(WatsonDeveloperCloudService):
         return self.request(method='GET', url='/v1/solr_clusters', accept_json=True)
 
     def create_solr_cluster(self, cluster_name=None, cluster_size=None):
-        if cluster_size and isinstance(cluster_size, (int, long)):
+        if cluster_size:
             cluster_size = str(cluster_size)
         params = {'cluster_name': cluster_name, 'cluster_size': cluster_size}
         return self.request(method='POST', url='/v1/solr_clusters', accept_json=True, json=params)


### PR DESCRIPTION
Since python 3 doesn't have long we can't check if `cluster_size` is a long instance.

I did a quick check and 

if `cluster_size` is not null we can just convert it to string. 

```
>>> str(3L)
'3'
>>> str(3)
'3'
>>> str('3')
```