### PR TITLE
Add support for IAM

### DIFF
--- a/test/integration/test_discovery_v1.py
+++ b/test/integration/test_discovery_v1.py
@@ -22,7 +22,11 @@ class Discoveryv1(TestCase):
             'X-Watson-Learning-Opt-Out': '1',
             'X-Watson-Test': '1'
         })
-        cls.collection_id = cls.discovery.list_collections(cls.environment_id)['collections'][0]['collection_id']
+        collections = cls.discovery.list_collections(cls.environment_id)['collections']
+        cls.collection_id = collections[0]['collection_id']
+        for collection in collections:
+            if collection['name'] != 'DO-NOT-DELETE':
+                cls.discovery.delete_collection(cls.environment_id, collection['collection_id'])
 
     @classmethod
     def teardown_class(cls):

--- a/test/integration/test_speech_to_text_v1.py
+++ b/test/integration/test_speech_to_text_v1.py
@@ -16,8 +16,8 @@ class TestSpeechToTextV1(TestCase):
     @classmethod
     def setup_class(cls):
         cls.speech_to_text = watson_developer_cloud.SpeechToTextV1(
-            username=os.getenv('YOUR SERVICE USERNAME'),
-            password=os.getenv('YOUR SERVICE PASSWORD'))
+            username='YOUR SERVICE USERNAME',
+            password='YOUR SERVICE PASSWORD')
         cls.speech_to_text.set_default_headers({
             'X-Watson-Learning-Opt-Out':
             '1',

--- a/test/integration/test_visual_recognition.py
+++ b/test/integration/test_visual_recognition.py
@@ -16,7 +16,7 @@ class IntegrationTestVisualRecognitionV3(TestCase):
     @classmethod
     def setup_class(cls):
         cls.visual_recognition = watson_developer_cloud.VisualRecognitionV3(
-            '2016-05-20', api_key=os.environ.get('YOUR API KEY'))
+            '2016-05-20', api_key='YOUR API KEY')
         cls.visual_recognition.set_default_headers({
             'X-Watson-Learning-Opt-Out':
             '1',

--- a/test/unit/test_iam_token_manager.py
+++ b/test/unit/test_iam_token_manager.py
@@ -15,7 +15,7 @@ def test_request_token():
     responses.add(responses.POST, url=iam_url, body=response, status=200)
 
     token_manager = iam_token_manager.IAMTokenManager("iam_api_key", "iam_access_token", iam_url)
-    token_manager.request_token()
+    token_manager._request_token()
 
     assert responses.calls[0].request.url == iam_url
     assert responses.calls[0].response.text == response
@@ -34,7 +34,7 @@ def test_refresh_token():
     responses.add(responses.POST, url=iam_url, body=response, status=200)
 
     token_manager = iam_token_manager.IAMTokenManager("iam_api_key", "iam_access_token", iam_url)
-    token_manager.refresh_token()
+    token_manager._refresh_token()
 
     assert responses.calls[0].request.url == iam_url
     assert responses.calls[0].response.text == response
@@ -50,9 +50,9 @@ def test_is_token_expired():
         "expiration": int(time.time()) + 6000,
         "refresh_token": "jy4gl91BQ"
     }
-    assert token_manager.is_token_expired() is False
+    assert token_manager._is_token_expired() is False
     token_manager.token_info['expiration'] = int(time.time()) - 3600
-    assert token_manager.is_token_expired()
+    assert token_manager._is_token_expired()
 
 @responses.activate
 def test_is_refresh_token_expired():
@@ -64,9 +64,9 @@ def test_is_refresh_token_expired():
         "expiration": int(time.time()),
         "refresh_token": "jy4gl91BQ"
     }
-    assert token_manager.is_refresh_token_expired() is False
+    assert token_manager._is_refresh_token_expired() is False
     token_manager.token_info['expiration'] = int(time.time()) - (8 * 24 * 3600)
-    assert token_manager.is_token_expired()
+    assert token_manager._is_token_expired()
 
 @responses.activate
 def test_get_token():

--- a/test/unit/test_iam_token_manager.py
+++ b/test/unit/test_iam_token_manager.py
@@ -1,0 +1,110 @@
+import responses
+from watson_developer_cloud import iam_token_manager
+import time
+
+@responses.activate
+def test_request_token():
+    iam_url = "https://iam.bluemix.net/identity/token"
+    response = """{
+        "access_token": "oAeisG8yqPY7sFR_x66Z15",
+        "token_type": "Bearer",
+        "expires_in": 3600,
+        "expiration": 1524167011,
+        "refresh_token": "jy4gl91BQ"
+    }"""
+    responses.add(responses.POST, url=iam_url, body=response, status=200)
+
+    token_manager = iam_token_manager.IAMTokenManager("iam_api_key", "iam_access_token", iam_url)
+    token_manager.request_token()
+
+    assert responses.calls[0].request.url == iam_url
+    assert responses.calls[0].response.text == response
+    assert len(responses.calls) == 1
+
+@responses.activate
+def test_refresh_token():
+    iam_url = "https://iam.bluemix.net/identity/token"
+    response = """{
+        "access_token": "oAeisG8yqPY7sFR_x66Z15",
+        "token_type": "Bearer",
+        "expires_in": 3600,
+        "expiration": 1524167011,
+        "refresh_token": "jy4gl91BQ"
+    }"""
+    responses.add(responses.POST, url=iam_url, body=response, status=200)
+
+    token_manager = iam_token_manager.IAMTokenManager("iam_api_key", "iam_access_token", iam_url)
+    token_manager.refresh_token()
+
+    assert responses.calls[0].request.url == iam_url
+    assert responses.calls[0].response.text == response
+    assert len(responses.calls) == 1
+
+@responses.activate
+def test_is_token_expired():
+    token_manager = iam_token_manager.IAMTokenManager("iam_api_key", "iam_access_token", "iam_url")
+    token_manager.token_info = {
+        "access_token": "oAeisG8yqPY7sFR_x66Z15",
+        "token_type": "Bearer",
+        "expires_in": 3600,
+        "expiration": int(time.time()) + 6000,
+        "refresh_token": "jy4gl91BQ"
+    }
+    assert token_manager.is_token_expired() is False
+    token_manager.token_info['expiration'] = int(time.time()) - 3600
+    assert token_manager.is_token_expired()
+
+@responses.activate
+def test_is_refresh_token_expired():
+    token_manager = iam_token_manager.IAMTokenManager("iam_api_key", "iam_access_token", "iam_url")
+    token_manager.token_info = {
+        "access_token": "oAeisG8yqPY7sFR_x66Z15",
+        "token_type": "Bearer",
+        "expires_in": 3600,
+        "expiration": int(time.time()),
+        "refresh_token": "jy4gl91BQ"
+    }
+    assert token_manager.is_refresh_token_expired() is False
+    token_manager.token_info['expiration'] = int(time.time()) - (8 * 24 * 3600)
+    assert token_manager.is_token_expired()
+
+@responses.activate
+def test_get_token():
+    iam_url = "https://iam.bluemix.net/identity/token"
+    token_manager = iam_token_manager.IAMTokenManager("iam_api_key", iam_url=iam_url)
+    token_manager.user_access_token = 'user_access_token'
+
+    # Case 1:
+    token = token_manager.get_token()
+    assert token == token_manager.user_access_token
+
+    # Case 2:
+    token_manager.user_access_token = ''
+    response = """{
+        "access_token": "hellohello",
+        "token_type": "Bearer",
+        "expires_in": 3600,
+        "expiration": 1524167011,
+        "refresh_token": "jy4gl91BQ"
+    }"""
+    responses.add(responses.POST, url=iam_url, body=response, status=200)
+    token = token_manager.get_token()
+    assert token == "hellohello"
+
+    # Case 3:
+    token_manager.token_info['expiration'] = int(time.time()) - (20 * 24 * 3600)
+    token = token_manager.get_token()
+    assert "grant_type=urn" in responses.calls[1].request.body
+    token_manager.token_info['expiration'] = int(time.time()) - 4000
+    token = token_manager.get_token()
+    assert "grant_type=refresh_token" in responses.calls[2].request.body
+
+    token_manager.token_info = {
+        "access_token": "dummy",
+        "token_type": "Bearer",
+        "expires_in": 3600,
+        "expiration": int(time.time()) + 3600,
+        "refresh_token": "jy4gl91BQ"
+    }
+    token = token_manager.get_token()
+    assert token == 'dummy'

--- a/test/unit/test_iam_token_manager.py
+++ b/test/unit/test_iam_token_manager.py
@@ -99,6 +99,7 @@ def test_get_token():
     token = token_manager.get_token()
     assert "grant_type=refresh_token" in responses.calls[2].request.body
 
+    # Case 4
     token_manager.token_info = {
         "access_token": "dummy",
         "token_type": "Bearer",

--- a/test/unit/test_watson_service.py
+++ b/test/unit/test_watson_service.py
@@ -12,14 +12,20 @@ import responses
 class AnyServiceV1(WatsonService):
     default_url = 'https://gateway.watsonplatform.net/test/api'
 
-    def __init__(self, version, url=default_url, username=None, password=None):
+    def __init__(self, version, url=default_url, username=None, password=None,
+                 iam_api_key=None,
+                 iam_access_token=None,
+                 iam_url=None):
         WatsonService.__init__(
             self,
             vcap_services_name='test',
             url=url,
             username=username,
             password=password,
-            use_vcap_services=True)
+            use_vcap_services=True,
+            iam_api_key=iam_api_key,
+            iam_access_token=iam_access_token,
+            iam_url=iam_url)
         self.version = version
 
     def op_with_path_params(self, path0, path1):
@@ -84,3 +90,8 @@ def test_fail_http_config():
     service = AnyServiceV1('2017-07-07', username='username', password='password')
     with pytest.raises(TypeError):
         service.with_http_config(None)
+
+@responses.activate
+def test_iam():
+    service = AnyServiceV1('2017-07-07', iam_api_key="iam_api_key")
+    assert service.token_manager is not None

--- a/test/unit/test_watson_service.py
+++ b/test/unit/test_watson_service.py
@@ -119,7 +119,7 @@ def test_iam():
     responses.add(responses.POST, url=iam_url, body=response, status=200)
     responses.add(responses.GET,
                   service.default_url,
-                  status=200,
-                  body={})
+                  body=json.dumps({"foobar": "baz"}),
+                  content_type='application/json')
     service.any_service_call()
     assert "grant_type=refresh_token" in responses.calls[0].request.body

