### PR TITLE
Fix SpeechToTextV1.add_corpus() to use POST instead of GET, closes #207

### DIFF
--- a/test/test_speech_to_text_v1.py
+++ b/test/test_speech_to_text_v1.py
@@ -106,49 +106,48 @@ def test_custom_model():
 
     assert len(responses.calls) == 5
 
-@responses.activate
 def test_custom_corpora():
 
     corpora_url = 'https://stream.watsonplatform.net/speech-to-text/api/v1/customizations/{0}/corpora'
     get_corpora_url = '{0}/{1}'.format(corpora_url.format('customid'),'corpus')
 
-    responses.add(responses.GET, corpora_url.format('customid'),
-                  body='{"get response": "yep"}', status=200,
-                  content_type='application/json')
+    with responses.RequestsMock(assert_all_requests_are_fired=True) as rsps:
+        rsps.add(responses.GET, corpora_url.format('customid'),
+                 body='{"get response": "yep"}', status=200,
+                 content_type='application/json')
 
-    responses.add(responses.POST, get_corpora_url,
+        rsps.add(responses.POST, get_corpora_url,
                  body='{"get response": "yep"}',
                  status=200,
                  content_type='application/json')
 
-    responses.add(responses.GET, get_corpora_url,
+        rsps.add(responses.GET, get_corpora_url,
                  body='{"get response": "yep"}',
                  status=200,
                  content_type='application/json')
 
-    responses.add(responses.DELETE, get_corpora_url,
-                  body='{"get response": "yep"}',
-                  status=200,
-                  content_type='application/json')
+        rsps.add(responses.DELETE, get_corpora_url,
+                 body='{"get response": "yep"}',
+                 status=200,
+                 content_type='application/json')
 
-    speech_to_text = watson_developer_cloud.SpeechToTextV1(
-        username="username", password="password")
+        speech_to_text = watson_developer_cloud.SpeechToTextV1(
+            username="username", password="password")
 
-    speech_to_text.list_corpora(customization_id='customid')
+        speech_to_text.list_corpora(customization_id='customid')
 
-    file_path = '../resources/speech_to_text/corpus-short-1.txt'
-    full_path = os.path.join(os.path.dirname(__file__), file_path)
-    with open(full_path) as corpus_file:
-        speech_to_text.add_corpus(customization_id='customid',
-                                  corpus_name="corpus", file_data=corpus_file)
+        file_path = '../resources/speech_to_text/corpus-short-1.txt'
+        full_path = os.path.join(os.path.dirname(__file__), file_path)
+        with open(full_path) as corpus_file:
+            speech_to_text.add_corpus(customization_id='customid',
+                                      corpus_name="corpus", file_data=corpus_file)
 
-    speech_to_text.get_corpus(customization_id='customid',
-                              corpus_name='corpus')
+        speech_to_text.get_corpus(customization_id='customid',
+                                  corpus_name='corpus')
 
-    speech_to_text.delete_corpus(customization_id='customid',
-                                 corpus_name='corpus')
+        speech_to_text.delete_corpus(customization_id='customid',
+                                     corpus_name='corpus')
 
-    assert len(responses.calls) == 4
 
 @responses.activate
 def test_custom_words():

--- a/watson_developer_cloud/speech_to_text_v1.py
+++ b/watson_developer_cloud/speech_to_text_v1.py
@@ -118,7 +118,7 @@ class SpeechToTextV1(WatsonDeveloperCloudService):
 
         headers = {'Content-Type': 'application/octet-stream'}
 
-        return self.request(method='GET',
+        return self.request(method='POST',
                             url=url.format(customization_id,
                                            corpus_name),
                             headers=headers,


### PR DESCRIPTION
`SpeechToTextV1.add_corpus()` just uses the wrong HTTP method (GET). I changed the HTTP method to POST and updated the test to ensure that the four expected calls to the `requests` library all get called. I verified my change manually in iPython as well.

Before change:
```
In [3]: client = SpeechToTextV1(...)
In [4]: cid = 'my-customization-id'
In [5]: f = open('tmp/test-corpus.txt')
In [6]: client.add_corpus(customization_id=cid, corpus_name='applebaum', file_data=f)
---------------------------------------------------------------------------
WatsonException                           Traceback (most recent call last)
<ipython-input-6-c9874441cbb1> in <module>()
----> 1 client.add_corpus(customization_id=cid, corpus_name='applebaum', file_data=f)

/Users/alexchao/workspace/watson-speech-client/env/lib/python3.5/site-packages/watson_developer_cloud/speech_to_text_v1.py in add_corpus(self, customization_id, corpus_name, file_data, allow_overwrite)
    125                             data=file_data,
    126                             params={'allow_overwrite': allow_overwrite},
--> 127                             accept_json=True)
    128
    129     def get_corpus(self, customization_id, corpus_name):

/Users/alexchao/workspace/watson-speech-client/env/lib/python3.5/site-packages/watson_developer_cloud/watson_developer_cloud_service.py in request(self, method, url, accept_json, headers, params, json, data, files, **kwargs)
    318             else:
    319                 error_message = self._get_error_message(response)
--> 320             raise WatsonException(error_message)

WatsonException: Unknown error
```

After:
```
In [3]: client = SpeechToTextV1(...)
In [4]: cid = 'my-customization-id'
In [5]: client.add_corpus(customization_id=cid, corpus_name='applebaum', file_data=open('tmp/test-corpus.txt'))
Out[5]: {}
```