### PR TITLE
Rename core service file to watson_service.py

### DIFF
--- a/examples/conversation_v1.py
+++ b/examples/conversation_v1.py
@@ -1,4 +1,5 @@
 import json
+import os
 from watson_developer_cloud import ConversationV1
 
 #########################
@@ -12,6 +13,8 @@ conversation = ConversationV1(
 
 # replace with your own workspace_id
 workspace_id = '0a0c06c1-8e31-4655-9067-58fcac5134fc'
+if os.getenv("conversation_workspace_id") is not None:
+    workspace_id = os.getenv("conversation_workspace_id")
 
 response = conversation.message(workspace_id=workspace_id, message_input={
     'text': 'What\'s the weather like?'})

--- a/examples/natural_language_classifier_v1.py
+++ b/examples/natural_language_classifier_v1.py
@@ -1,6 +1,12 @@
 import json
+import os
 # from os.path import join, dirname
 from watson_developer_cloud import NaturalLanguageClassifierV1
+
+# replace with your own classifier_id
+classifier_id = '0a0c06c1-8e31-4655-9067-58fcac5134fc'
+if os.getenv("natural_language_classifier_classifier_id") is not None:
+    classifier_id = os.getenv("natural_language_classifier_classifier_id")
 
 natural_language_classifier = NaturalLanguageClassifierV1(
     username='YOUR SERVICE USERNAME',
@@ -14,12 +20,11 @@ print(json.dumps(classifiers, indent=2))
 #     print(json.dumps(natural_language_classifier.create(
 # training_data=training_data, name='weather'), indent=2))
 
-# replace 2374f9x68-nlc-2697 with your classifier id
-status = natural_language_classifier.status('2374f9x68-nlc-2697')
+status = natural_language_classifier.status(classifier_id)
 print(json.dumps(status, indent=2))
 
 if status['status'] == 'Available':
-    classes = natural_language_classifier.classify('2374f9x68-nlc-2697',
+    classes = natural_language_classifier.classify(classifier_id,
                                                    'How hot will it be '
                                                    'tomorrow?')
     print(json.dumps(classes, indent=2))

--- a/examples/retrieve_and_rank_v1.py
+++ b/examples/retrieve_and_rank_v1.py
@@ -16,6 +16,8 @@ print(json.dumps(solr_clusters, indent=2))
 
 # Replace with your own solr_cluster_id
 solr_cluster_id = 'sc1264f746_d0f7_4840_90be_07164e6ed04b'
+if os.getenv("retrieve_and_rank_solr_cluster_id") is not None:
+    solr_cluster_id = os.getenv("retrieve_and_rank_solr_cluster_id")
 
 status = retrieve_and_rank.get_solr_cluster_status(
     solr_cluster_id=solr_cluster_id)

--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -2,6 +2,7 @@
 
 import os
 import re
+import traceback
 import pytest
 import json as json_import
 
@@ -54,4 +55,4 @@ def test_examples():
             exec(re.sub('# coding=utf-8', '', service_file), globals())
         except Exception as e:
             assert False, 'example in file ' + name + ' failed with error: '\
-                          + str(e)
+                          + str(e) + '\n' + traceback.format_exc()

--- a/watson_developer_cloud/__init__.py
+++ b/watson_developer_cloud/__init__.py
@@ -12,9 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .watson_developer_cloud_service import WatsonDeveloperCloudService
-from .watson_developer_cloud_service import WatsonException
-from .watson_developer_cloud_service import WatsonInvalidArgument
+from .watson_service import WatsonService
+from .watson_service import WatsonException
+from .watson_service import WatsonInvalidArgument
 from .alchemy_data_news_v1 import AlchemyDataNewsV1
 from .alchemy_language_v1 import AlchemyLanguageV1
 from .alchemy_vision_v1 import AlchemyVisionV1

--- a/watson_developer_cloud/alchemy_data_news_v1.py
+++ b/watson_developer_cloud/alchemy_data_news_v1.py
@@ -16,15 +16,14 @@ The AlchemyData News service
 (https://www.ibm.com/watson/developercloud/alchemy-data-news.html)
 """
 
-from .watson_developer_cloud_service import WatsonDeveloperCloudService
+from .watson_service import WatsonService
 
 
-class AlchemyDataNewsV1(WatsonDeveloperCloudService):
+class AlchemyDataNewsV1(WatsonService):
     default_url = 'https://gateway-a.watsonplatform.net/calls'
 
     def __init__(self, url=default_url, **kwargs):
-        WatsonDeveloperCloudService.__init__(self, 'alchemy_api', url,
-                                             **kwargs)
+        WatsonService.__init__(self, 'alchemy_api', url, **kwargs)
 
     def get_news_documents(self, start, end, max_results=10, query_fields=None,
                            return_fields=None, time_slice=None,

--- a/watson_developer_cloud/alchemy_language_v1.py
+++ b/watson_developer_cloud/alchemy_language_v1.py
@@ -16,15 +16,14 @@ The AlchemyAPI Language service
 (https://www.ibm.com/watson/developercloud/alchemy-language.html)
 """
 
-from .watson_developer_cloud_service import WatsonDeveloperCloudService
+from .watson_service import WatsonService
 
 
-class AlchemyLanguageV1(WatsonDeveloperCloudService):
+class AlchemyLanguageV1(WatsonService):
     default_url = 'https://gateway-a.watsonplatform.net/calls'
 
     def __init__(self, url=default_url, **kwargs):
-        WatsonDeveloperCloudService.__init__(self, 'alchemy_api', url,
-                                             **kwargs)
+        WatsonService.__init__(self, 'alchemy_api', url, **kwargs)
 
     def author(self, html=None, url=None, language=None):
         params = {'language': language}

--- a/watson_developer_cloud/alchemy_vision_v1.py
+++ b/watson_developer_cloud/alchemy_vision_v1.py
@@ -16,17 +16,16 @@ The AlchemyAPI Vision service
 (https://www.ibm.com/watson/developercloud/visual-recognition.html)
 """
 from __future__ import print_function
-from .watson_developer_cloud_service import WatsonDeveloperCloudService
+from .watson_service import WatsonService
 
 
-class AlchemyVisionV1(WatsonDeveloperCloudService):
+class AlchemyVisionV1(WatsonService):
     """AlchemyVision was deprecated, migrate your application to use
     VisualRecognition."""
     default_url = 'https://gateway-a.watsonplatform.net/calls'
 
     def __init__(self, url=default_url, **kwargs):
-        WatsonDeveloperCloudService.__init__(self, 'alchemy_api', url,
-                                             **kwargs)
+        WatsonService.__init__(self, 'alchemy_api', url, **kwargs)
         print(
             'WARNING: The AlchemyVision service was deprecated, '
             'use VisualRecognitionV3 instead')

--- a/watson_developer_cloud/authorization_v1.py
+++ b/watson_developer_cloud/authorization_v1.py
@@ -17,8 +17,7 @@ The v1 Authorization "service" that enables developers to
 retrieve a temporary access token
 """
 
-from watson_developer_cloud.watson_developer_cloud_service import \
-    WatsonDeveloperCloudService
+from watson_developer_cloud.watson_service import WatsonService
 
 try:
     import urllib.parse as urlparse  # Python 3
@@ -26,7 +25,7 @@ except ImportError:
     import urlparse  # Python 2
 
 
-class AuthorizationV1(WatsonDeveloperCloudService):
+class AuthorizationV1(WatsonService):
     """
     Generates tokens, which can be used client-side to avoid exposing the
     service credentials.
@@ -37,7 +36,7 @@ class AuthorizationV1(WatsonDeveloperCloudService):
 
     def __init__(self, url=default_url,
                  username=None, password=None, use_vcap_services=True):
-        WatsonDeveloperCloudService.__init__(
+        WatsonService.__init__(
             self, 'authorization', url, username, password, use_vcap_services)
 
     def get_token(self, url):

--- a/watson_developer_cloud/conversation_v1.py
+++ b/watson_developer_cloud/conversation_v1.py
@@ -18,17 +18,16 @@ language understanding, and integrated dialog tools to create conversation
 flows between your apps and your users.
 """
 
-from .watson_developer_cloud_service import WatsonDeveloperCloudService
+from .watson_service import WatsonService
 
-class ConversationV1(WatsonDeveloperCloudService):
+class ConversationV1(WatsonService):
     """Client for the Conversation service."""
 
     default_url = 'https://gateway.watsonplatform.net/conversation/api'
     latest_version = '2017-04-21'
 
     def __init__(self, version, url=default_url, **kwargs):
-        WatsonDeveloperCloudService.__init__(self, 'conversation', url,
-                                             **kwargs)
+        WatsonService.__init__(self, 'conversation', url, **kwargs)
         self.version = version
 
     #########################

--- a/watson_developer_cloud/dialog_v1.py
+++ b/watson_developer_cloud/dialog_v1.py
@@ -17,17 +17,17 @@ The v1 Dialog service
 (https://www.ibm.com/watson/developercloud/dialog.html)
 """
 from __future__ import print_function
-from .watson_developer_cloud_service import WatsonDeveloperCloudService
+from .watson_service import WatsonService
 
 
-class DialogV1(WatsonDeveloperCloudService):
+class DialogV1(WatsonService):
     default_url = 'https://gateway.watsonplatform.net/dialog/api'
     dialog_json_format = 'application/wds+json'
     dialog_xml_format = 'application/wds+xml'
     dialog_binary_format = 'application/octet-stream'
 
     def __init__(self, url=default_url, **kwargs):
-        WatsonDeveloperCloudService.__init__(self, 'dialog', url, **kwargs)
+        WatsonService.__init__(self, 'dialog', url, **kwargs)
         print(
             'WARNING: The Dialog service was deprecated. Existing instances '
             'of the service stopped functioning on August 9, 2017. '

--- a/watson_developer_cloud/discovery_v1.py
+++ b/watson_developer_cloud/discovery_v1.py
@@ -18,13 +18,13 @@ The v1 Discovery Service
 import json
 import mimetypes
 
-from .watson_developer_cloud_service import WatsonDeveloperCloudService
+from .watson_service import WatsonService
 
 default_url = 'https://gateway.watsonplatform.net/discovery/api'
 latest_version = '2016-11-07'
 
 
-class DiscoveryV1(WatsonDeveloperCloudService):
+class DiscoveryV1(WatsonService):
     """Client for Discovery service"""
 
     def __init__(self, version, url=default_url, username=None, password=None,
@@ -36,7 +36,7 @@ class DiscoveryV1(WatsonDeveloperCloudService):
         use
         """
 
-        WatsonDeveloperCloudService.__init__(
+        WatsonService.__init__(
             self, 'discovery', url, username, password, use_vcap_services)
         self.version = version
 

--- a/watson_developer_cloud/document_conversion_v1.py
+++ b/watson_developer_cloud/document_conversion_v1.py
@@ -16,12 +16,12 @@
 The v1 Document Conversion service
 (https://www.ibm.com/watson/developercloud/document-conversion.html)
 """
-from .watson_developer_cloud_service import WatsonDeveloperCloudService
+from .watson_service import WatsonService
 import os
 import json
 
 
-class DocumentConversionV1(WatsonDeveloperCloudService):
+class DocumentConversionV1(WatsonService):
     DEFAULT_URL = 'https://gateway.watsonplatform.net/document-conversion/api'
     ANSWER_UNITS = 'answer_units'
     NORMALIZED_HTML = 'normalized_html'
@@ -29,8 +29,7 @@ class DocumentConversionV1(WatsonDeveloperCloudService):
     latest_version = '2016-02-10'
 
     def __init__(self, version, url=DEFAULT_URL, **kwargs):
-        WatsonDeveloperCloudService.__init__(self, 'document_conversion', url,
-                                             **kwargs)
+        WatsonService.__init__(self, 'document_conversion', url, **kwargs)
         self.version = version
 
     def convert_document(self, document, config, media_type=None):

--- a/watson_developer_cloud/language_translation_v2.py
+++ b/watson_developer_cloud/language_translation_v2.py
@@ -18,16 +18,15 @@ The v2 Language Translation service
 """
 
 from __future__ import print_function
-from .watson_developer_cloud_service import WatsonDeveloperCloudService
-from .watson_developer_cloud_service import WatsonInvalidArgument
+from .watson_service import WatsonService
+from .watson_service import WatsonInvalidArgument
 
 
-class LanguageTranslationV2(WatsonDeveloperCloudService):
+class LanguageTranslationV2(WatsonService):
     default_url = "https://gateway.watsonplatform.net/language-translation/api"
 
     def __init__(self, url=default_url, **kwargs):
-        WatsonDeveloperCloudService.__init__(self, 'language_translation', url,
-                                             **kwargs)
+        WatsonService.__init__(self, 'language_translation', url, **kwargs)
         print(
             'WARNING: The Language Translation service was deprecated, '
             'please migrate to Language Translator.')

--- a/watson_developer_cloud/language_translator_v2.py
+++ b/watson_developer_cloud/language_translator_v2.py
@@ -17,16 +17,15 @@ The v2 Language Translator service
 (https://www.ibm.com/watson/developercloud/language-translator.html)
 """
 
-from .watson_developer_cloud_service import WatsonDeveloperCloudService
-from .watson_developer_cloud_service import WatsonInvalidArgument
+from .watson_service import WatsonService
+from .watson_service import WatsonInvalidArgument
 
 
-class LanguageTranslatorV2(WatsonDeveloperCloudService):
+class LanguageTranslatorV2(WatsonService):
     default_url = "https://gateway.watsonplatform.net/language-translator/api"
 
     def __init__(self, url=default_url, **kwargs):
-        WatsonDeveloperCloudService.__init__(self, 'language_translator', url,
-                                             **kwargs)
+        WatsonService.__init__(self, 'language_translator', url, **kwargs)
 
     def identify(self, text):
         """

--- a/watson_developer_cloud/natural_language_classifier_v1.py
+++ b/watson_developer_cloud/natural_language_classifier_v1.py
@@ -18,16 +18,15 @@ The v1 Natural Language Classifier service
 """
 
 import json
-from watson_developer_cloud.watson_developer_cloud_service import \
-    WatsonDeveloperCloudService
+from watson_developer_cloud.watson_service import WatsonService
 
 
-class NaturalLanguageClassifierV1(WatsonDeveloperCloudService):
+class NaturalLanguageClassifierV1(WatsonService):
     default_url = 'https://gateway.watsonplatform.net/natural-language' \
                   '-classifier/api'
 
     def __init__(self, url=default_url, **kwargs):
-        WatsonDeveloperCloudService.__init__(
+        WatsonService.__init__(
             self, 'natural_language_classifier', url, **kwargs)
 
     def create(self, training_data, name=None, language='en'):

--- a/watson_developer_cloud/natural_language_understanding_v1.py
+++ b/watson_developer_cloud/natural_language_understanding_v1.py
@@ -12,11 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from watson_developer_cloud.watson_developer_cloud_service import \
-    WatsonDeveloperCloudService
+from watson_developer_cloud.watson_service import WatsonService
 
 
-class NaturalLanguageUnderstandingV1(WatsonDeveloperCloudService):
+class NaturalLanguageUnderstandingV1(WatsonService):
     """
     All methods taking features use the feature classes
     from watson_developer_cloud/natural_language_understanding/features/v1
@@ -32,7 +31,7 @@ class NaturalLanguageUnderstandingV1(WatsonDeveloperCloudService):
                  username=None,
                  password=None,
                  **kwargs):
-        WatsonDeveloperCloudService.__init__(
+        WatsonService.__init__(
             self, 'natural-language-understanding', url,
             username, password, **kwargs)
         self.version = version

--- a/watson_developer_cloud/personality_insights_v2.py
+++ b/watson_developer_cloud/personality_insights_v2.py
@@ -17,10 +17,10 @@ The v2 Personality Insights service
 """
 
 import json
-from .watson_developer_cloud_service import WatsonDeveloperCloudService
+from .watson_service import WatsonService
 
 
-class PersonalityInsightsV2(WatsonDeveloperCloudService):
+class PersonalityInsightsV2(WatsonService):
     """Wrapper of the Personality Insights service"""
     default_url = 'https://gateway.watsonplatform.net/personality-insights/api'
 
@@ -30,7 +30,7 @@ class PersonalityInsightsV2(WatsonDeveloperCloudService):
         runtime variable for Bluemix, or it defaults to local URLs.
         """
 
-        WatsonDeveloperCloudService.__init__(
+        WatsonService.__init__(
             self, 'personality_insights', url, **kwargs)
 
     def profile(self, text, content_type='text/plain',

--- a/watson_developer_cloud/personality_insights_v3.py
+++ b/watson_developer_cloud/personality_insights_v3.py
@@ -17,10 +17,10 @@ The v3 Personality Insights service
 """
 
 import json
-from .watson_developer_cloud_service import WatsonDeveloperCloudService
+from .watson_service import WatsonService
 
 
-class PersonalityInsightsV3(WatsonDeveloperCloudService):
+class PersonalityInsightsV3(WatsonService):
     """Wrapper for the Personality Insights service"""
     default_url = 'https://gateway.watsonplatform.net/personality-insights/api'
     default_version = '2016-10-20'
@@ -33,8 +33,7 @@ class PersonalityInsightsV3(WatsonDeveloperCloudService):
         format (for example, '2016-10-20')
         """
 
-        WatsonDeveloperCloudService.__init__(self, 'personality_insights', url,
-                                             **kwargs)
+        WatsonService.__init__(self, 'personality_insights', url, **kwargs)
         self.version = version
 
     def profile(self, text, content_type='text/plain', content_language=None,

--- a/watson_developer_cloud/retrieve_and_rank_v1.py
+++ b/watson_developer_cloud/retrieve_and_rank_v1.py
@@ -19,16 +19,14 @@ The v1 Retrieve and Rank service
 
 import json
 import pysolr
-from watson_developer_cloud.watson_developer_cloud_service import \
-    WatsonDeveloperCloudService
+from watson_developer_cloud.watson_service import WatsonService
 
 
-class RetrieveAndRankV1(WatsonDeveloperCloudService):
+class RetrieveAndRankV1(WatsonService):
     default_url = 'https://gateway.watsonplatform.net/retrieve-and-rank/api'
 
     def __init__(self, url=default_url, **kwargs):
-        WatsonDeveloperCloudService.__init__(self, 'retrieve_and_rank', url,
-                                             **kwargs)
+        WatsonService.__init__(self, 'retrieve_and_rank', url, **kwargs)
 
     def list_solr_clusters(self):
         return self.request(method='GET', url='/v1/solr_clusters',

--- a/watson_developer_cloud/speech_to_text_v1.py
+++ b/watson_developer_cloud/speech_to_text_v1.py
@@ -16,16 +16,15 @@ The v1 Speech to Text service
 (https://www.ibm.com/watson/developercloud/speech-to-text.html)
 """
 
-from .watson_developer_cloud_service import WatsonDeveloperCloudService
+from .watson_service import WatsonService
 import json
 
 
-class SpeechToTextV1(WatsonDeveloperCloudService):
+class SpeechToTextV1(WatsonService):
     default_url = "https://stream.watsonplatform.net/speech-to-text/api"
 
     def __init__(self, url=default_url, **kwargs):
-        WatsonDeveloperCloudService.__init__(self, 'speech_to_text', url,
-                                             **kwargs)
+        WatsonService.__init__(self, 'speech_to_text', url, **kwargs)
 
     def recognize(self, audio, content_type, continuous=None, model=None,
                   customization_id=None,

--- a/watson_developer_cloud/text_to_speech_v1.py
+++ b/watson_developer_cloud/text_to_speech_v1.py
@@ -16,10 +16,10 @@ The v1 Text to Speech service
 (https://www.ibm.com/watson/developercloud/text-to-speech.html)
 """
 
-from .watson_developer_cloud_service import WatsonDeveloperCloudService
+from .watson_service import WatsonService
 
 
-class TextToSpeechV1(WatsonDeveloperCloudService):
+class TextToSpeechV1(WatsonService):
     """Client for the Text to Speech service"""
     default_url = "https://stream.watsonplatform.net/text-to-speech/api"
 
@@ -28,8 +28,7 @@ class TextToSpeechV1(WatsonDeveloperCloudService):
         Construct an instance. Fetches service parameters from VCAP_SERVICES
         runtime variable for Bluemix, or it defaults to local URLs.
         """
-        WatsonDeveloperCloudService.__init__(self, 'text_to_speech', url,
-                                             **kwargs)
+        WatsonService.__init__(self, 'text_to_speech', url, **kwargs)
 
     def synthesize(self, text, voice=None, accept=None, customization_id=None):
         """

--- a/watson_developer_cloud/tone_analyzer_v3.py
+++ b/watson_developer_cloud/tone_analyzer_v3.py
@@ -26,17 +26,16 @@ personality traits, and writing style that you want for your intended
 audience.
 """
 
-from .watson_developer_cloud_service import WatsonDeveloperCloudService
+from .watson_service import WatsonService
 
-class ToneAnalyzerV3(WatsonDeveloperCloudService):
+class ToneAnalyzerV3(WatsonService):
     """Client for the ToneAnalyzer service."""
 
     default_url = 'https://gateway.watsonplatform.net/tone-analyzer/api'
     latest_version = '2016-05-19'
 
     def __init__(self, version, url=default_url, **kwargs):
-        WatsonDeveloperCloudService.__init__(self, 'tone_analyzer', url,
-                                             **kwargs)
+        WatsonService.__init__(self, 'tone_analyzer', url, **kwargs)
         self.version = version
 
     #########################

--- a/watson_developer_cloud/tradeoff_analytics_v1.py
+++ b/watson_developer_cloud/tradeoff_analytics_v1.py
@@ -16,16 +16,15 @@ The v1 Tradeoff Analytics service
 (https://www.ibm.com/watson/developercloud/tradeoff-analytics.html)
 """
 
-from .watson_developer_cloud_service import WatsonDeveloperCloudService
+from .watson_service import WatsonService
 
 
-class TradeoffAnalyticsV1(WatsonDeveloperCloudService):
+class TradeoffAnalyticsV1(WatsonService):
     """Wrapper for the Tradeoff Analytics service"""
     default_url = 'https://gateway.watsonplatform.net/tradeoff-analytics/api'
 
     def __init__(self, url=default_url, **kwargs):
-        WatsonDeveloperCloudService.__init__(self, 'tradeoff_analytics', url,
-                                             **kwargs)
+        WatsonService.__init__(self, 'tradeoff_analytics', url, **kwargs)
 
     def dilemmas(self, params,
                  generate_visualization=True,

--- a/watson_developer_cloud/visual_recognition_v3.py
+++ b/watson_developer_cloud/visual_recognition_v3.py
@@ -18,10 +18,10 @@ The v3 Visual Recognition service
 import json
 import mimetypes
 
-from .watson_developer_cloud_service import WatsonDeveloperCloudService
+from .watson_service import WatsonService
 
 
-class VisualRecognitionV3(WatsonDeveloperCloudService):
+class VisualRecognitionV3(WatsonService):
     """Client for the Visual Recognition service"""
 
     default_url = 'https://gateway-a.watsonplatform.net/visual-recognition/api'
@@ -37,8 +37,7 @@ class VisualRecognitionV3(WatsonDeveloperCloudService):
         use username and password)
         """
 
-        WatsonDeveloperCloudService.__init__(self, 'watson_vision_combined',
-                                             url, **kwargs)
+        WatsonService.__init__(self, 'watson_vision_combined', url, **kwargs)
         self.version = version
 
     def get_classifier(self, classifier_id):

--- a/watson_developer_cloud/watson_service.py
+++ b/watson_developer_cloud/watson_service.py
@@ -84,7 +84,7 @@ def _convert_boolean_values(dictionary):
     return dictionary
 
 
-class WatsonDeveloperCloudService(object):
+class WatsonService(object):
     def __init__(self, vcap_services_name, url, username=None, password=None,
                  use_vcap_services=True, api_key=None,
                  x_watson_learning_opt_out=False):


### PR DESCRIPTION
Rename `watson_developer_cloud_service.py` to `watson_service.py`.  This will make it easier to reuse the core SDK files for other SDKs.