### PR TITLE
[discovery] Add update_document method

### DIFF
--- a/examples/discovery_v1.ipynb
+++ b/examples/discovery_v1.ipynb
@@ -550,7 +550,7 @@
     "    res = discovery.update_document(environment_id=writable_environment_id,\n",
     "                                    collection_id=collections['collections'][0]['collection_id'],\n",
     "                                    document_id='some_user_specified_id',\n",
-    "                                    fileinfo=fileinfo)\n",
+    "                                    file_info=fileinfo)\n",
     "    pp.pprint(res)"
    ]
   },

--- a/examples/discovery_v1.ipynb
+++ b/examples/discovery_v1.ipynb
@@ -532,10 +532,32 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 26,
    "metadata": {
     "collapsed": false
    },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'document_id': 'some_user_specfied_id', 'status': 'processing'}\n"
+     ]
+    }
+   ],
+   "source": [
+    "with open(os.path.join(os.getcwd(),'..','resources','simple.html')) as fileinfo:\n",
+    "    res = discovery.update_document(environment_id=writable_environment_id,\n",
+    "                                    collection_id=collections['collections'][0]['collection_id'],\n",
+    "                                    document_id='some_user_specified_id',\n",
+    "                                    fileinfo=fileinfo)\n",
+    "    pp.pprint(res)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",

--- a/test/test_discovery_v1.py
+++ b/test/test_discovery_v1.py
@@ -381,6 +381,8 @@ def test_document():
                           'environments/envid/collections/collid/documents')
 
     doc_id_path = 'environments/envid/collections/collid/documents/docid'
+
+    update_doc_url = urljoin(base_discovery_url, doc_id_path)
     del_doc_url = urljoin(base_discovery_url,
                           doc_id_path)
     responses.add(responses.POST, add_doc_url,
@@ -389,6 +391,11 @@ def test_document():
                   content_type='application/json')
 
     responses.add(responses.GET, del_doc_url,
+                  body="{\"body\": []}",
+                  status=200,
+                  content_type='application/json')
+
+    responses.add(responses.POST, update_doc_url,
                   body="{\"body\": []}",
                   status=200,
                   content_type='application/json')
@@ -413,24 +420,30 @@ def test_document():
 
     assert len(responses.calls) == 5
 
-    discovery.delete_document(environment_id='envid',
+    discovery.update_document(environment_id='envid',
                               collection_id='collid',
                               document_id='docid')
 
     assert len(responses.calls) == 6
 
+    discovery.delete_document(environment_id='envid',
+                              collection_id='collid',
+                              document_id='docid')
+
+    assert len(responses.calls) == 7
+
     conf_id = discovery.add_document(environment_id='envid',
                                      collection_id='collid',
                                      file_data='my string of file')
 
-    assert len(responses.calls) == 7
+    assert len(responses.calls) == 8
 
     conf_id = discovery.add_document(environment_id='envid',
                                      collection_id='collid',
                                      file_data='my string of file',
                                      mime_type='application/html')
 
-    assert len(responses.calls) == 8
+    assert len(responses.calls) == 9
 
     conf_id = discovery.add_document(environment_id='envid',
                                      collection_id='collid',
@@ -438,4 +451,4 @@ def test_document():
                                      mime_type='application/html',
                                      metadata={'stuff': 'woot!'})
 
-    assert len(responses.calls) == 9
+    assert len(responses.calls) == 10

--- a/watson_developer_cloud/discovery_v1.py
+++ b/watson_developer_cloud/discovery_v1.py
@@ -279,6 +279,41 @@ class DiscoveryV1(WatsonDeveloperCloudService):
                                                 json.dumps(metadata),
                                                 'application/json')},
                             accept_json=True)
+    def update_document(self,
+                        environment_id,
+                        collection_id,
+                        document_id,
+                        file_info=None,
+                        file_data=None,
+                        mime_type=None,
+                        metadata=None):
+        url_string = '/v1/environments/{0}/collections/{1}/documents/{2}'. \
+            format(environment_id, collection_id, document_id)
+
+        params = {'version': self.version}
+
+        if metadata is None:
+            metadata = {}
+
+        file_tuple = None
+
+        if file_info:
+            mime_type = mime_type or mimetypes.guess_type(
+                file_info.name)[0]
+            file_tuple = (file_info.name, file_info, mime_type)
+        elif file_data:
+            file_tuple = ('tmpfile', file_data, mime_type or
+                          'application/html')
+
+        return self.request(method='POST',
+                            url=url_string,
+                            params=params,
+                            data=metadata,
+                            files={'file': file_tuple,
+                                   'metadata': (None,
+                                                json.dumps(metadata),
+                                                'application/json')},
+                            accept_json=True)
 
     def test_document(self,
                       environment_id,


### PR DESCRIPTION
Adds in the https://watson-api-explorer.mybluemix.net/apis/discovery-v1#!/Documents/updateDocument method for Discovery that was missing. Required in order to have control over document ID when uploading (as well as being able to change an existing document without 2 steps of delete + add)