--- a/watson_developer_cloud/iam_token_manager.py
+++ b/watson_developer_cloud/iam_token_manager.py
@@ -1,0 +1,142 @@
+import requests
+import time
+
+DEFAULT_IAM_URL = 'https://iam.bluemix.net/identity/token'
+CONTENT_TYPE = 'application/x-www-form-urlencoded'
+ACCEPT = 'application/json'
+DEFAULT_AUTHORIZATION = 'Basic Yng6Yng='
+REQUEST_TOKEN_GRANT_TYPE = 'urn:ibm:params:oauth:grant-type:apikey'
+REQUEST_TOKEN_RESPONSE_TYPE = 'cloud_iam'
+REFRESH_TOKEN_GRANT_TYPE = 'refresh_token'
+
+class IAMTokenManager(object):
+    def __init__(self, iam_api_key=None, iam_access_token=None, iam_url=None):
+        self.iam_api_key = iam_api_key
+        self.user_access_token = iam_access_token
+        self.url = iam_url if iam_url else DEFAULT_IAM_URL
+        self.token_info = {
+            'access_token': None,
+            'refresh_token': None,
+            'token_type': None,
+            'expires_in': None,
+            'expiration': None,
+        }
+
+    def request(self, method, url, headers=None, params=None, data=None, **kwargs):
+        response = requests.request(method=method, url=url,
+                                    headers=headers, params=params,
+                                    data=data, **kwargs)
+        if 200 <= response.status_code <= 299:
+            return response.json()
+        else:
+            from .watson_service import WatsonApiException, get_error_message
+            error_message = get_error_message(response)
+            raise WatsonApiException(response.status_code, message=error_message, httpResponse=response)
+
+    def get_token(self):
+        """
+        The source of the token is determined by the following logic:
+        1. If user provides their own managed access token, assume it is valid and send it
+        2. If this class is managing tokens and does not yet have one, make a request for one
+        3. If this class is managing tokens and the token has expired refresh it. In case the refresh token is expired, get a new one
+        If this class is managing tokens and has a valid token stored, send it
+        """
+        if self.user_access_token:
+            return self.user_access_token
+        elif not self.token_info.get('access_token'):
+            token_info = self.request_token()
+            self.save_token_info(token_info)
+            return self.token_info.get('access_token')
+        elif self.is_token_expired():
+            if self.is_refresh_token_expired():
+                token_info = self.request_token()
+            else:
+                token_info = self.refresh_token()
+            self.save_token_info(token_info)
+            return self.token_info.get('access_token')
+        else:
+            return self.token_info.get('access_token')
+
+    def request_token(self):
+        """
+        Request an IAM token using an API key
+        """
+        headers = {
+            'Content-type': CONTENT_TYPE,
+            'Authorization': DEFAULT_AUTHORIZATION,
+            'accept': ACCEPT
+        }
+        data = {
+            'grant_type': REQUEST_TOKEN_GRANT_TYPE,
+            'apikey': self.iam_api_key,
+            'response_type': REQUEST_TOKEN_RESPONSE_TYPE
+        }
+        response = self.request(
+            method='POST',
+            url=self.url,
+            headers=headers,
+            data=data)
+        return response
+
+    def refresh_token(self):
+        """
+        Refresh an IAM token using a refresh token
+        """
+        headers = {
+            'Content-type': CONTENT_TYPE,
+            'Authorization': DEFAULT_AUTHORIZATION,
+            'accept': ACCEPT
+        }
+        data = {
+            'grant_type': REFRESH_TOKEN_GRANT_TYPE,
+            'refresh_token': self.token_info.get('refresh_token')
+        }
+        response = self.request(
+            method='POST',
+            url=self.url,
+            headers=headers,
+            data=data)
+        return response
+
+    def set_access_token(self, iam_access_token):
+        """
+        Set a self-managed IAM access token.
+        The access token should be valid and not yet expired.
+        """
+        self.user_access_token = iam_access_token
+
+    def is_token_expired(self):
+        """
+        Check if currently stored token is expired.
+
+        Using a buffer to prevent the edge case of the
+        oken expiring before the request could be made.
+
+        The buffer will be a fraction of the total TTL. Using 80%.
+        """
+        fraction_of_ttl = 0.8
+        time_to_live = self.token_info.get('expires_in')
+        expire_time = self.token_info.get('expiration')
+        refresh_time = expire_time - (time_to_live * (1.0 - fraction_of_ttl))
+        current_time = int(time.time())
+        return refresh_time < current_time
+
+    def is_refresh_token_expired(self):
+        """
+        Used as a fail-safe to prevent the condition of a refresh token expiring,
+        which could happen after around 30 days. This function will return true
+        if it has been at least 7 days and 1 hour since the last token was set
+        """
+        if self.token_info.get('expiration') is None:
+            return True
+
+        seven_days = 7 * 24 * 3600
+        current_time = int(time.time())
+        new_token_time = self.token_info.get('expiration') + seven_days
+        return new_token_time < current_time
+
+    def save_token_info(self, token_info):
+        """
+        Save the response from the IAM service request to the object's state.
+        """
+        self.token_info = token_info

