### PR TITLE
add create/update/delete methods for configurations in discovery v1

### DIFF
--- a/examples/discovery v1 configuration tasks .ipynb
+++ b/examples/discovery v1 configuration tasks .ipynb
@@ -1,0 +1,146 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "import os,sys\n",
+    "sys.path.append(os.path.join(os.getcwd(),'..'))\n",
+    "import watson_developer_cloud\n",
+    "\n",
+    "DISCOVERY_USERNAME='CHANGE_ME'\n",
+    "DISCOVERY_PASSWORD='CHANGE_ME'\n",
+    "ENVIRONMENT_NAME='CHANGE_ME' # this is the 'name' field of your environment\n",
+    "CONFIGURATION_NAME='CHANGE_ME' # this is the 'name' field of your cofiguration"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "discovery = watson_developer_cloud.DiscoveryV1(\n",
+    "    '2016-12-15',\n",
+    "    username=DISCOVERY_USERNAME,\n",
+    "    password=DISCOVERY_PASSWORD)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "environments = discovery.get_environments()\n",
+    "print(environments)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "target_environment = [x for x in environments['environments'] if x['name'] == ENVIRONMENT_NAME]\n",
+    "target_environment_id = target_environment[0]['environment_id']\n",
+    "print(target_environment_id)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "configs = discovery.list_configurations(environment_id=target_environment_id)\n",
+    "print(configs)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "target_config = [x for x in configs['configurations'] if x['name'] == CONFIGURATION_NAME]\n",
+    "target_config_id = target_config[0]['configuration_id']\n",
+    "print(target_config_id)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "config_data = discovery.get_configuration(environment_id=target_environment_id,\n",
+    "                                          configuration_id=target_config_id)\n",
+    "print(config_data)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "config_data['name'] = 'Changed Name for Example'\n",
+    "res = discovery.create_configuration(environment_id=target_environment_id, config_data=config_data)\n",
+    "print(res)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "res = discovery.delete_configuration(environment_id=target_environment_id, configuration_id=res['configuration_id'])\n",
+    "print(res)"
+   ]
+  }
+ ],
+ "metadata": {
+  "anaconda-cloud": {},
+  "kernelspec": {
+   "display_name": "Python [Root]",
+   "language": "python",
+   "name": "Python [Root]"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.5.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/examples/discovery_v1.ipynb
+++ b/examples/discovery_v1.ipynb
@@ -130,6 +130,15 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
    "execution_count": 13,
    "metadata": {
     "collapsed": false

--- a/test/test_discovery_v1.py
+++ b/test/test_discovery_v1.py
@@ -1,4 +1,4 @@
-import responses,os
+import responses,os, json
 import watson_developer_cloud
 try:
     from urllib.parse import urlparse, urljoin
@@ -244,7 +244,18 @@ def test_configs():
                   body="{\"configurations\": [{ \"name\": \"Default Configuration\", \"configuration_id\": \"confid\"}]}",
                   status=200,
                   content_type='application/json')
-
+    responses.add(responses.POST, discovery_url,
+                  body="{\"configurations\": [{ \"name\": \"Default Configuration\", \"configuration_id\": \"confid\"}]}",
+                  status=200,
+                  content_type = 'application/json')
+    responses.add(responses.DELETE, discovery_config_id,
+                  body=json.dumps({ 'deleted': 'bogus -- ok'}),
+                  status=200,
+                  content_type = 'application/json')
+    responses.add(responses.PUT, discovery_config_id,
+                  body=json.dumps({ 'updated': 'bogus -- ok'}),
+                  status=200,
+                  content_type = 'application/json')
 
     discovery = watson_developer_cloud.DiscoveryV1('2016-11-07',
                                                    username='username',
@@ -257,6 +268,11 @@ def test_configs():
 
     assert len(responses.calls) == 3
 
+    discovery.create_configuration(environment_id='envid', config_data={'name': 'my name'})
+    discovery.update_configuration(environment_id='envid', configuration_id='confid', config_data={'name': 'my new name'})
+    discovery.delete_configuration(environment_id='envid', configuration_id='confid')
+
+    assert len(responses.calls) == 6
 
 @responses.activate
 def test_empty_configs():

--- a/watson_developer_cloud/discovery_v1.py
+++ b/watson_developer_cloud/discovery_v1.py
@@ -149,6 +149,34 @@ class DiscoveryV1(WatsonDeveloperCloudService):
                             params={'version': self.version},
                             accept_json=True)
 
+    def create_configuration(self, environment_id, config_data):
+
+        format_string = '/v1/environments/{0}/configurations'
+        url_string = format_string.format(environment_id)
+        return self.request(method='POST', url=url_string,
+                            params={'version': self.version},
+                            data=json.dumps(config_data),
+                            headers={'content-type': 'application/json'},
+                            accept_json=True)
+
+    def delete_configuration(self, environment_id, configuration_id):
+
+        format_string = '/v1/environments/{0}/configurations/{1}'
+        url_string = format_string.format(environment_id, configuration_id)
+        return self.request(method='DELETE', url=url_string,
+                            params={'version': self.version},
+                            accept_json=True)
+
+    def update_configuration(self, environment_id, configuration_id, config_data):
+
+        format_string = '/v1/environments/{0}/configurations/{1}'
+        url_string = format_string.format(environment_id, configuration_id)
+        return self.request(method='PUT', url=url_string,
+                            params={'version': self.version},
+                            data=json.dumps(config_data),
+                            headers={'content-type': 'application/json'},
+                            accept_json=True)
+
     def list_collections(self, environment_id):
         """
         Retrieves information about the collections within a given environment


### PR DESCRIPTION
These methods were left out because tooling doesn't
support them very well and they are likely to change but
we got a request to add them for now.