### PR TITLE
Update user agent string to include OS and Python version info

### DIFF
--- a/watson_developer_cloud/watson_developer_cloud_service.py
+++ b/watson_developer_cloud/watson_developer_cloud_service.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import json as json_import
+import platform
 import os
 import requests
 import sys
@@ -102,6 +103,12 @@ class WatsonDeveloperCloudService(object):
         self.username = None
         self.password = None
         self.default_headers = None
+
+        user_agent_string = 'watson-apis-python-sdk-' + __version__ # SDK version
+        user_agent_string += ' ' + platform.system() # OS
+        user_agent_string += ' ' + platform.release() # OS version
+        user_agent_string += ' ' + platform.python_version() # Python version
+        self.user_agent_header = {'user-agent': user_agent_string}
 
         if x_watson_learning_opt_out:
             self.default_headers = {'x-watson-learning-opt-out': 'true'}
@@ -273,8 +280,7 @@ class WatsonDeveloperCloudService(object):
 
         input_headers = _remove_null_values(headers) if headers else {}
 
-        headers = CaseInsensitiveDict(
-            {'user-agent': 'watson-developer-cloud-python-' + __version__})
+        headers = CaseInsensitiveDict(self.user_agent_header)
         if self.default_headers is not None:
             headers.update(self.default_headers)
         if accept_json:


### PR DESCRIPTION
Small update to add OS and Python version info to the user-agent string.

On my Mac, this results in:
```
{'user-agent': 'watson-apis-python-sdk-0.26.1 Darwin 16.7.0 2.7.12'}
```
In a docker container running the "python" image, this results in:
```
{'user-agent': 'watson-apis-python-sdk-0.26.1 Linux 4.9.49-moby 3.6.3'}
```