### PR TITLE
Catch all exceptions for long_description

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ try:
         return convert(f, 'rst')
 
     # read_md = lambda f: convert(f, 'rst')
-except ImportError:
+except:
     print('warning: pypandoc module not found, '
           'could not convert Markdown to RST')
 


### PR DESCRIPTION
fixes https://github.com/watson-developer-cloud/python-sdk/issues/324

We would like to handle the call for long_description to be graceful. In case pandoc is not installed, it should use the raw contents.

In issue 324, it raised an OSError on an environment where the pypandoc module was already installed, but Pandoc itself was not setup/configured on the path. Catching all exceptions would be a good solution.