### PR TITLE
open README file as binary, since contains non-ascii chars

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ try:
     read_md = lambda f: convert(f, 'rst')
 except ImportError:
     print('warning: pypandoc module not found, could not convert Markdown to RST')
-    read_md = lambda f: open(f, 'r').read()
+    read_md = lambda f: open(f, 'rb').read()
 
 
 class PyTest(TestCommand):


### PR DESCRIPTION
If pypandoc is not there, `open('README.md', 'r').read()` is executed.
In python3, the default enconding is None, resulting in

```
In [1]: open('README.md', 'r').read()
UnicodeDecodeError: Traceback (most recent call last) <ipython-input-10-45ae3b586d42> in <module>()
----> 1 open('README.md', 'r').read()

/usr/lib/python3.5/encodings/ascii.py in decode(self, input, final)
     24 class IncrementalDecoder(codecs.IncrementalDecoder):
     25     def decode(self, input, final=False):
---> 26         return codecs.ascii_decode(input, self.errors)[0]
     27 
     28 class StreamWriter(Codec,codecs.StreamWriter):

UnicodeDecodeError: 'ascii' codec can't decode byte 0xf0 in position 1895: ordinal not in range(128)
```

In order to keep the compatibility with python2 and to handle the emoji in the README file, it needs to be opened as binary.