### PR TITLE
Tone Analyzer: Add support for JSON and HTML input to tone() method

### DIFF
--- a/examples/tone_analyzer_v3.py
+++ b/examples/tone_analyzer_v3.py
@@ -4,12 +4,15 @@ from os.path import join, dirname
 from watson_developer_cloud import ToneAnalyzerV3
 
 tone_analyzer = ToneAnalyzerV3(
-    username='YOUR SERVICE USERNAME',
-    password='YOUR SERVICE PASSWORD',
+    username='6e9af982-31bf-45c4-99b0-51f6b576e433',
+    password='2dXhAyPQjxD5',
+    # username='YOUR SERVICE USERNAME',
+    # password='YOUR SERVICE PASSWORD',
     version='2016-05-19')
 
 print("\ntone_chat() example 1:\n")
-utterances = [{'text': 'I am very happy', 'user': 'glenn'}]
+utterances = [{'text': 'I am very happy.', 'user': 'glenn'},
+              {'text': 'It is a good day.', 'user': 'glenn'}]
 print(json.dumps(tone_analyzer.tone_chat(utterances), indent=2))
 
 print("\ntone() example 1:\n")
@@ -19,27 +22,26 @@ print(json.dumps(tone_analyzer.tone(text='I am very happy. It is a good day.'),
 print("\ntone() example 2:\n")
 with open(join(dirname(__file__),
                '../resources/tone-example.json')) as tone_json:
-    tone = tone_analyzer.tone(json.load(tone_json)['text'],
-                              tones='emotion')
+    tone = tone_analyzer.tone(json.load(tone_json)['text'], 'emotion')
 print(json.dumps(tone, indent=2))
 
 print("\ntone() example 3:\n")
 with open(join(dirname(__file__),
                '../resources/tone-example.json')) as tone_json:
-    tone = tone_analyzer.tone(json.load(tone_json)['text'],
-                              content_type='text/plain', tones='emotion')
+    tone = tone_analyzer.tone(json.load(tone_json)['text'], 'emotion',
+                              True, 'text/plain')
 print(json.dumps(tone, indent=2))
 
 print("\ntone() example 4:\n")
 with open(join(dirname(__file__),
                '../resources/tone-example.json')) as tone_json:
-    tone = tone_analyzer.tone(json.load(tone_json),
-                              content_type='application/json', tones='emotion')
+    tone = tone_analyzer.tone(json.load(tone_json), 'emotion',
+                              content_type='application/json', )
 print(json.dumps(tone, indent=2))
 
 print("\ntone() example 5:\n")
 with open(join(dirname(__file__),
                '../resources/tone-example-html.json')) as tone_json:
-    tone = tone_analyzer.tone(json.load(tone_json)['text'],
-                              content_type='text/html', tones='emotion')
+    tone = tone_analyzer.tone(json.load(tone_json)['text'], 'emotion',
+                              content_type='text/html')
 print(json.dumps(tone, indent=2))

--- a/examples/tone_analyzer_v3.py
+++ b/examples/tone_analyzer_v3.py
@@ -1,13 +1,45 @@
 import json
+import os
+from os.path import join, dirname
 from watson_developer_cloud import ToneAnalyzerV3
-
 
 tone_analyzer = ToneAnalyzerV3(
     username='YOUR SERVICE USERNAME',
     password='YOUR SERVICE PASSWORD',
-    version='2016-02-11')
+    version='2016-05-19')
 
-print(json.dumps(tone_analyzer.tone(text='I am very happy'), indent=2))
-
+print("\ntone_chat() example 1:\n")
 utterances = [{'text': 'I am very happy', 'user': 'glenn'}]
 print(json.dumps(tone_analyzer.tone_chat(utterances), indent=2))
+
+print("\ntone() example 1:\n")
+print(json.dumps(tone_analyzer.tone(text='I am very happy. It is a good day.'),
+                 indent=2))
+
+print("\ntone() example 2:\n")
+with open(join(dirname(__file__),
+               '../resources/tone-example.json')) as tone_json:
+    tone = tone_analyzer.tone(json.load(tone_json)['text'],
+                              tones='emotion')
+print(json.dumps(tone, indent=2))
+
+print("\ntone() example 3:\n")
+with open(join(dirname(__file__),
+               '../resources/tone-example.json')) as tone_json:
+    tone = tone_analyzer.tone(json.load(tone_json)['text'],
+                              content_type='text/plain', tones='emotion')
+print(json.dumps(tone, indent=2))
+
+print("\ntone() example 4:\n")
+with open(join(dirname(__file__),
+               '../resources/tone-example.json')) as tone_json:
+    tone = tone_analyzer.tone(json.load(tone_json),
+                              content_type='application/json', tones='emotion')
+print(json.dumps(tone, indent=2))
+
+print("\ntone() example 5:\n")
+with open(join(dirname(__file__),
+               '../resources/tone-example-html.json')) as tone_json:
+    tone = tone_analyzer.tone(json.load(tone_json)['text'],
+                              content_type='text/html', tones='emotion')
+print(json.dumps(tone, indent=2))

--- a/examples/tone_analyzer_v3.py
+++ b/examples/tone_analyzer_v3.py
@@ -4,10 +4,8 @@ from os.path import join, dirname
 from watson_developer_cloud import ToneAnalyzerV3
 
 tone_analyzer = ToneAnalyzerV3(
-    username='6e9af982-31bf-45c4-99b0-51f6b576e433',
-    password='2dXhAyPQjxD5',
-    # username='YOUR SERVICE USERNAME',
-    # password='YOUR SERVICE PASSWORD',
+    username='YOUR SERVICE USERNAME',
+    password='YOUR SERVICE PASSWORD',
     version='2016-05-19')
 
 print("\ntone_chat() example 1:\n")

--- a/resources/tone-example-html.json
+++ b/resources/tone-example-html.json
@@ -1,0 +1,3 @@
+{
+  "text": "<p>Team, I know that times are tough!</p> <p>Product sales have been disappointing for the past three quarters.</p> <p>We have a competitive product, but <b>we need to do a better job of selling it!</b></p>"
+}

--- a/resources/tone-example.json
+++ b/resources/tone-example.json
@@ -1,0 +1,3 @@
+{
+  "text": "Team, I know that times are tough! Product sales have been disappointing for the past three quarters. We have a competitive product, but we need to do a better job of selling it!"
+}

--- a/test/test_tone_analyzer_v3.py
+++ b/test/test_tone_analyzer_v3.py
@@ -45,7 +45,6 @@ def test_tone_with_args():
             username="username", password="password")
         tone_analyzer.tone(tone_text.read(), tones="social", sentences=False)
 
