### PR TITLE
Uniform request handling

### DIFF
--- a/watson_developer_cloud/natural_language_classifier_v1.py
+++ b/watson_developer_cloud/natural_language_classifier_v1.py
@@ -218,9 +218,9 @@ class NaturalLanguageClassifierV1(WatsonService):
             headers.update(kwargs.get('headers'))
         url = '/v1/classifiers/{0}'.format(
             *self._encode_path_vars(classifier_id))
-        self.request(
+        response = self.request(
             method='DELETE', url=url, headers=headers, accept_json=True)
-        return None
+        return response
 
     def get_classifier(self, classifier_id, **kwargs):
         """


### PR DESCRIPTION
This patch returns the response object. The motivation for this patch is that I use the response object from the self.request.

I use it because I perform asynchronous requests (by overriding the request method in a manner like this):

```Python
def make_async_service(watson_service):
    "Override the request method, so that it acts nicer within the async environment."
    watson_service.request = types.MethodType(async_request, watson_service)
    watson_service._tls = threading.local()
    return watson_service
```

Everything works except for the `delete_classifier` function because for some arbitrary reason it returns `None` instead  of the response. This is an API bug.