### PR TITLE
Deprecate document conversion

### DIFF
--- a/watson_developer_cloud/document_conversion_v1.py
+++ b/watson_developer_cloud/document_conversion_v1.py
@@ -16,10 +16,19 @@
 The v1 Document Conversion service
 (https://www.ibm.com/watson/developercloud/document-conversion.html)
 """
+import warnings
 from .watson_service import WatsonService
 import os
 import json
 
+def deprecated(func):
+    def deprecated_func(*args, **kwargs):
+        warnings.warn("{} retired in  October 2017. To continue using document conversion capabilities, please use Watson Discovery.".format(func.__name__),
+                      category=DeprecationWarning,
+                      stacklevel=2)
+        warnings.simplefilter('default', DeprecationWarning)
+        return func(*args, **kwargs)
+    return deprecated_func
 
 class DocumentConversionV1(WatsonService):
     DEFAULT_URL = 'https://gateway.watsonplatform.net/document-conversion/api'
@@ -28,10 +37,12 @@ class DocumentConversionV1(WatsonService):
     NORMALIZED_TEXT = 'normalized_text'
     latest_version = '2016-02-10'
 
+    @deprecated
     def __init__(self, version, url=DEFAULT_URL, **kwargs):
         WatsonService.__init__(self, 'document_conversion', url, **kwargs)
         self.version = version
 
+    @deprecated
     def convert_document(self, document, config, media_type=None):
         params = {'version': self.version}
         filename = os.path.basename(document.name)
@@ -45,7 +56,7 @@ class DocumentConversionV1(WatsonService):
         return self.request(method='POST', url='/v1/convert_document',
                             files=files, params=params,
                             accept_json=accept_json)
-
+    @deprecated
     def index_document(self, config, document=None, metadata=None,
                        media_type=None):
         if document is None and metadata is None:

--- a/watson_developer_cloud/document_conversion_v1.py
+++ b/watson_developer_cloud/document_conversion_v1.py
@@ -16,19 +16,10 @@
 The v1 Document Conversion service
 (https://www.ibm.com/watson/developercloud/document-conversion.html)
 """
-import warnings
+from .utils import deprecated
 from .watson_service import WatsonService
 import os
 import json
-
-def deprecated(func):
-    def deprecated_func(*args, **kwargs):
-        warnings.warn("{} retired in  October 2017. To continue using document conversion capabilities, please use Watson Discovery.".format(func.__name__),
-                      category=DeprecationWarning,
-                      stacklevel=2)
-        warnings.simplefilter('default', DeprecationWarning)
-        return func(*args, **kwargs)
-    return deprecated_func
 
 class DocumentConversionV1(WatsonService):
     DEFAULT_URL = 'https://gateway.watsonplatform.net/document-conversion/api'
@@ -37,12 +28,12 @@ class DocumentConversionV1(WatsonService):
     NORMALIZED_TEXT = 'normalized_text'
     latest_version = '2016-02-10'
 
-    @deprecated
+    @deprecated("To continue using document conversion capabilities, please use Watson Discovery.")
     def __init__(self, version, url=DEFAULT_URL, **kwargs):
         WatsonService.__init__(self, 'document_conversion', url, **kwargs)
         self.version = version
 
-    @deprecated
+    @deprecated("To continue using document conversion capabilities, please use Watson Discovery.")
     def convert_document(self, document, config, media_type=None):
         params = {'version': self.version}
         filename = os.path.basename(document.name)
@@ -56,7 +47,7 @@ class DocumentConversionV1(WatsonService):
         return self.request(method='POST', url='/v1/convert_document',
                             files=files, params=params,
                             accept_json=accept_json)
-    @deprecated
+    @deprecated("To continue using document conversion capabilities, please use Watson Discovery.")
     def index_document(self, config, document=None, metadata=None,
                        media_type=None):
         if document is None and metadata is None:

--- a/watson_developer_cloud/document_conversion_v1.py
+++ b/watson_developer_cloud/document_conversion_v1.py
@@ -20,6 +20,7 @@ from .utils import deprecated
 from .watson_service import WatsonService
 import os
 import json
+DEPRECATION_MESSAGE = "Since Document Conversion Service was retired in October 2017, we have continued to improve document conversion capabilities within Watson Discovery. If you are a Document Conversion user, get started with Discovery today. Refer to the migration guide: https://console.bluemix.net/docs/services/discovery/migrate-dcs-rr.html"
 
 class DocumentConversionV1(WatsonService):
     DEFAULT_URL = 'https://gateway.watsonplatform.net/document-conversion/api'
@@ -28,12 +29,12 @@ class DocumentConversionV1(WatsonService):
     NORMALIZED_TEXT = 'normalized_text'
     latest_version = '2016-02-10'
 
-    @deprecated("To continue using document conversion capabilities, please use Watson Discovery.")
+    @deprecated(DEPRECATION_MESSAGE)
     def __init__(self, version, url=DEFAULT_URL, **kwargs):
         WatsonService.__init__(self, 'document_conversion', url, **kwargs)
         self.version = version
 
-    @deprecated("To continue using document conversion capabilities, please use Watson Discovery.")
+    @deprecated(DEPRECATION_MESSAGE)
     def convert_document(self, document, config, media_type=None):
         params = {'version': self.version}
         filename = os.path.basename(document.name)
@@ -47,7 +48,7 @@ class DocumentConversionV1(WatsonService):
         return self.request(method='POST', url='/v1/convert_document',
                             files=files, params=params,
                             accept_json=accept_json)
-    @deprecated("To continue using document conversion capabilities, please use Watson Discovery.")
+    @deprecated(DEPRECATION_MESSAGE)
     def index_document(self, config, document=None, metadata=None,
                        media_type=None):
         if document is None and metadata is None:

--- a/watson_developer_cloud/utils.py
+++ b/watson_developer_cloud/utils.py
@@ -1,0 +1,12 @@
+import warnings
+
+def deprecated(message):
+  def deprecated_decorator(func):
+      def deprecated_func(*args, **kwargs):
+          warnings.warn("{} is a deprecated function. {}".format(func.__name__, message),
+                        category=DeprecationWarning,
+                        stacklevel=2)
+          warnings.simplefilter('default', DeprecationWarning)
+          return func(*args, **kwargs)
+      return deprecated_func
+  return deprecated_decorator


### PR DESCRIPTION
The deprecation message is as follows:

```
(MY_ENV)  python examples/document_conversion_v1.py
examples/document_conversion_v1.py:17: DeprecationWarning: convert_document is a deprecated function. Since Document Conversion Service was retired in October 2017, we have continued to improve document conversion capabilities within Watson Discovery. If you are a Document Conversion user, get started with Discovery today. Refer to the migration guide: https://console.bluemix.net/docs/services/discovery/migrate-dcs-rr.html
```