### PR TITLE
Store datetime properties as Python datetime objects in models 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ requests>=2.0,<3.0
 pysolr>=3.3,<4.0
 argparse>=1.3.0
 pyOpenSSL>=16.2.0
+python_dateutil >= 2.5.3

--- a/watson_developer_cloud/conversation_v1.py
+++ b/watson_developer_cloud/conversation_v1.py
@@ -22,6 +22,7 @@ and your users.
 from __future__ import absolute_import
 
 import json
+from .watson_service import datetime_to_string, string_to_datetime
 from .watson_service import WatsonService
 
 ##############################################################################
@@ -1727,13 +1728,13 @@ class Counterexample(object):
             raise ValueError(
                 'Required property \'text\' not present in Counterexample JSON')
         if 'created' in _dict:
-            args['created'] = _dict['created']
+            args['created'] = string_to_datetime(_dict['created'])
         else:
             raise ValueError(
                 'Required property \'created\' not present in Counterexample JSON'
             )
         if 'updated' in _dict:
-            args['updated'] = _dict['updated']
+            args['updated'] = string_to_datetime(_dict['updated'])
         else:
             raise ValueError(
                 'Required property \'updated\' not present in Counterexample JSON'
@@ -1746,9 +1747,9 @@ class Counterexample(object):
         if hasattr(self, 'text') and self.text is not None:
             _dict['text'] = self.text
         if hasattr(self, 'created') and self.created is not None:
-            _dict['created'] = self.created
+            _dict['created'] = datetime_to_string(self.created)
         if hasattr(self, 'updated') and self.updated is not None:
-            _dict['updated'] = self.updated
+            _dict['updated'] = datetime_to_string(self.updated)
         return _dict
 
     def __str__(self):
@@ -2446,12 +2447,12 @@ class DialogNode(object):
                 'Required property \'next_step\' not present in DialogNode JSON'
             )
         if 'created' in _dict:
-            args['created'] = _dict['created']
+            args['created'] = string_to_datetime(_dict['created'])
         else:
             raise ValueError(
                 'Required property \'created\' not present in DialogNode JSON')
         if 'updated' in _dict:
