### PR TITLE
Add convert_model helper function and use this in generated code

### DIFF
--- a/watson_developer_cloud/conversation_v1.py
+++ b/watson_developer_cloud/conversation_v1.py
@@ -114,23 +114,13 @@ class ConversationV1(WatsonService):
         :rtype: dict
         """
         if intents is not None:
-            intents = [
-                x._to_dict() if hasattr(x, "_to_dict") else x for x in intents
-            ]
+            intents = [self._convert_model(x) for x in intents]
         if entities is not None:
-            entities = [
-                x._to_dict() if hasattr(x, "_to_dict") else x for x in entities
-            ]
+            entities = [self._convert_model(x) for x in entities]
         if dialog_nodes is not None:
-            dialog_nodes = [
-                x._to_dict() if hasattr(x, "_to_dict") else x
-                for x in dialog_nodes
-            ]
+            dialog_nodes = [self._convert_model(x) for x in dialog_nodes]
         if counterexamples is not None:
-            counterexamples = [
-                x._to_dict() if hasattr(x, "_to_dict") else x
-                for x in counterexamples
-            ]
+            counterexamples = [self._convert_model(x) for x in counterexamples]
         params = {'version': self.version}
         data = {
             'name': name,
@@ -252,23 +242,13 @@ class ConversationV1(WatsonService):
         if workspace_id is None:
             raise ValueError('workspace_id must be provided')
         if intents is not None:
-            intents = [
-                x._to_dict() if hasattr(x, "_to_dict") else x for x in intents
-            ]
+            intents = [self._convert_model(x) for x in intents]
         if entities is not None:
-            entities = [
-                x._to_dict() if hasattr(x, "_to_dict") else x for x in entities
-            ]
+            entities = [self._convert_model(x) for x in entities]
         if dialog_nodes is not None:
-            dialog_nodes = [
-                x._to_dict() if hasattr(x, "_to_dict") else x
-                for x in dialog_nodes
-            ]
+            dialog_nodes = [self._convert_model(x) for x in dialog_nodes]
         if counterexamples is not None:
-            counterexamples = [
-                x._to_dict() if hasattr(x, "_to_dict") else x
-                for x in counterexamples
-            ]
+            counterexamples = [self._convert_model(x) for x in counterexamples]
         params = {'version': self.version}
         data = {
             'name': name,
@@ -317,21 +297,15 @@ class ConversationV1(WatsonService):
         if workspace_id is None:
             raise ValueError('workspace_id must be provided')
         if input is not None:
-            input = input._to_dict() if hasattr(input, '_to_dict') else input
+            input = self._convert_model(input)
         if context is not None:
-            context = context._to_dict() if hasattr(context,
-                                                    '_to_dict') else context
+            context = self._convert_model(context)
         if entities is not None:
-            entities = [
-                x._to_dict() if hasattr(x, "_to_dict") else x for x in entities
-            ]
+            entities = [self._convert_model(x) for x in entities]
         if intents is not None:
-            intents = [
-                x._to_dict() if hasattr(x, "_to_dict") else x for x in intents
-            ]
+            intents = [self._convert_model(x) for x in intents]
         if output is not None:
-            output = output._to_dict() if hasattr(output,
-                                                  '_to_dict') else output
+            output = self._convert_model(output)
         params = {'version': self.version}
         data = {
             'input': input,
@@ -375,9 +349,7 @@ class ConversationV1(WatsonService):
         if intent is None:
             raise ValueError('intent must be provided')
         if examples is not None:
-            examples = [
-                x._to_dict() if hasattr(x, "_to_dict") else x for x in examples
-            ]
+            examples = [self._convert_model(x) for x in examples]
         params = {'version': self.version}
         data = {
             'intent': intent,
@@ -501,10 +473,7 @@ class ConversationV1(WatsonService):
         if intent is None:
             raise ValueError('intent must be provided')
         if new_examples is not None:
-            new_examples = [
-                x._to_dict() if hasattr(x, "_to_dict") else x
-                for x in new_examples
-            ]
+            new_examples = [self._convert_model(x) for x in new_examples]
         params = {'version': self.version}
         data = {
             'intent': new_intent,
@@ -705,9 +674,7 @@ class ConversationV1(WatsonService):
         if entity is None:
             raise ValueError('entity must be provided')
         if values is not None:
-            values = [
-                x._to_dict() if hasattr(x, "_to_dict") else x for x in values
-            ]
+            values = [self._convert_model(x) for x in values]
         params = {'version': self.version}
         data = {
             'entity': entity,
@@ -836,10 +803,7 @@ class ConversationV1(WatsonService):
         if entity is None:
             raise ValueError('entity must be provided')
         if new_values is not None:
-            new_values = [
-                x._to_dict() if hasattr(x, "_to_dict") else x
-                for x in new_values
-            ]
+            new_values = [self._convert_model(x) for x in new_values]
         params = {'version': self.version}
         data = {
             'entity': new_entity,
@@ -1276,12 +1240,9 @@ class ConversationV1(WatsonService):
         if dialog_node is None:
             raise ValueError('dialog_node must be provided')
         if next_step is not None:
-            next_step = next_step._to_dict() if hasattr(
-                next_step, '_to_dict') else next_step
+            next_step = self._convert_model(next_step)
         if actions is not None:
-            actions = [
-                x._to_dict() if hasattr(x, "_to_dict") else x for x in actions
-            ]
+            actions = [self._convert_model(x) for x in actions]
         params = {'version': self.version}
         data = {
             'dialog_node': dialog_node,
@@ -1437,13 +1398,9 @@ class ConversationV1(WatsonService):
         if new_dialog_node is None:
             raise ValueError('new_dialog_node must be provided')
         if new_next_step is not None:
-            new_next_step = new_next_step._to_dict() if hasattr(
-                new_next_step, '_to_dict') else new_next_step
+            new_next_step = self._convert_model(new_next_step)
         if new_actions is not None:
-            new_actions = [
-                x._to_dict() if hasattr(x, "_to_dict") else x
-                for x in new_actions
-            ]
+            new_actions = [self._convert_model(x) for x in new_actions]
         params = {'version': self.version}
         data = {
             'dialog_node': new_dialog_node,

--- a/watson_developer_cloud/discovery_v1.py
+++ b/watson_developer_cloud/discovery_v1.py
@@ -258,18 +258,11 @@ class DiscoveryV1(WatsonService):
         if name is None:
             raise ValueError('name must be provided')
         if conversions is not None:
-            conversions = conversions._to_dict() if hasattr(
-                conversions, '_to_dict') else conversions
+            conversions = self._convert_model(conversions)
         if enrichments is not None:
-            enrichments = [
-                x._to_dict() if hasattr(x, "_to_dict") else x
-                for x in enrichments
-            ]
+            enrichments = [self._convert_model(x) for x in enrichments]
         if normalizations is not None:
-            normalizations = [
-                x._to_dict() if hasattr(x, "_to_dict") else x
-                for x in normalizations
-            ]
+            normalizations = [self._convert_model(x) for x in normalizations]
         params = {'version': self.version}
         data = {
             'name': name,
@@ -394,18 +387,11 @@ class DiscoveryV1(WatsonService):
         if name is None:
             raise ValueError('name must be provided')
         if conversions is not None:
-            conversions = conversions._to_dict() if hasattr(
-                conversions, '_to_dict') else conversions
+            conversions = self._convert_model(conversions)
         if enrichments is not None:
-            enrichments = [
-                x._to_dict() if hasattr(x, "_to_dict") else x
-                for x in enrichments
-            ]
+            enrichments = [self._convert_model(x) for x in enrichments]
         if normalizations is not None:
-            normalizations = [
-                x._to_dict() if hasattr(x, "_to_dict") else x
-                for x in normalizations
-            ]
+            normalizations = [self._convert_model(x) for x in normalizations]
         params = {'version': self.version}
         data = {
             'name': name,
@@ -1195,9 +1181,7 @@ class DiscoveryV1(WatsonService):
         if collection_id is None:
             raise ValueError('collection_id must be provided')
         if examples is not None:
-            examples = [
-                x._to_dict() if hasattr(x, "_to_dict") else x for x in examples
-            ]
+            examples = [self._convert_model(x) for x in examples]
         params = {'version': self.version}
         data = {
             'natural_language_query': natural_language_query,
@@ -1402,6 +1386,32 @@ class DiscoveryV1(WatsonService):
             method='GET',
             url='/v1/environments/{0}/collections/{1}/training_data'.format(
                 environment_id, collection_id),
+            params=params,
+            accept_json=True)
+        return response
+
+    def list_training_examples(self, environment_id, collection_id, query_id):
+        """
+        List all examples for this training data query.
+
+        :param str environment_id: The ID of the environment.
+        :param str collection_id: The ID of the collection.
+        :param str query_id: The ID of the query used for training.
+        :return: A `dict` containing the `TrainingExampleList` response.
+        :rtype: dict
+        """
+        if environment_id is None:
+            raise ValueError('environment_id must be provided')
+        if collection_id is None:
+            raise ValueError('collection_id must be provided')
+        if query_id is None:
+            raise ValueError('query_id must be provided')
+        params = {'version': self.version}
+        response = self.request(
+            method='GET',
+            url=
+            '/v1/environments/{0}/collections/{1}/training_data/{2}/examples'.
+            format(environment_id, collection_id, query_id),
             params=params,
             accept_json=True)
         return response
@@ -4445,6 +4455,53 @@ class TrainingExample(object):
 
     def __str__(self):
         """Return a `str` version of this TrainingExample object."""
+        return json.dumps(self._to_dict(), indent=2)
+
+    def __eq__(self, other):
+        """Return `true` when self and other are equal, false otherwise."""
+        if not isinstance(other, self.__class__):
+            return False
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        """Return `true` when self and other are not equal, false otherwise."""
+        return not self == other
+
+
+class TrainingExampleList(object):
+    """
+    TrainingExampleList.
+
+    :attr list[TrainingExample] examples: (optional)
+    """
+
+    def __init__(self, examples=None):
+        """
+        Initialize a TrainingExampleList object.
+
+        :param list[TrainingExample] examples: (optional)
+        """
+        self.examples = examples
+
+    @classmethod
+    def _from_dict(cls, _dict):
+        """Initialize a TrainingExampleList object from a json dictionary."""
+        args = {}
+        if 'examples' in _dict:
+            args['examples'] = [
+                TrainingExample._from_dict(x) for x in _dict['examples']
+            ]
+        return cls(**args)
+
+    def _to_dict(self):
+        """Return a json dictionary representing this model."""
+        _dict = {}
+        if hasattr(self, 'examples') and self.examples is not None:
+            _dict['examples'] = [x._to_dict() for x in self.examples]
+        return _dict
+
+    def __str__(self):
+        """Return a `str` version of this TrainingExampleList object."""
         return json.dumps(self._to_dict(), indent=2)
 
     def __eq__(self, other):

--- a/watson_developer_cloud/natural_language_classifier_v1.py
+++ b/watson_developer_cloud/natural_language_classifier_v1.py
@@ -14,10 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """
-The The IBM Watson Natural Language Classifier service uses machine learning algorithms to
-return the top matching predefined classes for short text input. You create and train a
-classifier to connect predefined classes to example texts so that the service can apply
-those classes to new inputs.
+IBM Watson Natural Language Classifier uses machine learning algorithms to return the top
+matching predefined classes for short text input. You create and train a classifier to
+connect predefined classes to example texts so that the service can apply those classes to
+new inputs.
 """
 
 from __future__ import absolute_import
@@ -117,11 +117,11 @@ class NaturalLanguageClassifierV1(WatsonService):
             raise ValueError('training_data must be provided')
         if not metadata_filename and hasattr(metadata, 'name'):
             metadata_filename = metadata.name
-        mime_type = 'application/octet-stream'
+        mime_type = 'application/json'
         metadata_tuple = (metadata_filename, metadata, mime_type)
         if not training_data_filename and hasattr(training_data, 'name'):
             training_data_filename = training_data.name
-        mime_type = 'application/octet-stream'
+        mime_type = 'text/csv'
         training_data_tuple = (training_data_filename, training_data, mime_type)
         response = self.request(
             method='POST',

--- a/watson_developer_cloud/natural_language_understanding_v1.py
+++ b/watson_developer_cloud/natural_language_understanding_v1.py
@@ -155,8 +155,7 @@ class NaturalLanguageUnderstandingV1(WatsonService):
         """
         if features is None:
             raise ValueError('features must be provided')