--- a/watson_developer_cloud/watson_service.py
+++ b/watson_developer_cloud/watson_service.py
@@ -251,7 +251,7 @@ class WatsonService(object):
                     self.api_key = self.vcap_service_credentials['apikey']
                 if 'api_key' in self.vcap_service_credentials:
                     self.api_key = self.vcap_service_credentials['api_key']
-                if 'iam_api_key' in self.vcap_service_credentials:
+                if ('iam_api_key' or 'apikey')  in self.vcap_service_credentials:
                     self.iam_api_key = self.vcap_service_credentials['iam_api_key']
                 if 'iam_access_token' in self.vcap_service_credentials:
                     self.iam_access_token = self.vcap_service_credentials['iam_access_token']

--- a/watson_developer_cloud/watson_service.py
+++ b/watson_developer_cloud/watson_service.py
@@ -19,6 +19,7 @@ import requests
 import sys
 from requests.structures import CaseInsensitiveDict
 import dateutil.parser as date_parser
+from .iam_token_manager import IAMTokenManager
 
 try:
     from http.cookiejar import CookieJar  # Python 3
@@ -26,6 +27,7 @@ except ImportError:
     from cookielib import CookieJar  # Python 2
 from .version import __version__
 
+BEARER = 'Bearer'
 
 # Uncomment this to enable http debugging
 # try:
