### PR TITLE
Fix Visual Recognition classify call in windows

### DIFF
--- a/watson_developer_cloud/visual_recognition_v3.py
+++ b/watson_developer_cloud/visual_recognition_v3.py
@@ -125,6 +125,12 @@ class VisualRecognitionV3(WatsonDeveloperCloudService):
         filename = images_file.name
         mime_type = mimetypes.guess_type(
             filename)[0] or 'application/octet-stream'
+
+        if 'zip' in mime_type:
+            mime_type = 'application/zip'
+
+        filename = filename.replace('\\', '/')
+
         return self.request(method='POST', url=url,
                             files={'images_file': (
                                 filename, images_file, mime_type)},


### PR DESCRIPTION
Fixes https://github.com/watson-developer-cloud/python-sdk/issues/237 and fixes https://github.com/watson-developer-cloud/python-sdk/issues/200

Two main fixes to get it to work on windows was:
1) The multipart-encoded file content_type needs to be application/zip when sending to VR
2) replaced windows path which throws json parsing errors. 