-        features = features._to_dict() if hasattr(features,
-                                                  '_to_dict') else features
+        features = self._convert_model(features)
         params = {'version': self.version}
         data = {
             'features': features,

--- a/watson_developer_cloud/tone_analyzer_v3.py
+++ b/watson_developer_cloud/tone_analyzer_v3.py
@@ -197,9 +197,7 @@ class ToneAnalyzerV3(WatsonService):
         """
         if utterances is None:
             raise ValueError('utterances must be provided')
-        utterances = [
-            x._to_dict() if hasattr(x, "_to_dict") else x for x in utterances
-        ]
+        utterances = [self._convert_model(x) for x in utterances]
         headers = {'Accept-Language': accept_language}
         params = {'version': self.version}
         data = {'utterances': utterances}

--- a/watson_developer_cloud/watson_service.py
+++ b/watson_developer_cloud/watson_service.py
@@ -183,6 +183,12 @@ class WatsonService(object):
         return dictionary
 
     @staticmethod
+    def _convert_model(val):
+        if hasattr(val, "_to_dict"):
+            return val._to_dict()
+        return val
+
+    @staticmethod
     def _get_error_message(response):
         """
         Gets the error message from a JSON response.


### PR DESCRIPTION
This PR adds a `_convert_model` helper function that is intended for use in converting models passed as input parameters to dicts for subsequent processing.  This change was suggested by @jsstylos in [this PR comment](https://github.com/watson-developer-cloud/python-sdk/pull/286#pullrequestreview-72328000).

This PR also adds the `list_training_examples` method in the Discovery service because swagger changes now make it possible to generate this method.