### PR TITLE
Added customization_id to the recognize() method.

### DIFF
--- a/watson_developer_cloud/speech_to_text_v1.py
+++ b/watson_developer_cloud/speech_to_text_v1.py
@@ -28,6 +28,7 @@ class SpeechToTextV1(WatsonDeveloperCloudService):
                                              **kwargs)
 
     def recognize(self, audio, content_type, continuous=False, model=None,
+                  customization_id=None,
                   inactivity_timeout=None,
                   keywords=None, keywords_threshold=None,
                   max_alternatives=None,
@@ -46,6 +47,7 @@ class SpeechToTextV1(WatsonDeveloperCloudService):
                   'keywords_threshold': keywords_threshold,
                   'max_alternatives': max_alternatives,
                   'model': model,
+                  'customization_id': customization_id,
                   'word_alternatives_threshold': word_alternatives_threshold,
                   'word_confidence': word_confidence,
                   'timestamps': timestamps,


### PR DESCRIPTION
Added the 'customization_id' parameter in the 'customize()' method for speech to text, to be consistent with the API Documentation.
