### PR TITLE
Corrected feature import statement

### DIFF
--- a/examples/natural_language_understanding_v1.py
+++ b/examples/natural_language_understanding_v1.py
@@ -1,7 +1,7 @@
 import json
 from watson_developer_cloud import NaturalLanguageUnderstandingV1
 import watson_developer_cloud.natural_language_understanding.features.v1 as \
-    features
+    Features
 
 
 natural_language_understanding = NaturalLanguageUnderstandingV1(


### PR DESCRIPTION
I was recently using the Python SDK for one of my projects, my IDE gave me a syntax error, since the Features keyword was not defined on line 15 `features=[Features.Entities(), Features.Keywords()])`.

Also the code in the example does not correlate with the code in the [NLU docs](https://www.ibm.com/watson/developercloud/natural-language-understanding/api/v1/#post-analyze).