### PR TITLE
Now a document can be added from a string

### DIFF
--- a/test/test_discovery_v1.py
+++ b/test/test_discovery_v1.py
@@ -342,3 +342,18 @@ def test_document():
                               document_id='docid')
 
     assert len(responses.calls) == 5
+
+
+    conf_id = discovery.add_document(environment_id='envid',
+                                     collection_id='collid',
+                                     filedata='my string of file')
+
+    assert len(responses.calls) == 6
+
+
+    conf_id = discovery.add_document(environment_id='envid',
+                                     collection_id='collid',
+                                     mimetype='application/html',
+                                     filedata='my string of file')
+
+    assert len(responses.calls) == 7

--- a/test/test_discovery_v1.py
+++ b/test/test_discovery_v1.py
@@ -330,9 +330,7 @@ def test_document():
                   content_type='application/json')
 
     with open(os.path.join(os.getcwd(), 'resources', 'simple.html')) as fileinfo:
-        conf_id = discovery.add_document(environment_id='envid',
-                                         collection_id='collid',
-                                         fileinfo=fileinfo)
+        conf_id = discovery.add_document(environment_id='envid', collection_id='collid', file_info=fileinfo)
         assert conf_id != None
 
     assert len(responses.calls) == 4
@@ -344,16 +342,17 @@ def test_document():
     assert len(responses.calls) == 5
 
 
-    conf_id = discovery.add_document(environment_id='envid',
-                                     collection_id='collid',
-                                     filedata='my string of file')
+    conf_id = discovery.add_document(environment_id='envid', collection_id='collid', file_data='my string of file')
+
 
     assert len(responses.calls) == 6
 
-
-    conf_id = discovery.add_document(environment_id='envid',
-                                     collection_id='collid',
-                                     mimetype='application/html',
-                                     filedata='my string of file')
+    conf_id = discovery.add_document(environment_id='envid', collection_id='collid', mime_type='application/html',
+                                     file_data='my string of file')
 
     assert len(responses.calls) == 7
+
+    conf_id = discovery.add_document(environment_id='envid', collection_id='collid', mime_type='application/html',
+                                     file_data='my string of file', meta_data={'stuff': 'woot!'})
+
+    assert len(responses.calls) == 8

--- a/test/test_discovery_v1.py
+++ b/test/test_discovery_v1.py
@@ -347,12 +347,12 @@ def test_document():
 
     assert len(responses.calls) == 6
 
-    conf_id = discovery.add_document(environment_id='envid', collection_id='collid', mime_type='application/html',
-                                     file_data='my string of file')
+    conf_id = discovery.add_document(environment_id='envid', collection_id='collid', file_data='my string of file',
+                                     mime_type='application/html')
 
     assert len(responses.calls) == 7
 
-    conf_id = discovery.add_document(environment_id='envid', collection_id='collid', mime_type='application/html',
-                                     file_data='my string of file', meta_data={'stuff': 'woot!'})
+    conf_id = discovery.add_document(environment_id='envid', collection_id='collid', file_data='my string of file',
+                                     mime_type='application/html', metadata={'stuff': 'woot!'})
 
     assert len(responses.calls) == 8

--- a/watson_developer_cloud/discovery_v1.py
+++ b/watson_developer_cloud/discovery_v1.py
@@ -221,14 +221,14 @@ class DiscoveryV1(WatsonDeveloperCloudService):
                      file_info=None,
                      file_data=None,
                      mime_type=None,
-                     meta_data=None):
+                     metadata=None):
         url_string = '/v1/environments/{0}/collections/{1}/documents'.format(
             environment_id, collection_id)
 
         params = {'version': latest_version}
 
-        if meta_data is None:
-            meta_data = {}
+        if metadata is None:
+            metadata = {}
 
         file_tuple = None
 
@@ -238,15 +238,15 @@ class DiscoveryV1(WatsonDeveloperCloudService):
             file_tuple = (file_info.name, file_info, mime_type)
         elif file_data:
             file_tuple = ('tmpfile', file_data, mime_type or
-                         'application/html')
+                          'application/html')
 
         return self.request(method='POST',
                             url=url_string,
                             params=params,
-                            data=meta_data,
+                            data=metadata,
                             files={'file': file_tuple,
                                    'metadata': (None,
-                                                json.dumps(meta_data),
+                                                json.dumps(metadata),
                                                 'application/json')},
                             accept_json=True)
 

