### PR TITLE
fix(python): handling support for python 3.6.4

### DIFF
--- a/test/integration/test_discovery_v1.py
+++ b/test/integration/test_discovery_v1.py
@@ -9,8 +9,8 @@ class Discoveryv1(TestCase):
     def setUp(self):
         self.discovery = watson_developer_cloud.DiscoveryV1(
             version='2017-10-16',
-            username=os.getenv('DISCOVERY_TO_TEXT_USERNAME'),
-            password=os.getenv('DISCOVERY_TO_TEXT_PASSWORD'))
+            username="YOUR SERVICE USERNAME",
+            password="YOUR SERVICE PASSWORD")
         self.discovery.set_default_headers({
             'X-Watson-Learning-Opt-Out': '1',
             'X-Watson-Test': '1'
@@ -84,7 +84,10 @@ class Discoveryv1(TestCase):
             self.environment_id, self.collection_id, add_doc['document_id'])
         assert doc_status is not None
 
-        with open(os.path.join(os.path.dirname(__file__), '../../resources/simple.html'), 'r') as fileinfo:
+        with open(
+                os.path.join(
+                    os.path.dirname(__file__), '../../resources/simple.html'),
+                'r') as fileinfo:
             update_doc = self.discovery.update_document(
                 self.environment_id,
                 self.collection_id,

--- a/test/integration/test_speech_to_text_v1.py
+++ b/test/integration/test_speech_to_text_v1.py
@@ -7,8 +7,8 @@ import watson_developer_cloud
 class TestSpeechToTextV1(TestCase):
     def setUp(self):
         self.speech_to_text = watson_developer_cloud.SpeechToTextV1(
-            username=os.getenv('SPEECH_TO_TEXT_USERNAME'),
-            password=os.getenv('SPEECH_TO_TEXT_PASSWORD'))
+            username=os.getenv('YOUR SERVICE USERNAME'),
+            password=os.getenv('YOUR SERVICE PASSWORD'))
         self.speech_to_text.set_default_headers({
             'X-Watson-Learning-Opt-Out':
             '1',

--- a/test/integration/test_text_to_speech_v1.py
+++ b/test/integration/test_text_to_speech_v1.py
@@ -5,7 +5,8 @@ import watson_developer_cloud
 
 class TestIntegrationTextToSpeechV1(unittest.TestCase):
     def setUp(self):
-        self.text_to_speech = watson_developer_cloud.TextToSpeechV1()
+        self.text_to_speech = watson_developer_cloud.TextToSpeechV1(
+            username="YOUR SERVICE USERNAME", password="YOUR SERVICE PASSWORD")
         self.text_to_speech.set_default_headers({
             'X-Watson-Learning-Opt-Out':
             '1',

--- a/watson_developer_cloud/speech_to_text_v1.py
+++ b/watson_developer_cloud/speech_to_text_v1.py
@@ -32,7 +32,7 @@ import base64
 try:
     from urllib.parse import urlencode
 except ImportError:
-     from urllib import urlencode
+    from urllib import urlencode
 
 ##############################################################################
 # Service

--- a/watson_developer_cloud/speech_to_text_v1.py
+++ b/watson_developer_cloud/speech_to_text_v1.py
@@ -29,7 +29,10 @@ from .watson_service import WatsonService, _remove_null_values
 from .utils import deprecated
 from watson_developer_cloud.websocket import RecognizeCallback, RecognizeListener
 import base64
-import urllib
+try:
+    from urllib.parse import urlencode
+except ImportError:
+     from urllib import urlencode
 
 ##############################################################################
 # Service
@@ -241,8 +244,9 @@ class SpeechToTextV1(WatsonService):
         headers = {}
         if self.default_headers is not None:
             headers = self.default_headers.copy()
-        base64_authorization = base64.b64encode(
-            self.username + ':' + self.password)
+
+        authstring = "{0}:{1}".format(self.username, self.password)
+        base64_authorization = base64.b64encode(authstring.encode('utf-8')).decode('utf-8')
         headers['Authorization'] = 'Basic {0}'.format(base64_authorization)
 
         url = self.url.replace('https:', 'wss:')
@@ -254,7 +258,7 @@ class SpeechToTextV1(WatsonService):
             'version': version
         }
         params = _remove_null_values(params)
-        url = url + '/v1/recognize?{0}'.format(urllib.urlencode(params))
+        url = url + '/v1/recognize?{0}'.format(urlencode(params))
 
         options = {
             'content_type': content_type,

--- a/watson_developer_cloud/websocket/speech_to_text_websocket_listener.py
+++ b/watson_developer_cloud/websocket/speech_to_text_websocket_listener.py
@@ -62,7 +62,7 @@ class RecognizeListener(object):
             return options
 
         def build_close_message(self):
-            return json.dumps({'action': 'close'})
+            return json.dumps({'action': 'close'}).encode('utf8')
 
         # helper method that sends a chunk of audio if needed (as required what the specified pacing is)
         def send_audio(self, data):


### PR DESCRIPTION
Got the following two errors in python 3.6.4:
* 
```
Traceback (most recent call last):
  File "examples/speech_to_text_v1.py", line 57, in <module>
    audio=audio_file, recognize_callback=mycallback)
  File "/Users/erikadsouza/anaconda3/envs/testpypi/lib/python3.6/site-packages/watson_developer_cloud/speech_to_text_v1.py", line 245, in recognize_with_websocket
    self.username + ':' + self.password)
  File "/Users/erikadsouza/anaconda3/envs/testpypi/lib/python3.6/base64.py", line 58, in b64encode
    encoded = binascii.b2a_base64(s, newline=False)
TypeError: a bytes-like object is required, not 'str'
```
* urlencode support