-
     assert responses.calls[0].request.url.split('?')[0] == tone_url
     # Compare args. Order is not deterministic!
     actualArgs = {}
@@ -60,7 +59,7 @@ def test_tone_with_args():
 ## Invoking tone() with some modifiers specified as positional parameters: tones are emotion and social, and sentences is false
 def test_tone():
     tone_url = 'https://gateway.watsonplatform.net/tone-analyzer/api/v3/tone'
-    tone_args = '?version=2016-05-19&tones=emotion%2Csocial&sentences=false'
+    tone_args = { 'version': '2016-05-19', 'tones': 'emotion%2Csocial', 'sentences': 'false' }
     tone_response = None
     with open(os.path.join(os.path.dirname(__file__), '../resources/tone-v3-expect1.json')) as response_json:
         tone_response = response_json.read()
@@ -74,9 +73,13 @@ def test_tone():
             username="username", password="password")
         tone_analyzer.tone(tone_text.read(), 'emotion,social', False)
 
-    assert responses.calls[0].request.url == tone_url + tone_args
+    assert responses.calls[0].request.url.split('?')[0] == tone_url
+    # Compare args. Order is not deterministic!
+    actualArgs = {}
+    for arg in responses.calls[0].request.url.split('?')[1].split('&'):
+        actualArgs[arg.split('=')[0]] = arg.split('=')[1]
+    assert actualArgs == tone_args
     assert responses.calls[0].response.text == tone_response
