### PR TITLE
NameError: name 'features' is not defined

### DIFF
--- a/examples/natural_language_understanding_v1.ipynb
+++ b/examples/natural_language_understanding_v1.ipynb
@@ -65,7 +65,7 @@
    ],
    "source": [
     "nlu.analyze(text='this is my experimental text.  Bruce Banner is the Hulk and Bruce Wayne is BATMAN! Superman fears not Banner, but Wayne.',\n",
-    "            features=[features.Entities(), features.Keywords()])"
+    "            features=[Features.Entities(), Features.Keywords()])"
    ]
   },
   {


### PR DESCRIPTION
I was getting this error:

> NameError: name 'features' is not defined

`features=[features.Entities(), features.Keywords()])`
should be:
`features=[Features.Entities(), Features.Keywords()])`

Notice the uppercase 'F'.