### PR TITLE
python-sdk:  Fix STT test failure and add PI linebreaks.

### DIFF
--- a/test/test_speech_to_text_v1.py
+++ b/test/test_speech_to_text_v1.py
@@ -35,7 +35,7 @@ def test_success():
             audio_file, content_type='audio/l16; rate=44100')
 
     assert responses.calls[
-        1].request.url == recognize_url + '?continuous=False'
+        1].request.url == recognize_url + '?continuous=false'
     assert responses.calls[1].response.text == recognize_response
 
     assert len(responses.calls) == 2

--- a/watson_developer_cloud/personality_insights_v3.py
+++ b/watson_developer_cloud/personality_insights_v3.py
@@ -36,8 +36,10 @@ class PersonalityInsightsV3(WatsonDeveloperCloudService):
         WatsonDeveloperCloudService.__init__(self, 'personality_insights', url, **kwargs)
         self.version = version
 
-    def profile(self, text, content_type='text/plain', content_language=None, accept='application/json',
-                accept_language=None, raw_scores=False, consumption_preferences=False, csv_headers=False):
+    def profile(self, text, content_type='text/plain', content_language=None,
+                accept='application/json', accept_language=None,
+                raw_scores=False, consumption_preferences=False,
+                csv_headers=False):
         """
         :param text: The input text to be analyzed; provide a minimum of 100 words and a maximum of 20 MB of content
         :param content_type: Type of the input text: 'text/plain' (default), 'text/html', or 'application/json'; for

--- a/watson_developer_cloud/personality_insights_v3.py
+++ b/watson_developer_cloud/personality_insights_v3.py
@@ -34,10 +34,8 @@ class PersonalityInsightsV3(WatsonDeveloperCloudService):
         WatsonDeveloperCloudService.__init__(self, 'personality_insights', url, **kwargs)
         self.version = version
 
-    def profile(self, text, content_type='text/plain', content_language=None,
-                accept='application/json', accept_language=None,
-                raw_scores=False, consumption_preferences=False,
-                csv_headers=False):
+    def profile(self, text, content_type='text/plain', content_language=None, accept='application/json',
+                accept_language=None, raw_scores=False, consumption_preferences=False, csv_headers=False):
         """
         :param text: The input text to be analyzed; provide a minimum of 100 words and a maximum of 20 MB of content
         :param content_type: Type of the input text: 'text/plain' (default), 'text/html', or 'application/json'; for plain text or HTML, include the charset parameter to indicate the character encoding

--- a/watson_developer_cloud/personality_insights_v3.py
+++ b/watson_developer_cloud/personality_insights_v3.py
@@ -42,14 +42,11 @@ class PersonalityInsightsV3(WatsonDeveloperCloudService):
                 csv_headers=False):
         """
         :param text: The input text to be analyzed; provide a minimum of 100 words and a maximum of 20 MB of content
-        :param content_type: Type of the input text: 'text/plain' (default), 'text/html', or 'application/json'; for
-        plain text or HTML, include the charset parameter to indicate the character encoding
+        :param content_type: Type of the input text: 'text/plain' (default), 'text/html', or 'application/json'; for plain text or HTML, include the charset parameter to indicate the character encoding
         :param content_language: Language of the input text: 'ar', 'en' (default), 'es', or 'ja'
         :param accept: Type of the response: 'application/json' (default) or 'text/csv'
-        :param accept_language: Language of the response: 'ar', 'de', 'en' (default), 'es', 'fr', 'it', 'ja', 'ko',
-        'pt-br', 'zh-cn', or 'zh-tw'
-        :param raw_scores: If True, returns percentage scores not compared with a sample population in addition to
-        normalized scores
+        :param accept_language: Language of the response: 'ar', 'de', 'en' (default), 'es', 'fr', 'it', 'ja', 'ko', 'pt-br', 'zh-cn', or 'zh-tw'
+        :param raw_scores: If True, returns percentage scores not compared with a sample population in addition to normalized scores
         :param consumption_preferences: If True, returns consumption preferences in addition to normalized scores
         :param csv_headers: If True, returns a row of headers for CSV output
         :return: A personality profile with normalized percentile scores in JSON or CSV format

--- a/watson_developer_cloud/personality_insights_v3.py
+++ b/watson_developer_cloud/personality_insights_v3.py
@@ -19,7 +19,6 @@ The v3 Personality Insights service
 import json
 from .watson_developer_cloud_service import WatsonDeveloperCloudService
 
-
 class PersonalityInsightsV3(WatsonDeveloperCloudService):
 
     """Wrapper for the Personality Insights service"""
@@ -28,8 +27,7 @@ class PersonalityInsightsV3(WatsonDeveloperCloudService):
 
     def __init__(self, version=default_version, url=default_url, **kwargs):
         """
-        Constructs an instance of the service. Fetches service parameters from VCAP_SERVICES runtime variable for
-        Bluemix or defaults to local URLs.
+        Constructs an instance of the service. Fetches service parameters from VCAP_SERVICES runtime variable for Bluemix or defaults to local URLs.
         :param version: The version of the API to be used in YYYY-MM-DD format (for example, '2016-10-20')
         """
 


### PR DESCRIPTION
Change False to false in test_speech_to_text_v1.py to pass py.test.
Change linebreaks in personality_insights_v3.py for readability in narrow columns.