### PR TITLE
"Unknown error" is "daily-transaction-limit-exceeded error"

### DIFF
--- a/watson_developer_cloud/watson_developer_cloud_service.py
+++ b/watson_developer_cloud/watson_developer_cloud_service.py
@@ -167,6 +167,8 @@ class WatsonDeveloperCloudService(object):
                 error_message = 'Error: ' + error_json['error_message']
             elif 'msg' in error_json:
                 error_message = 'Error: ' + error_json['msg']
+            elif 'statusInfo' in error_json:
+                error_message = 'Error: ' + error_json['statusInfo']
             if 'description' in error_json:
                 error_message += ', Description: ' + error_json['description']
             error_message += ', Code: ' + str(response.status_code)


### PR DESCRIPTION
Hi there!
    I'm using a free account in bluemix and I this noon I start getting this issue:

`
…
  File "./watson.py", line 61, in main
    print(json.dumps(visual_recognition.create_classifier('c',**examples), indent=2))
  File "/usr/local/lib/python2.7/site-packages/watson_developer_cloud/visual_recognition_v3.py", line 82, in create_classifier
    accept_json=True)
  File "/usr/local/lib/python2.7/site-packages/watson_developer_cloud/watson_developer_cloud_service.py", line 289, in request
    raise WatsonException(error_message)
watson_developer_cloud.watson_developer_cloud_service.WatsonException: Unknown error, Code: 403
`

But when I make the query manually with curl, I'm getting:
`{
    "status": "ERROR",
    "statusInfo": "daily-transaction-limit-exceeded"
}`

So, I added this error message to the output to make it more informative. Now the output is:
`….
  File "./watson.py", line 61, in main
    print(json.dumps(visual_recognition.create_classifier('c',**examples), indent=2))
  File "/usr/local/lib/python2.7/site-packages/watson_developer_cloud/visual_recognition_v3.py", line 82, in create_classifier
    accept_json=True)
  File "/usr/local/lib/python2.7/site-packages/watson_developer_cloud/watson_developer_cloud_service.py", line 292, in request
    raise WatsonException(error_message)
watson_developer_cloud.watson_developer_cloud_service.WatsonException: Error: daily-transaction-limit-exceeded, Code: 403
`