### PR TITLE
Add support for default_headers

### DIFF
--- a/test/test_alchemy_language_v1.py
+++ b/test/test_alchemy_language_v1.py
@@ -10,7 +10,6 @@ class TestAlchemyLanguageV1(TestCase):
         default_url = 'https://gateway-a.watsonplatform.net/calls'
         inited = watson_developer_cloud.AlchemyLanguageV1(url=default_url, api_key='boguskey',
                                                           x_watson_learning_opt_out=True)
-        #assert inited.x_watson_learning_opt_out
         assert inited.api_key == 'boguskey'
         assert inited.url == default_url
         inited.set_url(url="http://google.com")

--- a/test/test_alchemy_language_v1.py
+++ b/test/test_alchemy_language_v1.py
@@ -10,7 +10,7 @@ class TestAlchemyLanguageV1(TestCase):
         default_url = 'https://gateway-a.watsonplatform.net/calls'
         inited = watson_developer_cloud.AlchemyLanguageV1(url=default_url, api_key='boguskey',
                                                           x_watson_learning_opt_out=True)
-        assert inited.x_watson_learning_opt_out
+        #assert inited.x_watson_learning_opt_out
         assert inited.api_key == 'boguskey'
         assert inited.url == default_url
         inited.set_url(url="http://google.com")

--- a/test/test_conversation_v1.py
+++ b/test/test_conversation_v1.py
@@ -719,6 +719,7 @@ def test_message():
 
     conversation = watson_developer_cloud.ConversationV1(
         username="username", password="password", version='2016-09-20')
+    conversation.set_default_headers({'x-watson-learning-opt-out': "true"})
 
     workspace_id = 'f8fdbc65-e0bd-4e43-b9f8-2975a366d4ec'
     message_url = '%s/v1/workspaces/%s/message' % (base_url, workspace_id)
@@ -752,6 +753,8 @@ def test_message():
 
     assert message is not None
     assert responses.calls[0].request.url == message_url1
+    assert 'x-watson-learning-opt-out' in responses.calls[0].request.headers
+    assert responses.calls[0].request.headers['x-watson-learning-opt-out'] == 'true'
     assert responses.calls[0].response.text == json.dumps(message_response)
 
     # test context

--- a/watson_developer_cloud/watson_developer_cloud_service.py
+++ b/watson_developer_cloud/watson_developer_cloud_service.py
@@ -101,7 +101,10 @@ class WatsonDeveloperCloudService(object):
         self.api_key = None
         self.username = None
         self.password = None
-        self.x_watson_learning_opt_out = x_watson_learning_opt_out
+        self.default_headers = None
+
+        if x_watson_learning_opt_out:
+            self.default_headers = {'x-watson-learning-opt-out': 'true'}
 
         if api_key is not None:
             if username is not None or password is not None:
@@ -152,6 +155,16 @@ class WatsonDeveloperCloudService(object):
 
     def set_url(self, url):
         self.url = url
+
+    def set_default_headers(self, headers):
+        """
+        Set http headers to be sent in every request.
+        :param headers: A dictionary of header names and values
+        """
+        if isinstance(headers, dict):
+            self.default_headers = headers
+        else:
+            raise WatsonException("headers parameter must be a dictionary")
 
     # Could make this compute the label_id based on the variable name of the
     # dictionary passed in (using **kwargs), but
@@ -262,6 +275,8 @@ class WatsonDeveloperCloudService(object):
 
         headers = CaseInsensitiveDict(
             {'user-agent': 'watson-developer-cloud-python-' + __version__})
+        if self.default_headers is not None:
+            headers.update(self.default_headers)
         if accept_json:
             headers['accept'] = 'application/json'
         headers.update(input_headers)
@@ -292,9 +307,6 @@ class WatsonDeveloperCloudService(object):
                 params['apikey'] = self.api_key
             else:
                 params['api_key'] = self.api_key
-
-        if self.x_watson_learning_opt_out:
-            headers['x-watson-learning-opt-out'] = 'true'
 
         response = requests.request(method=method, url=full_url,
                                     cookies=self.jar, auth=auth,


### PR DESCRIPTION
This PR adds support for a `set_default_headers` in the base `WatsonDeveloperCloudService` class.  This is a more general and flexible solution for setting the `x-watson-learning-opt-out` header.  I left the `x_watson_learning_opt_out`parameter on the service constructor for backward compatibility -- we should consider removing that on the next major release.