### PR TITLE
Discovery create_collection must send JSON

### DIFF
--- a/watson_developer_cloud/discovery_v1.py
+++ b/watson_developer_cloud/discovery_v1.py
@@ -222,7 +222,7 @@ class DiscoveryV1(WatsonDeveloperCloudService):
             environment_id)
         return self.request(method='POST',
                             url=url_string,
-                            data=data_dict,
+                            json=data_dict,
                             params={'version': self.version},
                             accept_json=True)
 


### PR DESCRIPTION
This fixes the problem described here:
https://stackoverflow.com/questions/44707586/watson-discovery-service-create-collection-api-call-returns-error-415-unsuppo