### PR TITLE
Add utility method to convert lists to csv.

### DIFF
--- a/watson_developer_cloud/watson_service.py
+++ b/watson_developer_cloud/watson_service.py
@@ -228,6 +228,12 @@ class WatsonService(object):
         return val
 
     @staticmethod
+    def _convert_list(val):
+        if isinstance(val, list):
+            return ",".join(val)
+        return val
+
+    @staticmethod
     def _encode_path_vars(*args):
         return (requests.utils.quote(x, safe='') for x in args)
 


### PR DESCRIPTION
This PR adds a helper method to the base service class to handle conversion of lists to comma-separated strings.  This allows service methods to use more concise (and PEP8-friendly) logic for list parameters.