### PR TITLE
Fix failing test in travis-ci add tox.ini for local testing

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,7 +8,6 @@ pylint>=1.4.4
 coverage<4
 codecov>=1.6.3
 pytest-cov>=2.2.1
-requests>=2.8.0
 
 # documentation
 recommonmark>=0.2.0

--- a/test/test_speech_to_text_v1.py
+++ b/test/test_speech_to_text_v1.py
@@ -34,7 +34,7 @@ def test_success():
             audio_file, content_type='audio/l16; rate=44100')
 
     request_url = responses.calls[1].request.url
-    assert request_url == recognize_url + '?continuous=false'
+    assert request_url == recognize_url
     assert responses.calls[1].response.text == recognize_response
 
     assert len(responses.calls) == 2
@@ -219,5 +219,3 @@ def test_custom_words():
     assert 'word type must be all, user, or corpora' in str(keyerror.value)
 
     assert len(responses.calls) == 9
-
-

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,19 @@
+[tox]
+envlist = pep8, py27, py34, py35, py36
+
+[testenv]
+commands = py.test -v
+deps =
+     -r{toxinidir}/requirements.txt
+     -r{toxinidir}/requirements-dev.txt
+
+[testenv:pep8]
+deps = flake8
+commands = flake8
+
+[flake8]
+exclude = .venv,.git,.tox,docs
+; If you want to make tox run the tests with the same versions, create a
+; requirements.txt with the pinned versions and uncomment the following lines:
+; deps =
+;     -r{toxinidir}/requirements.txt


### PR DESCRIPTION
The last commit changed a feature without updating the test, so is
failing in travis ci. This fixes that issue, as well as adding a
tox.ini file for easy local testing. Tox is a pretty standard test run
setup tool for python projects, and makes it easy to test against
multiple python versions simultaneously. The added one is boiler plate
for python 2.7, 3.4 -> 3.6, and has a pep8 rule.

Requests was removed from requirements-dev because it is also listed in requirements,
being in both breaks tox setting up the environment.