### PR TITLE
Size for environments was not correct

### DIFF
--- a/test/test_discovery_v1.py
+++ b/test/test_discovery_v1.py
@@ -2,6 +2,7 @@ import responses
 import os
 import json
 import watson_developer_cloud
+import pytest
 try:
     from urllib.parse import urlparse, urljoin
 except ImportError:
@@ -112,14 +113,12 @@ def test_create_environment():
 
     assert thrown
 
-    try:
+    with pytest.raises(ValueError):
         discovery.create_environment(size=14)
-    except ValueError as ve:
-        thrown = True
-        assert str(ve) == "Size can be 1, 2, or 3"
 
-    assert thrown
-    assert len(responses.calls) == 2
+    discovery.create_environment(size=0)
+
+    assert len(responses.calls) == 3
 
 
 @responses.activate

--- a/watson_developer_cloud/discovery_v1.py
+++ b/watson_developer_cloud/discovery_v1.py
@@ -78,8 +78,8 @@ class DiscoveryV1(WatsonDeveloperCloudService):
         :return:
         """
         self._valid_name_and_description(name=name, description=description)
-        if size not in range(1, 4):
-            raise ValueError("Size can be 1, 2, or 3")
+        if size not in range(0, 4):
+            raise ValueError("Size can be 0, 1, 2, or 3")
 
         body = json.dumps({"name": name,
                            "description": description,


### PR DESCRIPTION
Sizes can be 0, 1, 2, or 3  originally the size
param excluded 0 (which is the free tier). Now this is
included.

Fixes #174