### PR TITLE
Fix unicode error in examples tests

### DIFF
--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -52,7 +52,7 @@ def test_examples():
 
         try:
             service_file = open(example).read()
-            exec(re.sub('# coding=utf-8', '', service_file), globals())
+            exec(re.sub('# coding[:=]\s*utf-8', '', service_file), globals())
         except Exception as e:
             assert False, 'example in file ' + name + ' failed with error: '\
                           + str(e) + '\n' + traceback.format_exc()


### PR DESCRIPTION
This PR fixes #295 by making the re.sub pattern in `test_examples.py` more flexible so that is handles either `# coding=utf-8` or `# coding: utf-8`, both of which are valid according to [PEP 263](https://www.python.org/dev/peps/pep-0263/).