### PR TITLE
Updating Conversation doc link

### DIFF
--- a/watson_developer_cloud/dialog_v1.py
+++ b/watson_developer_cloud/dialog_v1.py
@@ -29,11 +29,11 @@ class DialogV1(WatsonDeveloperCloudService):
     def __init__(self, url=default_url, **kwargs):
         WatsonDeveloperCloudService.__init__(self, 'dialog', url, **kwargs)
         print(
-            'WARNING: The Dialog service was deprecated, existing instances '
-            'of the service will continue to function'
-            'until August 9, 2017. See '
-            'https://www.ibm.com/watson/developercloud/doc/conversation'
-            '/migration.shtml')
+            'WARNING: The Dialog service was deprecated. Existing instances '
+            'of the service stopped functioning on August 9, 2017. '
+            'Dialog was replaced by the Conversation service. See '
+            'https://console.bluemix.net/docs/services/conversation'
+            '/index.html#about')
 
     def get_dialogs(self):
         return self.request(method='GET', url='/v1/dialogs', accept_json=True)


### PR DESCRIPTION
Updating link to the Conversation docs which moved from WDC to Bluemix Docs site. 