### PR TITLE
Update links to developercloud

### DIFF
--- a/docs/generate_index_html.sh
+++ b/docs/generate_index_html.sh
@@ -17,8 +17,8 @@ echo '<!DOCTYPE html>
         <h1>IBM Watson Developer Cloud Python SDK</h1>
     </div>
 
-    <p><a href="http://www.ibm.com/watson/developercloud/">Info</a>
-        | <a href="http://www.ibm.com/watson/developercloud/doc/">Documentation</a>
+    <p><a href="https://www.ibm.com/watson/developer/">Info</a>
+        | <a href="https://console.bluemix.net/developer/watson/documentation">Documentation</a>
         | <a href="https://github.com/watson-developer-cloud/python-sdk">GitHub</a>
         | <a href="https://pypi.python.org/pypi/watson-developer-cloud">pypi</a>
     </p>

--- a/examples/conversation_tone_analyzer_integration/tone_detection.py
+++ b/examples/conversation_tone_analyzer_integration/tone_detection.py
@@ -15,8 +15,7 @@
  * Thresholds for identifying meaningful tones returned by the Watson Tone
  Analyzer.  Current values are
  * based on the recommendations made by the Watson Tone Analyzer at
- * https://www.ibm.com/watson/developercloud/doc/tone-analyzer/understanding
- -tone.shtml
+ * https://console.bluemix.net/docs/services/tone-analyzer/using-tone.html
  * These thresholds can be adjusted to client/domain requirements.
 """
 

--- a/watson_developer_cloud/natural_language_classifier_v1.py
+++ b/watson_developer_cloud/natural_language_classifier_v1.py
@@ -104,8 +104,8 @@ class NaturalLanguageClassifierV1(WatsonService):
         Sends data to create and train a classifier and returns information about the new
         classifier.
 
-        :param file metadata: Metadata in JSON format. The metadata identifies the language of the data, and an optional name to identify the classifier. For details, see the [API reference](https://www.ibm.com/watson/developercloud/natural-language-classifier/api/v1/#create_classifier).
-        :param file training_data: Training data in CSV format. Each text value must have at least one class. The data can include up to 15,000 records. For details, see [Using your own data](https://www.ibm.com/watson/developercloud/doc/natural-language-classifier/using-your-data.html).
+        :param file metadata: Metadata in JSON format. The metadata identifies the language of the data, and an optional name to identify the classifier. For details, see the [API reference](https://www.ibm.com/watson/developercloud/natural-language-classifier/api/v1/python.html?python#create-classifier).
+        :param file training_data: Training data in CSV format. Each text value must have at least one class. The data can include up to 15,000 records. For details, see [Using your own data](https://console.bluemix.net/docs/services/natural-language-classifier/using-your-data.html).
         :param str metadata_filename: The filename for training_metadata.
         :param str training_data_filename: The filename for training_data.
         :return: A `dict` containing the `Classifier` response.


### PR DESCRIPTION
Updating links that point to WDC documentation to go to the Watson
console.
