### PR TITLE
changed name to have dashes instead of underscores

### DIFF
--- a/watson_developer_cloud/natural_language_understanding_v1.py
+++ b/watson_developer_cloud/natural_language_understanding_v1.py
@@ -33,7 +33,7 @@ class NaturalLanguageUnderstandingV1(WatsonDeveloperCloudService):
                  password=None,
                  use_vcap_services=True):
         WatsonDeveloperCloudService.__init__(
-            self, 'natural_language_understanding', url,
+            self, 'natural-language-understanding', url,
             username, password, use_vcap_services)
         self.version = version
 


### PR DESCRIPTION
The NLU name has dash seperators.

Fixes #172