### PR TITLE
Eliminate content-type parameters from LT create_model

### DIFF
--- a/watson_developer_cloud/language_translator_v2.py
+++ b/watson_developer_cloud/language_translator_v2.py
@@ -140,11 +140,8 @@ class LanguageTranslatorV2(WatsonService):
                      forced_glossary=None,
                      parallel_corpus=None,
                      monolingual_corpus=None,
-                     forced_glossary_content_type=None,
                      forced_glossary_filename=None,
-                     parallel_corpus_content_type=None,
                      parallel_corpus_filename=None,
-                     monolingual_corpus_content_type=None,
                      monolingual_corpus_filename=None):
         """
         Uploads a TMX glossary file on top of a domain to customize a translation model.
@@ -154,11 +151,8 @@ class LanguageTranslatorV2(WatsonService):
         :param file forced_glossary: A TMX file with your customizations. The customizations in the file completely overwrite the domain data translation, including high frequency or high confidence phrase translations. You can upload only one glossary with a file size less than 10 MB per call.
         :param file parallel_corpus: A TMX file that contains entries that are treated as a parallel corpus instead of a glossary.
         :param file monolingual_corpus: A UTF-8 encoded plain text file that is used to customize the target language model.
-        :param str forced_glossary_content_type: The content type of forced_glossary.
         :param str forced_glossary_filename: The filename for forced_glossary.
-        :param str parallel_corpus_content_type: The content type of parallel_corpus.
         :param str parallel_corpus_filename: The filename for parallel_corpus.
-        :param str monolingual_corpus_content_type: The content type of monolingual_corpus.
         :param str monolingual_corpus_filename: The filename for monolingual_corpus.
         :return: A `dict` containing the `TranslationModel` response.
         :rtype: dict
@@ -171,7 +165,7 @@ class LanguageTranslatorV2(WatsonService):
             if not forced_glossary_filename and hasattr(forced_glossary,
                                                         'name'):
                 forced_glossary_filename = forced_glossary.name
-            mime_type = forced_glossary_content_type or 'application/octet-stream'
+            mime_type = 'application/octet-stream'
             forced_glossary_tuple = (forced_glossary_filename, forced_glossary,
                                      mime_type)
         parallel_corpus_tuple = None
@@ -179,7 +173,7 @@ class LanguageTranslatorV2(WatsonService):
             if not parallel_corpus_filename and hasattr(parallel_corpus,
                                                         'name'):
                 parallel_corpus_filename = parallel_corpus.name
-            mime_type = parallel_corpus_content_type or 'application/octet-stream'
+            mime_type = 'application/octet-stream'
             parallel_corpus_tuple = (parallel_corpus_filename, parallel_corpus,
                                      mime_type)
         monolingual_corpus_tuple = None
@@ -187,7 +181,7 @@ class LanguageTranslatorV2(WatsonService):
             if not monolingual_corpus_filename and hasattr(
                     monolingual_corpus, 'name'):
                 monolingual_corpus_filename = monolingual_corpus.name
-            mime_type = monolingual_corpus_content_type or 'application/octet-stream'
+            mime_type = 'text/plain'
             monolingual_corpus_tuple = (monolingual_corpus_filename,
                                         monolingual_corpus, mime_type)
         response = self.request(

--- a/watson_developer_cloud/natural_language_classifier_v1.py
+++ b/watson_developer_cloud/natural_language_classifier_v1.py
@@ -96,7 +96,7 @@ class NaturalLanguageClassifierV1(WatsonService):
     def create_classifier(self,
                           metadata,
                           training_data,
-                          training_metadata_filename=None,
+                          metadata_filename=None,
                           training_data_filename=None):
         """
         Create classifier.
@@ -106,7 +106,7 @@ class NaturalLanguageClassifierV1(WatsonService):
 
         :param file metadata: Metadata in JSON format. The metadata identifies the language of the data, and an optional name to identify the classifier. For details, see the [API reference](https://www.ibm.com/watson/developercloud/natural-language-classifier/api/v1/#create_classifier).
         :param file training_data: Training data in CSV format. Each text value must have at least one class. The data can include up to 15,000 records. For details, see [Using your own data](https://www.ibm.com/watson/developercloud/doc/natural-language-classifier/using-your-data.html).
-        :param str training_metadata_filename: The filename for training_metadata.
+        :param str metadata_filename: The filename for training_metadata.
         :param str training_data_filename: The filename for training_data.
         :return: A `dict` containing the `Classifier` response.
         :rtype: dict
@@ -115,10 +115,10 @@ class NaturalLanguageClassifierV1(WatsonService):
             raise ValueError('metadata must be provided')
         if training_data is None:
             raise ValueError('training_data must be provided')
-        if not training_metadata_filename and hasattr(metadata, 'name'):
-            training_metadata_filename = metadata.name
+        if not metadata_filename and hasattr(metadata, 'name'):
+            metadata_filename = metadata.name
         mime_type = 'application/octet-stream'
-        metadata_tuple = (training_metadata_filename, metadata, mime_type)
+        metadata_tuple = (metadata_filename, metadata, mime_type)
         if not training_data_filename and hasattr(training_data, 'name'):
             training_data_filename = training_data.name
         mime_type = 'application/octet-stream'


### PR DESCRIPTION
The content-type parameters on create_model are not needed since each of these parameters allow only one content type.