--- a/watson_developer_cloud/discovery_v1.py
+++ b/watson_developer_cloud/discovery_v1.py
@@ -215,7 +215,13 @@ class DiscoveryV1(WatsonDeveloperCloudService):
                             params={'version': latest_version},
                             accept_json=True)
 
-    def add_document(self, environment_id, collection_id, fileinfo, metadata=None):
+    def add_document(self,
+                     environment_id,
+                     collection_id,
+                     fileinfo=None,
+                     filedata=None,
+                     mimetype=None,
+                     metadata=None):
         url_string = '/v1/environments/{0}/collections/{1}/documents'.format(
             environment_id, collection_id)
 
@@ -224,15 +230,28 @@ class DiscoveryV1(WatsonDeveloperCloudService):
         if metadata is None:
             metadata = {}
 
-        mime_type = mimetypes.guess_type(
-            fileinfo.name)[0] or 'application/octet-stream'
+        mime_type = None
+        filetuple = None
+
+        if mimetype:
+            mime_type = mimetype
+
+        if fileinfo:
+            mime_type = mimetypes.guess_type(
+                fileinfo.name)[0] or 'application/octet-stream'
+            filetuple = (fileinfo.name, fileinfo, mime_type)
+        elif filedata:
+            filetuple = ('tmpfile', filedata, mime_type or
+                         'application/html')
 
         return self.request(method='POST',
                             url=url_string,
                             params=params,
                             data=metadata,
-                            files={'file': (fileinfo.name, fileinfo, mime_type),
-                                   'metadata': (None, json.dumps(metadata), 'application/json')},
+                            files={'file': filetuple,
+                                   'metadata': (None,
+                                                json.dumps(metadata),
+                                                'application/json')},
                             accept_json=True)
 
     def test_document(self, environment_id, fileinfo, configuration_id=None, metadata=None):

--- a/watson_developer_cloud/discovery_v1.py
+++ b/watson_developer_cloud/discovery_v1.py
@@ -218,39 +218,35 @@ class DiscoveryV1(WatsonDeveloperCloudService):
     def add_document(self,
                      environment_id,
                      collection_id,
-                     fileinfo=None,
-                     filedata=None,
-                     mimetype=None,
-                     metadata=None):
+                     file_info=None,
+                     file_data=None,
+                     mime_type=None,
+                     meta_data=None):
         url_string = '/v1/environments/{0}/collections/{1}/documents'.format(
             environment_id, collection_id)
 
         params = {'version': latest_version}
 
-        if metadata is None:
-            metadata = {}
+        if meta_data is None:
+            meta_data = {}
 
-        mime_type = None
-        filetuple = None
+        file_tuple = None
 
-        if mimetype:
-            mime_type = mimetype
-
-        if fileinfo:
-            mime_type = mimetypes.guess_type(
-                fileinfo.name)[0] or 'application/octet-stream'
-            filetuple = (fileinfo.name, fileinfo, mime_type)
-        elif filedata:
-            filetuple = ('tmpfile', filedata, mime_type or
+        if file_info:
+            mime_type = mime_type or mimetypes.guess_type(
+                file_info.name)[0]
+            file_tuple = (file_info.name, file_info, mime_type)
+        elif file_data:
+            file_tuple = ('tmpfile', file_data, mime_type or
                          'application/html')
 
         return self.request(method='POST',
                             url=url_string,
                             params=params,
-                            data=metadata,
-                            files={'file': filetuple,
+                            data=meta_data,
+                            files={'file': file_tuple,
                                    'metadata': (None,
-                                                json.dumps(metadata),
+                                                json.dumps(meta_data),
                                                 'application/json')},
                             accept_json=True)
 


### PR DESCRIPTION
Before you could only add documents as files. now
the document data doesn't have to be in a file, it can be
in a string.

Fixes #140 