### PR TITLE
Update vcap and credential info in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## Watson Developer Cloud Python SDK
+‹## Watson Developer Cloud Python SDK
 [![Build Status](https://travis-ci.org/watson-developer-cloud/python-sdk.svg)](https://travis-ci.org/watson-developer-cloud/python-sdk)
 [![codecov.io](https://codecov.io/github/watson-developer-cloud/python-sdk/coverage.svg?branch=master)](https://codecov.io/github/watson-developer-cloud/python-sdk?branch=master)
 [![Latest Stable Version](https://img.shields.io/pypi/v/watson-developer-cloud.svg)](https://pypi.python.org/pypi/watson-developer-cloud)
@@ -22,21 +22,26 @@ $ easy_install --upgrade watson-developer-cloud
 The [examples][examples] folder has basic and advanced examples.
 
 ## Getting the Service Credentials
-Service credentials are required to access the APIs. When running on Bluemix, the SDK uses the VCAP_SERVICES environment variable to load the credentials automatically.
+Service credentials are required to access the APIs.
 
-To run locally or outside of Bluemix you will need the `username` and `password` credentials for each service. (Service credentials are different from your Bluemix account email and password.)
+If you run your app in Bluemix, you don't need to specify the username and password. In that case, the SDK uses the `VCAP_SERVICES` environment variable to load the credentials.
 
-To get your service credentials, follow these steps:
- 1. Log in to Bluemix at https://bluemix.net.
+To run locally or outside of Bluemix you need the `username` and `password` credentials for each service. (Service credentials are different from your Bluemix account email and password.)
 
- 1. Create an instance of the service:
-     1. In the Bluemix **Catalog**, select the Watson service you want to use. For example, select the Natural Language Classifier service.
-     1. Under **Add Service**, type a unique name for the service instance in the Service name field. For example, type `my-service-name`. Leave the default values for the other options.
-     1. Click **Use**.
+To create an instance of the service:
 
- 1. Copy your credentials:
-     1. On the left side of the page, click **Service Credentials** to view your service credentials.
-     1. Copy `username` and `password` from these service credentials.
+1. Log in to [Bluemix][bluemix].
+1. Create an instance of the service:
+   1. In the Bluemix **Catalog**, select the Watson service you want to use. For example, select the Conversation service.
+   1. Type a unique name for the service instance in the **Service name** field. For example, type `my-service-name`. Leave the default values for the other options.
+   1. Click **Create**.
+
+To get your service credentials:
+
+Copy your credentials from the **Service details** page. To find the the Service details page for an existing service, navigate to your Bluemix dashboard and click the service name.
+
+1. On the **Service Details** page, click **Service Credentials**, and then **View credentials**.
+1. Copy `username` and `password`.
 
 ## Python Version
 Tested 👌 (lightly) on: Python from 2.7 to 3.5-dev (development branch).

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-‹## Watson Developer Cloud Python SDK
+## Watson Developer Cloud Python SDK
 [![Build Status](https://travis-ci.org/watson-developer-cloud/python-sdk.svg)](https://travis-ci.org/watson-developer-cloud/python-sdk)
 [![codecov.io](https://codecov.io/github/watson-developer-cloud/python-sdk/coverage.svg?branch=master)](https://codecov.io/github/watson-developer-cloud/python-sdk?branch=master)
 [![Latest Stable Version](https://img.shields.io/pypi/v/watson-developer-cloud.svg)](https://pypi.python.org/pypi/watson-developer-cloud)


### PR DESCRIPTION

- Add clearer information in the Python SDK README file about using
VCAP_SERVICES when running in Bluemix.
- Also update the instructions to getting credentials to match current
Bluemix UI.