@@ -137,6 +139,33 @@ def _convert_boolean_values(dictionary):
             [(k, _convert_boolean_value(v)) for k, v in dictionary.items()])
     return dictionary
 
+def get_error_message(response):
+    """
+    Gets the error message from a JSON response.
+    :return: the error message
+    :rtype: string
+    """
+    error_message = 'Unknown error'
+    try:
+        error_json = response.json()
+        if 'error' in error_json:
+            if isinstance(error_json['error'], dict) and 'description' in \
+                    error_json['error']:
+                error_message = error_json['error']['description']
+            else:
+                error_message = error_json['error']
+        elif 'error_message' in error_json:
+            error_message = error_json['error_message']
+        elif 'errorMessage' in error_json:
+            error_message = error_json['errorMessage']
+        elif 'msg' in error_json:
+            error_message = error_json['msg']
+        elif 'statusInfo' in error_json:
+            error_message = error_json['statusInfo']
+        return error_message
+    except:
+        return response.text or error_message
+
 class DetailedResponse(object):
     """
     Custom class for detailed response returned from Watson APIs.
@@ -168,7 +197,8 @@ class DetailedResponse(object):
 class WatsonService(object):
     def __init__(self, vcap_services_name, url, username=None, password=None,
                  use_vcap_services=True, api_key=None,
-                 x_watson_learning_opt_out=False):
+                 x_watson_learning_opt_out=False,
+                 iam_api_key=None, iam_access_token=None, iam_url=None):
         """
         Loads credentials from the VCAP_SERVICES environment variable if
         available, preferring credentials explicitly
