### PR TITLE
Use nested dict to access `conversation_id`.

### DIFF
--- a/watson_developer_cloud/conversation_v1.py
+++ b/watson_developer_cloud/conversation_v1.py
@@ -1708,16 +1708,16 @@ class Context(object):
         """Initialize a Context object from a json dictionary."""
         args = {}
         xtra = _dict.copy()
-        if 'conversation_id' in _dict:
-            args['conversation_id'] = _dict['conversation_id']
-            del xtra['conversation_id']
+        if 'conversation_id' in _dict['context']:
+            args['conversation_id'] = _dict['context']['conversation_id']
+            del xtra['context']['conversation_id']
         else:
             raise ValueError(
                 'Required property \'conversation_id\' not present in Context JSON'
             )
-        if 'system' in _dict:
-            args['system'] = SystemResponse._from_dict(_dict['system'])
-            del xtra['system']
+        if 'system' in _dict['context']:
+            args['system'] = SystemResponse._from_dict(_dict['context']['system'])
+            del xtra['context']['system']
         else:
             raise ValueError(
                 'Required property \'system\' not present in Context JSON')


### PR DESCRIPTION
The checks for `conversation_id` in:
`watson_developer_cloud/conversation_v1.py", line 1716, in _from_dict"`
Fails because it is a nested dictionary within a dictionary.
We must access the `conversation_id` field via:
`['context']['conversation_id']`

Closes: #410