-
     assert len(responses.calls) == 1
 
 

--- a/test/test_tone_analyzer_v3.py
+++ b/test/test_tone_analyzer_v3.py
@@ -46,7 +46,7 @@ def test_tone_with_args():
         tone_analyzer.tone(tone_text.read(), tones="social", sentences=False)
 
 
-    assert responses.calls[0].request.url.split('?')[0] == tone_url 
+    assert responses.calls[0].request.url.split('?')[0] == tone_url
     # Compare args. Order is not deterministic!
     actualArgs = {}
     for arg in responses.calls[0].request.url.split('?')[1].split('&'):
@@ -54,6 +54,31 @@ def test_tone_with_args():
     assert actualArgs == tone_args
     assert responses.calls[0].response.text == tone_response
     assert len(responses.calls) == 1
+
+
+@responses.activate
+## Invoking tone() with some modifiers specified as positional parameters: tones are emotion and social, and sentences is false
+def test_tone():
+    tone_url = 'https://gateway.watsonplatform.net/tone-analyzer/api/v3/tone'
+    tone_args = '?version=2016-05-19&tones=emotion%2Csocial&sentences=false'
+    tone_response = None
+    with open(os.path.join(os.path.dirname(__file__), '../resources/tone-v3-expect1.json')) as response_json:
+        tone_response = response_json.read()
+
+    responses.add(responses.POST, tone_url,
+                  body=tone_response, status=200,
+                  content_type='application/json')
+
+    with open(os.path.join(os.path.dirname(__file__), '../resources/personality.txt')) as tone_text:
+        tone_analyzer = watson_developer_cloud.ToneAnalyzerV3("2016-05-19",
+            username="username", password="password")
+        tone_analyzer.tone(tone_text.read(), 'emotion,social', False)
+
+    assert responses.calls[0].request.url == tone_url + tone_args
+    assert responses.calls[0].response.text == tone_response
+
+    assert len(responses.calls) == 1
+
 
 @responses.activate
 ## Invoking tone_chat()

--- a/watson_developer_cloud/tone_analyzer_v3.py
+++ b/watson_developer_cloud/tone_analyzer_v3.py
@@ -74,7 +74,10 @@ class ToneAnalyzerV3(WatsonDeveloperCloudService):
                 method='POST', headers=headers, url='/v3/tone', params=params,
                 json=text, accept_json=True)
 
-        if content_type == 'text/html':
+        # Use the equivalent of an 'else' rather than checking for explicit
+        # 'text/html' so that the call is made and returns a meaningful error
+        # for an invalid content type.
+        if content_type != 'application/json':
             return self.request(
                 method='POST', headers=headers, url='/v3/tone', params=params,
                 data=text, accept_json=True)

--- a/watson_developer_cloud/tone_analyzer_v3.py
+++ b/watson_developer_cloud/tone_analyzer_v3.py
@@ -43,19 +43,19 @@ class ToneAnalyzerV3(WatsonDeveloperCloudService):
     # tone
     #########################
 
-    def tone(self, text, content_type='text/plain', tones=None, sentences=None):
+    def tone(self, text, tones=None, sentences=None, content_type='text/plain'):
         """
         The general purpose tone API analyzes the "tone" of input text.
         The message is analyzed for several tones (social, emotional, and
         writing), with various characteristics derived for each tone.
         :param text: The input content to analyze.
-        :param content_type: The type of the input content: "text/plain"
-        (the default), "text/html", or "application/json".
         :param sentences: If false, sentence-level analysis is omitted; by
         default (or if true), each sentence is analyzed.
         :param tones: A comma-separated list of one or more of the following
         tones for which to analyze the input text, 'social', 'language', and
         'emotion'; the default is all tones.
+        :param content_type: The type of the input content: "text/plain"
+        (the default), "text/html", or "application/json".
         """
         params = {'version': self.version}
         if tones is not None:

--- a/watson_developer_cloud/tone_analyzer_v3.py
+++ b/watson_developer_cloud/tone_analyzer_v3.py
@@ -28,7 +28,6 @@ audience.
 
 from .watson_developer_cloud_service import WatsonDeveloperCloudService
 
-
 class ToneAnalyzerV3(WatsonDeveloperCloudService):
     """Client for the ToneAnalyzer service."""
 
@@ -44,27 +43,43 @@ class ToneAnalyzerV3(WatsonDeveloperCloudService):
     # tone
     #########################
 
-    def tone(self, text, tones=None, sentences=None):
+    def tone(self, text, content_type='text/plain', tones=None, sentences=None):
         """
-        The tone API is the main API call: it analyzes the "tone" of a piece
-        of text. The message is analyzed from
-        several tones (social tone, emotional tone, writing tone), and for
-        each of them various traits are derived
-        (such as conscientiousness, agreeableness, openness).
-        :param text: Text to analyze
-        :param sentences: If "false", sentence-level analysis is omitted
-        :param tones: Can be one or more of 'social', 'language', 'emotion';
-        comma-separated.
+        The general purpose tone API analyzes the "tone" of input text.
+        The message is analyzed for several tones (social, emotional, and
+        writing), with various characteristics derived for each tone.
+        :param text: The input content to analyze.
+        :param content_type: The type of the input content: "text/plain"
+        (the default), "text/html", or "application/json".
+        :param sentences: If false, sentence-level analysis is omitted; by
+        default (or if true), each sentence is analyzed.
+        :param tones: A comma-separated list of one or more of the following
+        tones for which to analyze the input text, 'social', 'language', and
+        'emotion'; the default is all tones.
         """
         params = {'version': self.version}
         if tones is not None:
             params['tones'] = tones
         if sentences is not None:
-            params['sentences'] = str(
-                sentences).lower()  # Cast boolean to "false" / "true"
-        data = {'text': text}
-        return self.request(method='POST', url='/v3/tone', params=params,
-                            json=data, accept_json=True)
+            # Cast boolean to "false" / "true"
+            params['sentences'] = str(sentences).lower()
+        if content_type == 'text/plain':
+            text = {'text': text}
+            content_type = 'application/json'
+        headers = {'content-type': content_type}
+
+        if content_type == 'application/json':
+            return self.request(
+                method='POST', headers=headers, url='/v3/tone', params=params,
+                json=text, accept_json=True)
+        else:
+            return self.request(
+                method='POST', headers=headers, url='/v3/tone', params=params,
+                data=text, accept_json=True)
+
+    #########################
+    # tone_chat
+    #########################
 
     def tone_chat(self, utterances):
         """

--- a/watson_developer_cloud/tone_analyzer_v3.py
+++ b/watson_developer_cloud/tone_analyzer_v3.py
@@ -57,6 +57,7 @@ class ToneAnalyzerV3(WatsonDeveloperCloudService):
         :param content_type: The type of the input content: "text/plain"
         (the default), "text/html", or "application/json".
         """
+
         params = {'version': self.version}
         if tones is not None:
             params['tones'] = tones
@@ -72,7 +73,8 @@ class ToneAnalyzerV3(WatsonDeveloperCloudService):
             return self.request(
                 method='POST', headers=headers, url='/v3/tone', params=params,
                 json=text, accept_json=True)
-        else:
+
+        if content_type == 'text/html':
             return self.request(
                 method='POST', headers=headers, url='/v3/tone', params=params,
                 data=text, accept_json=True)


### PR DESCRIPTION
Adds the missing content types, JSON and HTML.  Also preserves the functionality of the existing code for backward-compatibility. Adds a number of new examples to demonstrate the new content types. See issue https://github.com/watson-developer-cloud/python-sdk/issues/217.