@@ -186,6 +216,10 @@ class WatsonService(object):
         self.default_headers = None
         self.http_config = {}
         self.detailed_response = False
+        self.iam_api_key = None
+        self.iam_access_token = None
+        self.iam_url = None
+        self.token_manager = None
 
         user_agent_string = 'watson-apis-python-sdk-' + __version__ # SDK version
         user_agent_string += ' ' + platform.system() # OS
@@ -197,12 +231,11 @@ class WatsonService(object):
             self.default_headers = {'x-watson-learning-opt-out': 'true'}
 
         if api_key is not None:
-            if username is not None or password is not None:
-                raise ValueError(
-                    'Cannot set api_key and username and password together')
             self.set_api_key(api_key)
-        else:
+        elif username is not None and password is not None:
             self.set_username_and_password(username, password)
+        else:
+            self.set_token_manager(iam_api_key, iam_access_token, iam_url)
 
         if use_vcap_services and not self.username and not self.api_key:
             self.vcap_service_credentials = load_from_vcap_services(
@@ -218,11 +251,17 @@ class WatsonService(object):
                     self.api_key = self.vcap_service_credentials['apikey']
                 if 'api_key' in self.vcap_service_credentials:
                     self.api_key = self.vcap_service_credentials['api_key']
+                if 'iam_api_key' in self.vcap_service_credentials:
+                    self.iam_api_key = self.vcap_service_credentials['iam_api_key']
+                if 'iam_access_token' in self.vcap_service_credentials:
+                    self.iam_access_token = self.vcap_service_credentials['iam_access_token']
+                if 'iam_url' in self.vcap_service_credentials:
+                    self.iam_url = self.vcap_service_credentials['iam_url']
 
         if (self.username is None or self.password is None)\
-                and self.api_key is None:
+                and self.api_key is None and self.iam_api_key is None:
             raise ValueError(
-                'You must specify your username and password service '
+                'You must specify your IAM api key or username and password service '
                 'credentials (Note: these are different from your Bluemix id)')
 
     def set_username_and_password(self, username=None, password=None):
@@ -241,6 +280,23 @@ class WatsonService(object):
 
         self.api_key = api_key
         self.jar = CookieJar()
+
+    def set_token_manager(self, iam_api_key, iam_access_token, iam_url):
+        if iam_api_key == 'YOUR IAM API KEY':
+            iam_api_key = None
+
+        self.iam_api_key = iam_api_key
+        self.iam_access_token = iam_access_token
+        self.iam_url = iam_url
+        self.token_manager = IAMTokenManager(iam_api_key, iam_access_token, iam_url)
+        self.jar = CookieJar()
+
+    def set_iam_access_token(self, iam_access_token):
+        if self.token_manager:
+            self.token_manager.set_access_token(iam_access_token)
+        else:
+            self.token_manager = IAMTokenManager(iam_access_token=iam_access_token)
+        self.iam_access_token = iam_access_token
 
     def set_url(self, url):
         self.url = url
@@ -297,33 +353,6 @@ class WatsonService(object):
         return (requests.utils.quote(x, safe='') for x in args)
 
     @staticmethod
-    def _get_error_message(response):
-        """
-        Gets the error message from a JSON response.
-        :return: the error message
-        :rtype: string
-        """
-        error_message = 'Unknown error'
-        try:
-            error_json = response.json()
-            if 'error' in error_json:
-                if isinstance(error_json['error'], dict) and 'description' in \
-                        error_json['error']:
-                    error_message = error_json['error']['description']
-                else:
-                    error_message = error_json['error']
-            elif 'error_message' in error_json:
-                error_message = error_json['error_message']
-            elif 'msg' in error_json:
-                error_message = error_json['msg']
-            elif 'statusInfo' in error_json:
-                error_message = error_json['statusInfo']
-            return error_message
-        except:
-            return response.text or error_message
-
-
-    @staticmethod
     def _get_error_info(response):
         """
         Gets the error info (if any) from a JSON response.
@@ -370,6 +399,9 @@ class WatsonService(object):
             headers.update({'content-type': 'application/json'})
 
         auth = None
+        if self.token_manager:
+            access_token = self.token_manager.get_token()
+            headers['Authorization'] = '{0} {1}'.format(BEARER, access_token)
         if self.username and self.password:
             auth = (self.username, self.password)
         if self.api_key is not None:
@@ -410,7 +442,7 @@ class WatsonService(object):
                 error_message = 'Unauthorized: Access is denied due to ' \
                                 'invalid credentials '
             else:
-                error_message = self._get_error_message(response)
+                error_message = get_error_message(response)
             error_info = self._get_error_info(response)
             raise WatsonApiException(response.status_code, error_message,
                                      info=error_info, httpResponse=response)

--- a/watson_developer_cloud/watson_service.py
+++ b/watson_developer_cloud/watson_service.py
@@ -234,7 +234,7 @@ class WatsonService(object):
             self.set_api_key(api_key)
         elif username is not None and password is not None:
             self.set_username_and_password(username, password)
-        else:
+        elif iam_access_token is not None or iam_api_key is not None:
             self.set_token_manager(iam_api_key, iam_access_token, iam_url)
 
         if use_vcap_services and not self.username and not self.api_key:
@@ -252,14 +252,14 @@ class WatsonService(object):
                 if 'api_key' in self.vcap_service_credentials:
                     self.api_key = self.vcap_service_credentials['api_key']
                 if ('iam_api_key' or 'apikey')  in self.vcap_service_credentials:
-                    self.iam_api_key = self.vcap_service_credentials['iam_api_key']
+                    self.iam_api_key = self.vcap_service_credentials.get('iam_api_key') or self.vcap_service_credentials.get('apikey')
                 if 'iam_access_token' in self.vcap_service_credentials:
                     self.iam_access_token = self.vcap_service_credentials['iam_access_token']
                 if 'iam_url' in self.vcap_service_credentials:
                     self.iam_url = self.vcap_service_credentials['iam_url']
 
         if (self.username is None or self.password is None)\
-                and self.api_key is None and self.iam_api_key is None:
+                and self.api_key is None and self.token_manager is None:
             raise ValueError(
                 'You must specify your IAM api key or username and password service '
                 'credentials (Note: these are different from your Bluemix id)')


### PR DESCRIPTION
Each service can pass in the IAM information in the constructor, so the new constructor looks like:
```python
    def __init__(self, version, url=default_url, username=None, password=None,
                 iam_api_key=None, iam_access_token=None, iam_url=None):
```

The implementation is the same as Node as done by @dpopp07.