### PR TITLE
Replace latest_version with named version dates

### DIFF
--- a/watson_developer_cloud/conversation_v1.py
+++ b/watson_developer_cloud/conversation_v1.py
@@ -33,7 +33,11 @@ class ConversationV1(WatsonService):
     """The Conversation V1 service."""
 
     default_url = 'https://gateway.watsonplatform.net/conversation/api'
-    latest_version = '2017-05-26'
+    VERSION_DATE_2017_05_26 = '2017-05-26'
+    VERSION_DATE_2017_04_21 = '2017-04-21'
+    VERSION_DATE_2017_02_03 = '2017-02-03'
+    VERSION_DATE_2016_09_20 = '2016-09-20'
+    VERSION_DATE_2016_07_11 = '2016-07-11'
 
     def __init__(self, version, url=default_url, username=None, password=None):
         """

--- a/watson_developer_cloud/discovery_v1.py
+++ b/watson_developer_cloud/discovery_v1.py
@@ -35,7 +35,11 @@ class DiscoveryV1(WatsonService):
     """The Discovery V1 service."""
 
     default_url = 'https://gateway.watsonplatform.net/discovery/api'
-    latest_version = '2017-09-01'
+    VERSION_DATE_2017_09_01 = '2017-09-01'
+    VERSION_DATE_2017_08_01 = '2017-08-01'
+    VERSION_DATE_2017_07_19 = '2017-07-19'
+    VERSION_DATE_2017_06_25 = '2017-06-25'
+    VERSION_DATE_2016_12_01 = '2016-12-01'
 
     def __init__(self, version, url=default_url, username=None, password=None):
         """

--- a/watson_developer_cloud/language_translator_v2.py
+++ b/watson_developer_cloud/language_translator_v2.py
@@ -34,7 +34,6 @@ class LanguageTranslatorV2(WatsonService):
     """The Language Translator V2 service."""
 
     default_url = 'https://gateway.watsonplatform.net/language-translator/api'
-    latest_version = ''
 
     def __init__(self, url=default_url, username=None, password=None):
         """

--- a/watson_developer_cloud/natural_language_classifier_v1.py
+++ b/watson_developer_cloud/natural_language_classifier_v1.py
@@ -34,7 +34,6 @@ class NaturalLanguageClassifierV1(WatsonService):
     """The Natural Language Classifier V1 service."""
 
     default_url = 'https://gateway.watsonplatform.net/natural-language-classifier/api'
-    latest_version = ''
 
     def __init__(self, url=default_url, username=None, password=None):
         """

--- a/watson_developer_cloud/natural_language_understanding_v1.py
+++ b/watson_developer_cloud/natural_language_understanding_v1.py
@@ -76,7 +76,7 @@ class NaturalLanguageUnderstandingV1(WatsonService):
     """The Natural Language Understanding V1 service."""
 
     default_url = 'https://gateway.watsonplatform.net/natural-language-understanding/api'
-    latest_version = '2017-02-27'
+    VERSION_DATE_2017_02_27 = '2017-02-27'
 
     def __init__(self, version, url=default_url, username=None, password=None):
         """

--- a/watson_developer_cloud/personality_insights_v3.py
+++ b/watson_developer_cloud/personality_insights_v3.py
@@ -69,7 +69,6 @@ class PersonalityInsightsV3(WatsonService):
     """The Personality Insights V3 service."""
 
     default_url = 'https://gateway.watsonplatform.net/personality-insights/api'
-    latest_version = ''
 
     def __init__(self, version, url=default_url, username=None, password=None):
         """

--- a/watson_developer_cloud/tone_analyzer_v3.py
+++ b/watson_developer_cloud/tone_analyzer_v3.py
@@ -65,7 +65,6 @@ class ToneAnalyzerV3(WatsonService):
     """The Tone Analyzer V3 service."""
 
     default_url = 'https://gateway.watsonplatform.net/tone-analyzer/api'
-    latest_version = ''
 
     def __init__(self, version, url=default_url, username=None, password=None):
         """

--- a/watson_developer_cloud/visual_recognition_v3.py
+++ b/watson_developer_cloud/visual_recognition_v3.py
@@ -40,7 +40,7 @@ class VisualRecognitionV3(WatsonService):
     """The Visual Recognition V3 service."""
 
     default_url = 'https://gateway-a.watsonplatform.net/visual-recognition/api'
-    latest_version = '2016-05-20'
+    VERSION_DATE_2016_05_20 = '2016-05-20'
 
     def __init__(self, version, url=default_url, api_key=None):
         """


### PR DESCRIPTION
This PR removes the `latest_version` constant from each of the service files and replaces it with a list of named version dates.