-            args['updated'] = _dict['updated']
+            args['updated'] = string_to_datetime(_dict['updated'])
         if 'actions' in _dict:
             args['actions'] = [
                 DialogNodeAction._from_dict(x) for x in _dict['actions']
@@ -2492,9 +2493,9 @@ class DialogNode(object):
         if hasattr(self, 'next_step') and self.next_step is not None:
             _dict['next_step'] = self.next_step._to_dict()
         if hasattr(self, 'created') and self.created is not None:
-            _dict['created'] = self.created
+            _dict['created'] = datetime_to_string(self.created)
         if hasattr(self, 'updated') and self.updated is not None:
-            _dict['updated'] = self.updated
+            _dict['updated'] = datetime_to_string(self.updated)
         if hasattr(self, 'actions') and self.actions is not None:
             _dict['actions'] = [x._to_dict() for x in self.actions]
         if hasattr(self, 'title') and self.title is not None:
@@ -2780,12 +2781,12 @@ class Entity(object):
             raise ValueError(
                 'Required property \'entity\' not present in Entity JSON')
         if 'created' in _dict:
-            args['created'] = _dict['created']
+            args['created'] = string_to_datetime(_dict['created'])
         else:
             raise ValueError(
                 'Required property \'created\' not present in Entity JSON')
         if 'updated' in _dict:
-            args['updated'] = _dict['updated']
+            args['updated'] = string_to_datetime(_dict['updated'])
         else:
             raise ValueError(
                 'Required property \'updated\' not present in Entity JSON')
@@ -2803,9 +2804,9 @@ class Entity(object):
         if hasattr(self, 'entity_name') and self.entity_name is not None:
             _dict['entity'] = self.entity_name
         if hasattr(self, 'created') and self.created is not None:
-            _dict['created'] = self.created
+            _dict['created'] = datetime_to_string(self.created)
         if hasattr(self, 'updated') and self.updated is not None:
-            _dict['updated'] = self.updated
+            _dict['updated'] = datetime_to_string(self.updated)
         if hasattr(self, 'description') and self.description is not None:
             _dict['description'] = self.description
         if hasattr(self, 'metadata') and self.metadata is not None:
@@ -2941,13 +2942,13 @@ class EntityExport(object):
             raise ValueError(
                 'Required property \'entity\' not present in EntityExport JSON')
         if 'created' in _dict:
-            args['created'] = _dict['created']
+            args['created'] = string_to_datetime(_dict['created'])
         else:
             raise ValueError(
                 'Required property \'created\' not present in EntityExport JSON'
             )
         if 'updated' in _dict:
-            args['updated'] = _dict['updated']
+            args['updated'] = string_to_datetime(_dict['updated'])
         else:
             raise ValueError(
                 'Required property \'updated\' not present in EntityExport JSON'
@@ -2970,9 +2971,9 @@ class EntityExport(object):
         if hasattr(self, 'entity_name') and self.entity_name is not None:
             _dict['entity'] = self.entity_name
         if hasattr(self, 'created') and self.created is not None:
-            _dict['created'] = self.created
+            _dict['created'] = datetime_to_string(self.created)
         if hasattr(self, 'updated') and self.updated is not None:
-            _dict['updated'] = self.updated
+            _dict['updated'] = datetime_to_string(self.updated)
         if hasattr(self, 'description') and self.description is not None:
             _dict['description'] = self.description
         if hasattr(self, 'metadata') and self.metadata is not None:
@@ -3029,12 +3030,12 @@ class Example(object):
             raise ValueError(
                 'Required property \'text\' not present in Example JSON')
         if 'created' in _dict:
-            args['created'] = _dict['created']
+            args['created'] = string_to_datetime(_dict['created'])
         else:
             raise ValueError(
                 'Required property \'created\' not present in Example JSON')
         if 'updated' in _dict:
-            args['updated'] = _dict['updated']
+            args['updated'] = string_to_datetime(_dict['updated'])
         else:
             raise ValueError(
                 'Required property \'updated\' not present in Example JSON')
@@ -3046,9 +3047,9 @@ class Example(object):
         if hasattr(self, 'example_text') and self.example_text is not None:
             _dict['text'] = self.example_text
         if hasattr(self, 'created') and self.created is not None:
-            _dict['created'] = self.created
+            _dict['created'] = datetime_to_string(self.created)
         if hasattr(self, 'updated') and self.updated is not None:
-            _dict['updated'] = self.updated
+            _dict['updated'] = datetime_to_string(self.updated)
         return _dict
 
     def __str__(self):
@@ -3210,12 +3211,12 @@ class Intent(object):
             raise ValueError(
                 'Required property \'intent\' not present in Intent JSON')
         if 'created' in _dict:
-            args['created'] = _dict['created']
+            args['created'] = string_to_datetime(_dict['created'])
         else:
             raise ValueError(
                 'Required property \'created\' not present in Intent JSON')
         if 'updated' in _dict:
-            args['updated'] = _dict['updated']
+            args['updated'] = string_to_datetime(_dict['updated'])
         else:
             raise ValueError(
                 'Required property \'updated\' not present in Intent JSON')
@@ -3229,9 +3230,9 @@ class Intent(object):
         if hasattr(self, 'intent_name') and self.intent_name is not None:
             _dict['intent'] = self.intent_name
         if hasattr(self, 'created') and self.created is not None:
-            _dict['created'] = self.created
+            _dict['created'] = datetime_to_string(self.created)
         if hasattr(self, 'updated') and self.updated is not None:
-            _dict['updated'] = self.updated
+            _dict['updated'] = datetime_to_string(self.updated)
         if hasattr(self, 'description') and self.description is not None:
             _dict['description'] = self.description
         return _dict
@@ -3355,13 +3356,13 @@ class IntentExport(object):
             raise ValueError(
                 'Required property \'intent\' not present in IntentExport JSON')
         if 'created' in _dict:
-            args['created'] = _dict['created']
+            args['created'] = string_to_datetime(_dict['created'])
         else:
             raise ValueError(
                 'Required property \'created\' not present in IntentExport JSON'
             )
         if 'updated' in _dict:
-            args['updated'] = _dict['updated']
+            args['updated'] = string_to_datetime(_dict['updated'])
         else:
             raise ValueError(
                 'Required property \'updated\' not present in IntentExport JSON'
@@ -3380,9 +3381,9 @@ class IntentExport(object):
         if hasattr(self, 'intent_name') and self.intent_name is not None:
             _dict['intent'] = self.intent_name
         if hasattr(self, 'created') and self.created is not None:
-            _dict['created'] = self.created
+            _dict['created'] = datetime_to_string(self.created)
         if hasattr(self, 'updated') and self.updated is not None:
-            _dict['updated'] = self.updated
+            _dict['updated'] = datetime_to_string(self.updated)
         if hasattr(self, 'description') and self.description is not None:
             _dict['description'] = self.description
         if hasattr(self, 'examples') and self.examples is not None:
@@ -4366,12 +4367,12 @@ class Synonym(object):
             raise ValueError(
                 'Required property \'synonym\' not present in Synonym JSON')
         if 'created' in _dict:
-            args['created'] = _dict['created']
+            args['created'] = string_to_datetime(_dict['created'])
         else:
             raise ValueError(
                 'Required property \'created\' not present in Synonym JSON')
         if 'updated' in _dict:
-            args['updated'] = _dict['updated']
+            args['updated'] = string_to_datetime(_dict['updated'])
         else:
             raise ValueError(
                 'Required property \'updated\' not present in Synonym JSON')
@@ -4383,9 +4384,9 @@ class Synonym(object):
         if hasattr(self, 'synonym_text') and self.synonym_text is not None:
             _dict['synonym'] = self.synonym_text
         if hasattr(self, 'created') and self.created is not None:
-            _dict['created'] = self.created
+            _dict['created'] = datetime_to_string(self.created)
         if hasattr(self, 'updated') and self.updated is not None:
-            _dict['updated'] = self.updated
+            _dict['updated'] = datetime_to_string(self.updated)
         return _dict
 
     def __str__(self):
@@ -4574,12 +4575,12 @@ class Value(object):
         if 'metadata' in _dict:
             args['metadata'] = _dict['metadata']
         if 'created' in _dict:
-            args['created'] = _dict['created']
+            args['created'] = string_to_datetime(_dict['created'])
         else:
             raise ValueError(
                 'Required property \'created\' not present in Value JSON')
         if 'updated' in _dict:
-            args['updated'] = _dict['updated']
+            args['updated'] = string_to_datetime(_dict['updated'])
         else:
             raise ValueError(
                 'Required property \'updated\' not present in Value JSON')
@@ -4602,9 +4603,9 @@ class Value(object):
         if hasattr(self, 'metadata') and self.metadata is not None:
             _dict['metadata'] = self.metadata
         if hasattr(self, 'created') and self.created is not None:
-            _dict['created'] = self.created
+            _dict['created'] = datetime_to_string(self.created)
         if hasattr(self, 'updated') and self.updated is not None:
-            _dict['updated'] = self.updated
+            _dict['updated'] = datetime_to_string(self.updated)
         if hasattr(self, 'synonyms') and self.synonyms is not None:
             _dict['synonyms'] = self.synonyms
         if hasattr(self, 'patterns') and self.patterns is not None:
@@ -4742,12 +4743,12 @@ class ValueExport(object):
         if 'metadata' in _dict:
             args['metadata'] = _dict['metadata']
         if 'created' in _dict:
-            args['created'] = _dict['created']
+            args['created'] = string_to_datetime(_dict['created'])
         else:
             raise ValueError(
                 'Required property \'created\' not present in ValueExport JSON')
         if 'updated' in _dict:
-            args['updated'] = _dict['updated']
+            args['updated'] = string_to_datetime(_dict['updated'])
         else:
             raise ValueError(
                 'Required property \'updated\' not present in ValueExport JSON')
@@ -4770,9 +4771,9 @@ class ValueExport(object):
         if hasattr(self, 'metadata') and self.metadata is not None:
             _dict['metadata'] = self.metadata
         if hasattr(self, 'created') and self.created is not None:
-            _dict['created'] = self.created
+            _dict['created'] = datetime_to_string(self.created)
         if hasattr(self, 'updated') and self.updated is not None:
-            _dict['updated'] = self.updated
+            _dict['updated'] = datetime_to_string(self.updated)
         if hasattr(self, 'synonyms') and self.synonyms is not None:
             _dict['synonyms'] = self.synonyms
         if hasattr(self, 'patterns') and self.patterns is not None:
@@ -4855,12 +4856,12 @@ class Workspace(object):
             raise ValueError(
                 'Required property \'language\' not present in Workspace JSON')
         if 'created' in _dict:
-            args['created'] = _dict['created']
+            args['created'] = string_to_datetime(_dict['created'])
         else:
             raise ValueError(
                 'Required property \'created\' not present in Workspace JSON')
         if 'updated' in _dict:
-            args['updated'] = _dict['updated']
+            args['updated'] = string_to_datetime(_dict['updated'])
         else:
             raise ValueError(
                 'Required property \'updated\' not present in Workspace JSON')
@@ -4886,9 +4887,9 @@ class Workspace(object):
         if hasattr(self, 'language') and self.language is not None:
             _dict['language'] = self.language
         if hasattr(self, 'created') and self.created is not None:
-            _dict['created'] = self.created
+            _dict['created'] = datetime_to_string(self.created)
         if hasattr(self, 'updated') and self.updated is not None:
-            _dict['updated'] = self.updated
+            _dict['updated'] = datetime_to_string(self.updated)
         if hasattr(self, 'workspace_id') and self.workspace_id is not None:
             _dict['workspace_id'] = self.workspace_id
         if hasattr(self, 'description') and self.description is not None:
@@ -5070,13 +5071,13 @@ class WorkspaceExport(object):
                 'Required property \'metadata\' not present in WorkspaceExport JSON'
             )
         if 'created' in _dict:
-            args['created'] = _dict['created']
+            args['created'] = string_to_datetime(_dict['created'])
         else:
             raise ValueError(
                 'Required property \'created\' not present in WorkspaceExport JSON'
             )
         if 'updated' in _dict:
-            args['updated'] = _dict['updated']
+            args['updated'] = string_to_datetime(_dict['updated'])
         else:
             raise ValueError(
                 'Required property \'updated\' not present in WorkspaceExport JSON'
@@ -5129,9 +5130,9 @@ class WorkspaceExport(object):
         if hasattr(self, 'metadata') and self.metadata is not None:
             _dict['metadata'] = self.metadata
         if hasattr(self, 'created') and self.created is not None:
-            _dict['created'] = self.created
+            _dict['created'] = datetime_to_string(self.created)
         if hasattr(self, 'updated') and self.updated is not None:
-            _dict['updated'] = self.updated
+            _dict['updated'] = datetime_to_string(self.updated)
         if hasattr(self, 'workspace_id') and self.workspace_id is not None:
             _dict['workspace_id'] = self.workspace_id
         if hasattr(self, 'status') and self.status is not None:

--- a/watson_developer_cloud/discovery_v1.py
+++ b/watson_developer_cloud/discovery_v1.py
@@ -24,6 +24,7 @@ results.
 from __future__ import absolute_import
 
 import json
+from .watson_service import datetime_to_string, string_to_datetime
 from .watson_service import WatsonService
 
 ##############################################################################
@@ -1590,9 +1591,9 @@ class Collection(object):
         if 'description' in _dict:
             args['description'] = _dict['description']
         if 'created' in _dict:
-            args['created'] = _dict['created']
+            args['created'] = string_to_datetime(_dict['created'])
         if 'updated' in _dict:
-            args['updated'] = _dict['updated']
+            args['updated'] = string_to_datetime(_dict['updated'])
         if 'status' in _dict:
             args['status'] = _dict['status']
         if 'configuration_id' in _dict:
@@ -1620,9 +1621,9 @@ class Collection(object):
         if hasattr(self, 'description') and self.description is not None:
             _dict['description'] = self.description
         if hasattr(self, 'created') and self.created is not None:
-            _dict['created'] = self.created
+            _dict['created'] = datetime_to_string(self.created)
         if hasattr(self, 'updated') and self.updated is not None:
-            _dict['updated'] = self.updated
+            _dict['updated'] = datetime_to_string(self.updated)
         if hasattr(self, 'status') and self.status is not None:
             _dict['status'] = self.status
         if hasattr(self,
@@ -1756,9 +1757,9 @@ class Configuration(object):
             raise ValueError(
                 'Required property \'name\' not present in Configuration JSON')
         if 'created' in _dict:
-            args['created'] = _dict['created']
+            args['created'] = string_to_datetime(_dict['created'])
         if 'updated' in _dict:
-            args['updated'] = _dict['updated']
+            args['updated'] = string_to_datetime(_dict['updated'])
         if 'description' in _dict:
             args['description'] = _dict['description']
         if 'conversions' in _dict:
@@ -1783,9 +1784,9 @@ class Configuration(object):
         if hasattr(self, 'name') and self.name is not None:
             _dict['name'] = self.name
         if hasattr(self, 'created') and self.created is not None:
-            _dict['created'] = self.created
+            _dict['created'] = datetime_to_string(self.created)
         if hasattr(self, 'updated') and self.updated is not None:
-            _dict['updated'] = self.updated
+            _dict['updated'] = datetime_to_string(self.updated)
         if hasattr(self, 'description') and self.description is not None:
             _dict['description'] = self.description
         if hasattr(self, 'conversions') and self.conversions is not None:
@@ -2453,13 +2454,13 @@ class DocumentStatus(object):
                 'Required property \'configuration_id\' not present in DocumentStatus JSON'
             )
         if 'created' in _dict:
-            args['created'] = _dict['created']
+            args['created'] = string_to_datetime(_dict['created'])
         else:
             raise ValueError(
                 'Required property \'created\' not present in DocumentStatus JSON'
             )
         if 'updated' in _dict:
-            args['updated'] = _dict['updated']
+            args['updated'] = string_to_datetime(_dict['updated'])
         else:
             raise ValueError(
                 'Required property \'updated\' not present in DocumentStatus JSON'
@@ -2499,9 +2500,9 @@ class DocumentStatus(object):
                    'configuration_id') and self.configuration_id is not None:
             _dict['configuration_id'] = self.configuration_id
         if hasattr(self, 'created') and self.created is not None:
-            _dict['created'] = self.created
+            _dict['created'] = datetime_to_string(self.created)
         if hasattr(self, 'updated') and self.updated is not None:
-            _dict['updated'] = self.updated
+            _dict['updated'] = datetime_to_string(self.updated)
         if hasattr(self, 'status') and self.status is not None:
             _dict['status'] = self.status
         if hasattr(
@@ -2799,9 +2800,9 @@ class Environment(object):
         if 'description' in _dict:
             args['description'] = _dict['description']
         if 'created' in _dict:
-            args['created'] = _dict['created']
+            args['created'] = string_to_datetime(_dict['created'])
         if 'updated' in _dict:
-            args['updated'] = _dict['updated']
+            args['updated'] = string_to_datetime(_dict['updated'])
         if 'status' in _dict:
             args['status'] = _dict['status']
         if 'read_only' in _dict:
@@ -2823,9 +2824,9 @@ class Environment(object):
         if hasattr(self, 'description') and self.description is not None:
             _dict['description'] = self.description
         if hasattr(self, 'created') and self.created is not None:
-            _dict['created'] = self.created
+            _dict['created'] = datetime_to_string(self.created)
         if hasattr(self, 'updated') and self.updated is not None:
-            _dict['updated'] = self.updated
+            _dict['updated'] = datetime_to_string(self.updated)
         if hasattr(self, 'status') and self.status is not None:
             _dict['status'] = self.status
         if hasattr(self, 'read_only') and self.read_only is not None:
@@ -3580,7 +3581,7 @@ class Notice(object):
         if 'notice_id' in _dict:
             args['notice_id'] = _dict['notice_id']
         if 'created' in _dict:
-            args['created'] = _dict['created']
+            args['created'] = string_to_datetime(_dict['created'])
         if 'document_id' in _dict:
             args['document_id'] = _dict['document_id']
         if 'query_id' in _dict:
@@ -3599,7 +3600,7 @@ class Notice(object):
         if hasattr(self, 'notice_id') and self.notice_id is not None:
             _dict['notice_id'] = self.notice_id
         if hasattr(self, 'created') and self.created is not None:
-            _dict['created'] = self.created
+            _dict['created'] = datetime_to_string(self.created)
         if hasattr(self, 'document_id') and self.document_id is not None:
             _dict['document_id'] = self.document_id
         if hasattr(self, 'query_id') and self.query_id is not None:
@@ -4656,9 +4657,10 @@ class TrainingStatus(object):
         if 'notices' in _dict:
             args['notices'] = _dict['notices']
         if 'successfully_trained' in _dict:
-            args['successfully_trained'] = _dict['successfully_trained']
+            args['successfully_trained'] = string_to_datetime(
+                _dict['successfully_trained'])
         if 'data_updated' in _dict:
-            args['data_updated'] = _dict['data_updated']
+            args['data_updated'] = string_to_datetime(_dict['data_updated'])
         return cls(**args)
 
     def _to_dict(self):
@@ -4684,9 +4686,10 @@ class TrainingStatus(object):
             _dict['notices'] = self.notices
         if hasattr(self, 'successfully_trained'
                   ) and self.successfully_trained is not None:
-            _dict['successfully_trained'] = self.successfully_trained
+            _dict['successfully_trained'] = datetime_to_string(
+                self.successfully_trained)
         if hasattr(self, 'data_updated') and self.data_updated is not None:
-            _dict['data_updated'] = self.data_updated
+            _dict['data_updated'] = datetime_to_string(self.data_updated)
         return _dict
 
     def __str__(self):

--- a/watson_developer_cloud/natural_language_classifier_v1.py
+++ b/watson_developer_cloud/natural_language_classifier_v1.py
@@ -23,6 +23,7 @@ new inputs.
 from __future__ import absolute_import
 
 import json
+from .watson_service import datetime_to_string, string_to_datetime
 from .watson_service import WatsonService
 
 ##############################################################################
@@ -377,7 +378,7 @@ class Classifier(object):
                 'Required property \'classifier_id\' not present in Classifier JSON'
             )
         if 'created' in _dict:
-            args['created'] = _dict['created']
+            args['created'] = string_to_datetime(_dict['created'])
         if 'status_description' in _dict:
             args['status_description'] = _dict['status_description']
         if 'language' in _dict:
@@ -396,7 +397,7 @@ class Classifier(object):
         if hasattr(self, 'classifier_id') and self.classifier_id is not None:
             _dict['classifier_id'] = self.classifier_id
         if hasattr(self, 'created') and self.created is not None:
-            _dict['created'] = self.created
+            _dict['created'] = datetime_to_string(self.created)
         if hasattr(
                 self,
                 'status_description') and self.status_description is not None:

--- a/watson_developer_cloud/visual_recognition_v3.py
+++ b/watson_developer_cloud/visual_recognition_v3.py
@@ -29,6 +29,7 @@ provide your `api_key` from your Bluemix service instance.
 from __future__ import absolute_import
 
 import json
+from .watson_service import datetime_to_string, string_to_datetime
 from .watson_service import WatsonService
 
 ##############################################################################
@@ -460,19 +461,26 @@ class ClassifiedImages(object):
     """
     Classify results for multiple images.
 
+    :attr int custom_classes: (optional) The number of custom classes identified in the images.
     :attr int images_processed: (optional) Number of images processed for the API call.
     :attr list[ClassifiedImage] images: The array of classified images.
     :attr list[WarningInfo] warnings: (optional) Information about what might cause less than optimal output. For example, a request sent with a corrupt .zip file and a list of image URLs will still complete, but does not return the expected output. Not returned when there is no warning.
     """
 
-    def __init__(self, images, images_processed=None, warnings=None):
+    def __init__(self,
+                 images,
+                 custom_classes=None,
+                 images_processed=None,
+                 warnings=None):
         """
         Initialize a ClassifiedImages object.
 
         :param list[ClassifiedImage] images: The array of classified images.
+        :param int custom_classes: (optional) The number of custom classes identified in the images.
         :param int images_processed: (optional) Number of images processed for the API call.
         :param list[WarningInfo] warnings: (optional) Information about what might cause less than optimal output. For example, a request sent with a corrupt .zip file and a list of image URLs will still complete, but does not return the expected output. Not returned when there is no warning.
         """
+        self.custom_classes = custom_classes
         self.images_processed = images_processed
         self.images = images
         self.warnings = warnings
@@ -481,6 +489,8 @@ class ClassifiedImages(object):
     def _from_dict(cls, _dict):
         """Initialize a ClassifiedImages object from a json dictionary."""
         args = {}
+        if 'custom_classes' in _dict:
+            args['custom_classes'] = _dict['custom_classes']
         if 'images_processed' in _dict:
             args['images_processed'] = _dict['images_processed']
         if 'images' in _dict:
@@ -500,6 +510,8 @@ class ClassifiedImages(object):
     def _to_dict(self):
         """Return a json dictionary representing this model."""
         _dict = {}
+        if hasattr(self, 'custom_classes') and self.custom_classes is not None:
+            _dict['custom_classes'] = self.custom_classes
         if hasattr(self,
                    'images_processed') and self.images_processed is not None:
             _dict['images_processed'] = self.images_processed
@@ -586,7 +598,7 @@ class Classifier(object):
         if 'explanation' in _dict:
             args['explanation'] = _dict['explanation']
         if 'created' in _dict:
-            args['created'] = _dict['created']
+            args['created'] = string_to_datetime(_dict['created'])
         if 'classes' in _dict:
             args['classes'] = [Class._from_dict(x) for x in _dict['classes']]
         return cls(**args)
@@ -605,7 +617,7 @@ class Classifier(object):
         if hasattr(self, 'explanation') and self.explanation is not None:
             _dict['explanation'] = self.explanation
         if hasattr(self, 'created') and self.created is not None:
-            _dict['created'] = self.created
+            _dict['created'] = datetime_to_string(self.created)
         if hasattr(self, 'classes') and self.classes is not None:
             _dict['classes'] = [x._to_dict() for x in self.classes]
         return _dict

--- a/watson_developer_cloud/watson_service.py
+++ b/watson_developer_cloud/watson_service.py
@@ -17,6 +17,7 @@ import os
 import requests
 import sys
 from requests.structures import CaseInsensitiveDict
+import dateutil.parser as date_parser
 
 try:
     from http.cookiejar import CookieJar  # Python 3
@@ -72,6 +73,23 @@ class WatsonApiException(WatsonException):
 
 class WatsonInvalidArgument(WatsonException):
     pass
+
+def datetime_to_string(datetime):
+    """
+    Serializes a datetime to a string.
+    :param datetime: datetime value
+    :return: string. containing iso8601 format date string
+    """
+    return datetime.isoformat().replace('+00:00', 'Z')
+
+
+def string_to_datetime(string):
+    """
+    Deserializes string to datetime.
+    :param string: string containing datetime in iso8601 format
+    :return: datetime.
+    """
+    return date_parser.parse(string)
 
 
 def _cleanup_param_value(value):


### PR DESCRIPTION
This PR adds helper functions to convert to/from iso8601 datetimes and uses these functions in the `_from_dict()` and `_to_dict()` methods of the models so that datetime values are stored as datetime objects and not simply strings.

The PR also includes a minor update to VisualRecognitionV3 resulting from a recent update to the swagger.