### PR TITLE
Updated code to be Python2.6+ compliant.

### DIFF
--- a/examples/conversation_tone_analyzer_integration/README.md
+++ b/examples/conversation_tone_analyzer_integration/README.md
@@ -1,6 +1,6 @@
 # Conversation and Tone Analyzer Integration Example
 
-This example provides sample code for integrating [Tone Analyzer][tone_analyzer] and [Conversation][conversation].
+This example provides sample code for integrating [Tone Analyzer][tone_analyzer] and [Conversation][conversation] in Python 2.6+.  All calls are made synchronously. For sample Python 3.5 asynchronous code, please see [https://github.com/aprilwebster/python-sdk][aprilwebster_python_sdk_github].
 
   * [tone_detection.py][tone_conversation_integration_example_tone_detection] - sample code to initialize a user object in the conversation payload's context (initUser), to call Tone Analyzer to retrieve tone for a user's input (invokeToneAsync), and to update tone in the user object in the conversation payload's context (updateUserTone).
 
@@ -29,3 +29,4 @@ Command to run the sample code
 [conversation_simple_workspace]: https://github.com/watson-developer-cloud/conversation-simple#workspace
 [tone_conversation_integration_example]: https://github.com/watson-developer-cloud/python-sdk/tree/master/examples/tone_conversation_integration.v1.py
 [tone_conversation_integration_example_tone_detection]: https://github.com/watson-developer-cloud/python-sdk/tree/master/examples/conversation_addons/tone_detection.py
+[aprilwebster_python_sdk_github]: https://github.com/aprilwebster/python-sdk

--- a/examples/conversation_tone_analyzer_integration/tone_conversation_integration.v1.py
+++ b/examples/conversation_tone_analyzer_integration/tone_conversation_integration.v1.py
@@ -1,7 +1,6 @@
 import json
 import os
 from dotenv import load_dotenv, find_dotenv
-import asyncio
 
 from watson_developer_cloud import ConversationV1
 from watson_developer_cloud import ToneAnalyzerV3
@@ -56,20 +55,7 @@ def invokeToneConversation (payload, maintainToneHistoryInContext):
     response = conversation.message(workspace_id=workspace_id, message_input=conversation_payload['input'], context=conversation_payload['context'])
     print(json.dumps(response, indent=2))
 
-async def invokeToneConversationAsync (payload, maintainToneHistoryInContext):
-    tone = await tone_detection.invokeToneAsync(payload,tone_analyzer)
-    conversation_payload =  tone_detection.updateUserTone(payload, tone, maintainToneHistoryInContext)
-    response = conversation.message(workspace_id=workspace_id, message_input=conversation_payload['input'], context=conversation_payload['context'])
-    print(json.dumps(response, indent=2))
-
-
-# invoke tone aware calls to conversation - either synchronously or asynchronously
-
 # synchronous call to conversation with tone included in the context
 invokeToneConversation(payload,maintainToneHistoryInContext)
 
-# asynchronous call to conversation with tone included in the context
-loop = asyncio.get_event_loop()
-loop.run_until_complete(invokeToneConversationAsync(payload,maintainToneHistoryInContext))
-loop.close()
 

--- a/examples/conversation_tone_analyzer_integration/tone_detection.py
+++ b/examples/conversation_tone_analyzer_integration/tone_detection.py
@@ -22,7 +22,6 @@
 """
 
 import json
-import asyncio
 
 PRIMARY_EMOTION_SCORE_THRESHOLD = 0.5
 WRITING_HIGH_SCORE_THRESHOLD = 0.75
@@ -100,18 +99,6 @@ def initUser():
     }
   }
 
-
-
-
-'''
- invokeToneAsync is an asynchronous function that calls the Tone Analyzer service
- @param conversationPayload json object returned by the Watson Conversation Service
- @param tone_analyzer an instance of the Watson Tone Analyzer service
- @returns the result of calling the tone_analyzer with the conversationPayload 
- (which contains the user's input text)
-'''
-async def invokeToneAsync(conversationPayload, tone_analyzer):
-    return tone_analyzer.tone(text=conversationPayload['input']['text'])
 
 
 '''


### PR DESCRIPTION
As per @jsstylos request, updated conversation tone integration example to be python 2.6+ compliant - removed all code dependent on asyncio.  Only synchronous calls made now - this is consistent with other python-sdk examples.  Changed README to point to github.com/aprilwebster/python-sdk for an asynchronous example (python 3.5).