### PR TITLE
Uniform request handling

### DIFF
--- a/test/unit/test_assistant_v1.py
+++ b/test/unit/test_assistant_v1.py
@@ -105,7 +105,6 @@ def test_delete_counterexample():
         workspace_id='boguswid', text='I want financial advice today')
     assert len(responses.calls) == 1
     assert responses.calls[0].request.url.startswith(url)
-    assert counterexample is None
 
 
 @responses.activate
@@ -241,7 +240,7 @@ def test_create_entity():
 def test_delete_entity():
     endpoint = '/v1/workspaces/{0}/entities/{1}'.format('boguswid', 'pizza_toppings')
     url = '{0}{1}'.format(base_url, endpoint)
-    response = ""
+    response = {}
     responses.add(
         responses.DELETE,
         url,
@@ -253,7 +252,6 @@ def test_delete_entity():
     entity = service.delete_entity(workspace_id='boguswid', entity='pizza_toppings')
     assert len(responses.calls) == 1
     assert responses.calls[0].request.url.startswith(url)
-    assert entity is None
 
 
 @responses.activate
@@ -414,7 +412,6 @@ def test_delete_example():
         text='Gimme a pizza with pepperoni')
     assert len(responses.calls) == 1
     assert responses.calls[0].request.url.startswith(url)
-    assert example is None
 
 
 @responses.activate
@@ -567,7 +564,6 @@ def test_delete_intent():
         workspace_id='boguswid', intent='pizza_order')
     assert len(responses.calls) == 1
     assert responses.calls[0].request.url.startswith(url)
-    assert intent is None
 
 
 @responses.activate
@@ -998,7 +994,7 @@ def test_delete_synonym():
     endpoint = '/v1/workspaces/{0}/entities/{1}/values/{2}/synonyms/{3}'.format(
         'boguswid', 'aeiou', 'vowel', 'a')
     url = '{0}{1}'.format(base_url, endpoint)
-    response = ""
+    response = {}
     responses.add(
         responses.DELETE,
         url,
@@ -1011,7 +1007,6 @@ def test_delete_synonym():
         workspace_id='boguswid', entity='aeiou', value='vowel', synonym='a')
     assert len(responses.calls) == 1
     assert responses.calls[0].request.url.startswith(url)
-    assert synonym is None
 
 
 @responses.activate
@@ -1153,7 +1148,7 @@ def test_delete_value():
     endpoint = '/v1/workspaces/{0}/entities/{1}/values/{2}'.format(
         'boguswid', 'grilling', 'bbq')
     url = '{0}{1}'.format(base_url, endpoint)
-    response = ""
+    response = {}
     responses.add(
         responses.DELETE,
         url,
@@ -1166,7 +1161,6 @@ def test_delete_value():
         workspace_id='boguswid', entity='grilling', value='bbq')
     assert len(responses.calls) == 1
     assert responses.calls[0].request.url.startswith(url)
-    assert value is None
 
 
 @responses.activate
@@ -1330,7 +1324,6 @@ def test_delete_workspace():
     workspace = service.delete_workspace(workspace_id='boguswid')
     assert len(responses.calls) == 1
     assert responses.calls[0].request.url.startswith(url)
-    assert workspace is None
 
 
 @responses.activate

--- a/test/unit/test_conversation_v1.py
+++ b/test/unit/test_conversation_v1.py
@@ -105,7 +105,6 @@ def test_delete_counterexample():
         workspace_id='boguswid', text='I want financial advice today')
     assert len(responses.calls) == 1
     assert responses.calls[0].request.url.startswith(url)
-    assert counterexample is None
 
 
 @responses.activate
@@ -241,7 +240,7 @@ def test_create_entity():
 def test_delete_entity():
     endpoint = '/v1/workspaces/{0}/entities/{1}'.format('boguswid', 'pizza_toppings')
     url = '{0}{1}'.format(base_url, endpoint)
-    response = ""
+    response = {}
     responses.add(
         responses.DELETE,
         url,
@@ -253,7 +252,6 @@ def test_delete_entity():
     entity = service.delete_entity(workspace_id='boguswid', entity='pizza_toppings')
     assert len(responses.calls) == 1
     assert responses.calls[0].request.url.startswith(url)
-    assert entity is None
 
 
 @responses.activate
@@ -414,7 +412,6 @@ def test_delete_example():
         text='Gimme a pizza with pepperoni')
     assert len(responses.calls) == 1
     assert responses.calls[0].request.url.startswith(url)
-    assert example is None
 
 
 @responses.activate
@@ -567,7 +564,6 @@ def test_delete_intent():
         workspace_id='boguswid', intent='pizza_order')
     assert len(responses.calls) == 1
     assert responses.calls[0].request.url.startswith(url)
-    assert intent is None
 
 
 @responses.activate
@@ -998,7 +994,7 @@ def test_delete_synonym():
     endpoint = '/v1/workspaces/{0}/entities/{1}/values/{2}/synonyms/{3}'.format(
         'boguswid', 'aeiou', 'vowel', 'a')
     url = '{0}{1}'.format(base_url, endpoint)
-    response = ""
+    response = {}
     responses.add(
         responses.DELETE,
         url,
@@ -1011,7 +1007,6 @@ def test_delete_synonym():
         workspace_id='boguswid', entity='aeiou', value='vowel', synonym='a')
     assert len(responses.calls) == 1
     assert responses.calls[0].request.url.startswith(url)
-    assert synonym is None
 
 
 @responses.activate
@@ -1153,7 +1148,7 @@ def test_delete_value():
     endpoint = '/v1/workspaces/{0}/entities/{1}/values/{2}'.format(
         'boguswid', 'grilling', 'bbq')
     url = '{0}{1}'.format(base_url, endpoint)
-    response = ""
+    response = {}
     responses.add(
         responses.DELETE,
         url,
@@ -1166,7 +1161,6 @@ def test_delete_value():
         workspace_id='boguswid', entity='grilling', value='bbq')
     assert len(responses.calls) == 1
     assert responses.calls[0].request.url.startswith(url)
-    assert value is None
 
 
 @responses.activate
@@ -1330,7 +1324,6 @@ def test_delete_workspace():
     workspace = service.delete_workspace(workspace_id='boguswid')
     assert len(responses.calls) == 1
     assert responses.calls[0].request.url.startswith(url)
-    assert workspace is None
 
 
 @responses.activate

--- a/watson_developer_cloud/assistant_v1.py
+++ b/watson_developer_cloud/assistant_v1.py
@@ -253,7 +253,7 @@ class AssistantV1(WatsonService):
 
         :param str workspace_id: Unique identifier of the workspace.
         :param dict headers: A `dict` containing the request headers
-        :rtype: None
+        :rtype: dict
         """
         if workspace_id is None:
             raise ValueError('workspace_id must be provided')
@@ -263,13 +263,13 @@ class AssistantV1(WatsonService):
         params = {'version': self.version}
         url = '/v1/workspaces/{0}'.format(
             *self._encode_path_vars(workspace_id))
-        self.request(
+        response = self.request(
             method='DELETE',
             url=url,
             headers=headers,
             params=params,
             accept_json=True)
-        return None
+        return response
 
     def get_workspace(self,
                       workspace_id,
@@ -492,7 +492,7 @@ class AssistantV1(WatsonService):
         :param str workspace_id: Unique identifier of the workspace.
         :param str intent: The intent name.
         :param dict headers: A `dict` containing the request headers
-        :rtype: None
+        :rtype: dict
         """
         if workspace_id is None:
             raise ValueError('workspace_id must be provided')
@@ -504,13 +504,13 @@ class AssistantV1(WatsonService):
         params = {'version': self.version}
         url = '/v1/workspaces/{0}/intents/{1}'.format(*self._encode_path_vars(
             workspace_id, intent))
-        self.request(
+        response = self.request(
             method='DELETE',
             url=url,
             headers=headers,
             params=params,
             accept_json=True)
-        return None
+        return response
 
     def get_intent(self,
                    workspace_id,
@@ -709,7 +709,7 @@ class AssistantV1(WatsonService):
         :param str intent: The intent name.
         :param str text: The text of the user input example.
         :param dict headers: A `dict` containing the request headers
-        :rtype: None
+        :rtype: dict
         """
         if workspace_id is None:
             raise ValueError('workspace_id must be provided')
@@ -723,13 +723,13 @@ class AssistantV1(WatsonService):
         params = {'version': self.version}
         url = '/v1/workspaces/{0}/intents/{1}/examples/{2}'.format(
             *self._encode_path_vars(workspace_id, intent, text))
-        self.request(
+        response = self.request(
             method='DELETE',
             url=url,
             headers=headers,
             params=params,
             accept_json=True)
-        return None
+        return response
 
     def get_example(self,
                     workspace_id,
@@ -913,7 +913,7 @@ class AssistantV1(WatsonService):
         :param str workspace_id: Unique identifier of the workspace.
         :param str text: The text of a user input counterexample (for example, `What are you wearing?`).
         :param dict headers: A `dict` containing the request headers
-        :rtype: None
+        :rtype: dict
         """
         if workspace_id is None:
             raise ValueError('workspace_id must be provided')
@@ -925,13 +925,13 @@ class AssistantV1(WatsonService):
         params = {'version': self.version}
         url = '/v1/workspaces/{0}/counterexamples/{1}'.format(
             *self._encode_path_vars(workspace_id, text))
-        self.request(
+        response = self.request(
             method='DELETE',
             url=url,
             headers=headers,
             params=params,
             accept_json=True)
-        return None
+        return response
 
     def get_counterexample(self,
                            workspace_id,
@@ -1123,7 +1123,7 @@ class AssistantV1(WatsonService):
         :param str workspace_id: Unique identifier of the workspace.
         :param str entity: The name of the entity.
         :param dict headers: A `dict` containing the request headers
-        :rtype: None
+        :rtype: dict
         """
         if workspace_id is None:
             raise ValueError('workspace_id must be provided')
@@ -1135,13 +1135,13 @@ class AssistantV1(WatsonService):
         params = {'version': self.version}
         url = '/v1/workspaces/{0}/entities/{1}'.format(*self._encode_path_vars(
             workspace_id, entity))
-        self.request(
+        response = self.request(
             method='DELETE',
             url=url,
             headers=headers,
             params=params,
             accept_json=True)
-        return None
+        return response
 
     def get_entity(self,
                    workspace_id,
@@ -1364,7 +1364,7 @@ class AssistantV1(WatsonService):
         :param str entity: The name of the entity.
         :param str value: The text of the entity value.
         :param dict headers: A `dict` containing the request headers
-        :rtype: None
+        :rtype: dict
         """
         if workspace_id is None:
             raise ValueError('workspace_id must be provided')
@@ -1378,13 +1378,13 @@ class AssistantV1(WatsonService):
         params = {'version': self.version}
         url = '/v1/workspaces/{0}/entities/{1}/values/{2}'.format(
             *self._encode_path_vars(workspace_id, entity, value))
-        self.request(
+        response = self.request(
             method='DELETE',
             url=url,
             headers=headers,
             params=params,
             accept_json=True)
-        return None
+        return response
 
     def get_value(self,
                   workspace_id,
@@ -1599,7 +1599,7 @@ class AssistantV1(WatsonService):
         :param str value: The text of the entity value.
         :param str synonym: The text of the synonym.
         :param dict headers: A `dict` containing the request headers
-        :rtype: None
+        :rtype: dict
         """
         if workspace_id is None:
             raise ValueError('workspace_id must be provided')
@@ -1615,13 +1615,13 @@ class AssistantV1(WatsonService):
         params = {'version': self.version}
         url = '/v1/workspaces/{0}/entities/{1}/values/{2}/synonyms/{3}'.format(
             *self._encode_path_vars(workspace_id, entity, value, synonym))
-        self.request(
+        response = self.request(
             method='DELETE',
             url=url,
             headers=headers,
             params=params,
             accept_json=True)
-        return None
+        return response
 
     def get_synonym(self,
                     workspace_id,
@@ -1875,7 +1875,7 @@ class AssistantV1(WatsonService):
         :param str workspace_id: Unique identifier of the workspace.
         :param str dialog_node: The dialog node ID (for example, `get_order`).
         :param dict headers: A `dict` containing the request headers
-        :rtype: None
+        :rtype: dict
         """
         if workspace_id is None:
             raise ValueError('workspace_id must be provided')
@@ -1887,13 +1887,13 @@ class AssistantV1(WatsonService):
         params = {'version': self.version}
         url = '/v1/workspaces/{0}/dialog_nodes/{1}'.format(
             *self._encode_path_vars(workspace_id, dialog_node))
-        self.request(
+        response = self.request(
             method='DELETE',
             url=url,
             headers=headers,
             params=params,
             accept_json=True)
-        return None
+        return response
 
     def get_dialog_node(self,
                         workspace_id,

--- a/watson_developer_cloud/conversation_v1.py
+++ b/watson_developer_cloud/conversation_v1.py
@@ -253,7 +253,7 @@ class ConversationV1(WatsonService):
 
         :param str workspace_id: Unique identifier of the workspace.
         :param dict headers: A `dict` containing the request headers
-        :rtype: None
+        :rtype: dict
         """
         if workspace_id is None:
             raise ValueError('workspace_id must be provided')
@@ -263,13 +263,13 @@ class ConversationV1(WatsonService):
         params = {'version': self.version}
         url = '/v1/workspaces/{0}'.format(
             *self._encode_path_vars(workspace_id))
-        self.request(
+        response = self.request(
             method='DELETE',
             url=url,
             headers=headers,
             params=params,
             accept_json=True)
-        return None
+        return response
 
     def get_workspace(self,
                       workspace_id,
@@ -492,7 +492,7 @@ class ConversationV1(WatsonService):
         :param str workspace_id: Unique identifier of the workspace.
         :param str intent: The intent name.
         :param dict headers: A `dict` containing the request headers
-        :rtype: None
+        :rtype: dict
         """
         if workspace_id is None:
             raise ValueError('workspace_id must be provided')
@@ -504,13 +504,13 @@ class ConversationV1(WatsonService):
         params = {'version': self.version}
         url = '/v1/workspaces/{0}/intents/{1}'.format(*self._encode_path_vars(
             workspace_id, intent))
-        self.request(
+        response = self.request(
             method='DELETE',
             url=url,
             headers=headers,
             params=params,
             accept_json=True)
-        return None
+        return response
 
     def get_intent(self,
                    workspace_id,
@@ -709,7 +709,7 @@ class ConversationV1(WatsonService):
         :param str intent: The intent name.
         :param str text: The text of the user input example.
         :param dict headers: A `dict` containing the request headers
-        :rtype: None
+        :rtype: dict
         """
         if workspace_id is None:
             raise ValueError('workspace_id must be provided')
@@ -723,13 +723,13 @@ class ConversationV1(WatsonService):
         params = {'version': self.version}
         url = '/v1/workspaces/{0}/intents/{1}/examples/{2}'.format(
             *self._encode_path_vars(workspace_id, intent, text))
-        self.request(
+        response = self.request(
             method='DELETE',
             url=url,
             headers=headers,
             params=params,
             accept_json=True)
-        return None
+        return response
 
     def get_example(self,
                     workspace_id,
@@ -913,7 +913,7 @@ class ConversationV1(WatsonService):
         :param str workspace_id: Unique identifier of the workspace.
         :param str text: The text of a user input counterexample (for example, `What are you wearing?`).
         :param dict headers: A `dict` containing the request headers
-        :rtype: None
+        :rtype: dict
         """
         if workspace_id is None:
             raise ValueError('workspace_id must be provided')
@@ -925,13 +925,13 @@ class ConversationV1(WatsonService):
         params = {'version': self.version}
         url = '/v1/workspaces/{0}/counterexamples/{1}'.format(
             *self._encode_path_vars(workspace_id, text))
-        self.request(
+        response = self.request(
             method='DELETE',
             url=url,
             headers=headers,
             params=params,
             accept_json=True)
-        return None
+        return response
 
     def get_counterexample(self,
                            workspace_id,
@@ -1123,7 +1123,7 @@ class ConversationV1(WatsonService):
         :param str workspace_id: Unique identifier of the workspace.
         :param str entity: The name of the entity.
         :param dict headers: A `dict` containing the request headers
-        :rtype: None
+        :rtype: dict
         """
         if workspace_id is None:
             raise ValueError('workspace_id must be provided')
@@ -1135,13 +1135,13 @@ class ConversationV1(WatsonService):
         params = {'version': self.version}
         url = '/v1/workspaces/{0}/entities/{1}'.format(*self._encode_path_vars(
             workspace_id, entity))
-        self.request(
+        response = self.request(
             method='DELETE',
             url=url,
             headers=headers,
             params=params,
             accept_json=True)
-        return None
+        return response
 
     def get_entity(self,
                    workspace_id,
@@ -1364,7 +1364,7 @@ class ConversationV1(WatsonService):
         :param str entity: The name of the entity.
         :param str value: The text of the entity value.
         :param dict headers: A `dict` containing the request headers
-        :rtype: None
+        :rtype: dict
         """
         if workspace_id is None:
             raise ValueError('workspace_id must be provided')
@@ -1378,13 +1378,13 @@ class ConversationV1(WatsonService):
         params = {'version': self.version}
         url = '/v1/workspaces/{0}/entities/{1}/values/{2}'.format(
             *self._encode_path_vars(workspace_id, entity, value))
-        self.request(
+        response = self.request(
             method='DELETE',
             url=url,
             headers=headers,
             params=params,
             accept_json=True)
-        return None
+        return response
 
     def get_value(self,
                   workspace_id,
@@ -1599,7 +1599,7 @@ class ConversationV1(WatsonService):
         :param str value: The text of the entity value.
         :param str synonym: The text of the synonym.
         :param dict headers: A `dict` containing the request headers
-        :rtype: None
+        :rtype: dict
         """
         if workspace_id is None:
             raise ValueError('workspace_id must be provided')
@@ -1615,13 +1615,13 @@ class ConversationV1(WatsonService):
         params = {'version': self.version}
         url = '/v1/workspaces/{0}/entities/{1}/values/{2}/synonyms/{3}'.format(
             *self._encode_path_vars(workspace_id, entity, value, synonym))
-        self.request(
+        response = self.request(
             method='DELETE',
             url=url,
             headers=headers,
             params=params,
             accept_json=True)
-        return None
+        return response
 
     def get_synonym(self,
                     workspace_id,
@@ -1875,7 +1875,7 @@ class ConversationV1(WatsonService):
         :param str workspace_id: Unique identifier of the workspace.
         :param str dialog_node: The dialog node ID (for example, `get_order`).
         :param dict headers: A `dict` containing the request headers
-        :rtype: None
+        :rtype: dict
         """
         if workspace_id is None:
             raise ValueError('workspace_id must be provided')
@@ -1887,13 +1887,13 @@ class ConversationV1(WatsonService):
         params = {'version': self.version}
         url = '/v1/workspaces/{0}/dialog_nodes/{1}'.format(
             *self._encode_path_vars(workspace_id, dialog_node))
-        self.request(
+        response = self.request(
             method='DELETE',
             url=url,
             headers=headers,
             params=params,
             accept_json=True)
-        return None
+        return response
 
     def get_dialog_node(self,
                         workspace_id,

--- a/watson_developer_cloud/discovery_v1.py
+++ b/watson_developer_cloud/discovery_v1.py
@@ -845,7 +845,7 @@ class DiscoveryV1(WatsonService):
         :param str environment_id: The ID of the environment.
         :param str collection_id: The ID of the collection.
         :param dict headers: A `dict` containing the request headers
-        :rtype: None
+        :rtype: dict
         """
         if environment_id is None:
             raise ValueError('environment_id must be provided')
@@ -857,13 +857,13 @@ class DiscoveryV1(WatsonService):
         params = {'version': self.version}
         url = '/v1/environments/{0}/collections/{1}/expansions'.format(
             *self._encode_path_vars(environment_id, collection_id))
-        self.request(
+        response = self.request(
             method='DELETE',
             url=url,
             headers=headers,
             params=params,
             accept_json=True)
-        return None
+        return response
 
     def list_expansions(self, environment_id, collection_id, **kwargs):
         """
@@ -1679,7 +1679,7 @@ class DiscoveryV1(WatsonService):
         :param str environment_id: The ID of the environment.
         :param str collection_id: The ID of the collection.
         :param dict headers: A `dict` containing the request headers
-        :rtype: None
+        :rtype: dict
         """
         if environment_id is None:
             raise ValueError('environment_id must be provided')
@@ -1691,13 +1691,13 @@ class DiscoveryV1(WatsonService):
         params = {'version': self.version}
         url = '/v1/environments/{0}/collections/{1}/training_data'.format(
             *self._encode_path_vars(environment_id, collection_id))
-        self.request(
+        response = self.request(
             method='DELETE',
             url=url,
             headers=headers,
             params=params,
             accept_json=True)
-        return None
+        return response
 
     def delete_training_data(self, environment_id, collection_id, query_id,
                              **kwargs):
@@ -1711,7 +1711,7 @@ class DiscoveryV1(WatsonService):
         :param str collection_id: The ID of the collection.
         :param str query_id: The ID of the query used for training.
         :param dict headers: A `dict` containing the request headers
-        :rtype: None
+        :rtype: dict
         """
         if environment_id is None:
             raise ValueError('environment_id must be provided')
@@ -1725,13 +1725,13 @@ class DiscoveryV1(WatsonService):
         params = {'version': self.version}
         url = '/v1/environments/{0}/collections/{1}/training_data/{2}'.format(
             *self._encode_path_vars(environment_id, collection_id, query_id))
-        self.request(
+        response = self.request(
             method='DELETE',
             url=url,
             headers=headers,
             params=params,
             accept_json=True)
-        return None
+        return response
 
     def delete_training_example(self, environment_id, collection_id, query_id,
                                 example_id, **kwargs):
@@ -1745,7 +1745,7 @@ class DiscoveryV1(WatsonService):
         :param str query_id: The ID of the query used for training.
         :param str example_id: The ID of the document as it is indexed.
         :param dict headers: A `dict` containing the request headers
-        :rtype: None
+        :rtype: dict
         """
         if environment_id is None:
             raise ValueError('environment_id must be provided')
@@ -1762,13 +1762,13 @@ class DiscoveryV1(WatsonService):
         url = '/v1/environments/{0}/collections/{1}/training_data/{2}/examples/{3}'.format(
             *self._encode_path_vars(environment_id, collection_id, query_id,
                                     example_id))
-        self.request(
+        response = self.request(
             method='DELETE',
             url=url,
             headers=headers,
             params=params,
             accept_json=True)
-        return None
+        return response
 
     def get_training_data(self, environment_id, collection_id, query_id,
                           **kwargs):

--- a/watson_developer_cloud/natural_language_classifier_v1.py
+++ b/watson_developer_cloud/natural_language_classifier_v1.py
@@ -214,7 +214,7 @@ class NaturalLanguageClassifierV1(WatsonService):
 
         :param str classifier_id: Classifier ID to delete.
         :param dict headers: A `dict` containing the request headers
-        :rtype: None
+        :rtype: dict
         """
         if classifier_id is None:
             raise ValueError('classifier_id must be provided')
@@ -223,9 +223,9 @@ class NaturalLanguageClassifierV1(WatsonService):
             headers.update(kwargs.get('headers'))
         url = '/v1/classifiers/{0}'.format(
             *self._encode_path_vars(classifier_id))
-        self.request(
+        response = self.request(
             method='DELETE', url=url, headers=headers, accept_json=True)
-        return None
+        return response
 
     def get_classifier(self, classifier_id, **kwargs):
         """

--- a/watson_developer_cloud/speech_to_text_v1.py
+++ b/watson_developer_cloud/speech_to_text_v1.py
@@ -565,7 +565,7 @@ class SpeechToTextV1(WatsonService):
 
         :param str id: The ID of the asynchronous job.
         :param dict headers: A `dict` containing the request headers
-        :rtype: None
+        :rtype: dict
         """
         if id is None:
             raise ValueError('id must be provided')
@@ -573,9 +573,9 @@ class SpeechToTextV1(WatsonService):
         if 'headers' in kwargs:
             headers.update(kwargs.get('headers'))
         url = '/v1/recognitions/{0}'.format(*self._encode_path_vars(id))
-        self.request(
+        response = self.request(
             method='DELETE', url=url, headers=headers, accept_json=True)
-        return None
+        return response
 
     def register_callback(self, callback_url, user_secret=None, **kwargs):
         """
@@ -640,7 +640,7 @@ class SpeechToTextV1(WatsonService):
 
         :param str callback_url: The callback URL that is to be unregistered.
         :param dict headers: A `dict` containing the request headers
-        :rtype: None
+        :rtype: dict
         """
         if callback_url is None:
             raise ValueError('callback_url must be provided')
@@ -649,13 +649,13 @@ class SpeechToTextV1(WatsonService):
             headers.update(kwargs.get('headers'))
         params = {'callback_url': callback_url}
         url = '/v1/unregister_callback'
-        self.request(
+        response = self.request(
             method='POST',
             url=url,
             headers=headers,
             params=params,
             accept_json=True)
-        return None
+        return response
 
     #########################
     # Custom language models
@@ -724,7 +724,7 @@ class SpeechToTextV1(WatsonService):
 
         :param str customization_id: The customization ID (GUID) of the custom language model. You must make the request with service credentials created for the instance of the service that owns the custom model.
         :param dict headers: A `dict` containing the request headers
-        :rtype: None
+        :rtype: dict
         """
         if customization_id is None:
             raise ValueError('customization_id must be provided')
@@ -733,9 +733,9 @@ class SpeechToTextV1(WatsonService):
             headers.update(kwargs.get('headers'))
         url = '/v1/customizations/{0}'.format(
             *self._encode_path_vars(customization_id))
-        self.request(
+        response = self.request(
             method='DELETE', url=url, headers=headers, accept_json=True)
-        return None
+        return response
 
     @deprecated('Use delete_language_model() instead.')
     def delete_custom_model(self, modelid):
@@ -813,7 +813,7 @@ class SpeechToTextV1(WatsonService):
 
         :param str customization_id: The customization ID (GUID) of the custom language model. You must make the request with service credentials created for the instance of the service that owns the custom model.
         :param dict headers: A `dict` containing the request headers
-        :rtype: None
+        :rtype: dict
         """
         if customization_id is None:
             raise ValueError('customization_id must be provided')
@@ -822,8 +822,8 @@ class SpeechToTextV1(WatsonService):
             headers.update(kwargs.get('headers'))
         url = '/v1/customizations/{0}/reset'.format(
             *self._encode_path_vars(customization_id))
-        self.request(method='POST', url=url, headers=headers, accept_json=True)
-        return None
+        response = self.request(method='POST', url=url, headers=headers, accept_json=True)
+        return response
 
     def train_language_model(self,
                              customization_id,
@@ -859,7 +859,7 @@ class SpeechToTextV1(WatsonService):
         :param str word_type_to_add: The type of words from the custom language model's words resource on which to train the model: * `all` (the default) trains the model on all new words, regardless of whether they were extracted from corpora or were added or modified by the user. * `user` trains the model only on new words that were added or modified by the user; the model is not trained on new words extracted from corpora.
         :param float customization_weight: Specifies a customization weight for the custom language model. The customization weight tells the service how much weight to give to words from the custom language model compared to those from the base model for speech recognition. Specify a value between 0.0 and 1.0; the default is 0.3.   The default value yields the best performance in general. Assign a higher value if your audio makes frequent use of OOV words from the custom model. Use caution when setting the weight: a higher value can improve the accuracy of phrases from the custom model's domain, but it can negatively affect performance on non-domain phrases.   The value that you assign is used for all recognition requests that use the model. You can override it for any recognition request by specifying a customization weight for that request.
         :param dict headers: A `dict` containing the request headers
-        :rtype: None
+        :rtype: dict
         """
         if customization_id is None:
             raise ValueError('customization_id must be provided')
@@ -872,13 +872,13 @@ class SpeechToTextV1(WatsonService):
         }
         url = '/v1/customizations/{0}/train'.format(
             *self._encode_path_vars(customization_id))
-        self.request(
+        response = self.request(
             method='POST',
             url=url,
             headers=headers,
             params=params,
             accept_json=True)
-        return None
+        return response
 
     @deprecated('Use train_language_model() instead.')
     def train_custom_model(self,
@@ -909,7 +909,7 @@ class SpeechToTextV1(WatsonService):
 
         :param str customization_id: The customization ID (GUID) of the custom language model. You must make the request with service credentials created for the instance of the service that owns the custom model.
         :param dict headers: A `dict` containing the request headers
-        :rtype: None
+        :rtype: dict
         """
         if customization_id is None:
             raise ValueError('customization_id must be provided')
@@ -918,8 +918,8 @@ class SpeechToTextV1(WatsonService):
             headers.update(kwargs.get('headers'))
         url = '/v1/customizations/{0}/upgrade_model'.format(
             *self._encode_path_vars(customization_id))
-        self.request(method='POST', url=url, headers=headers, accept_json=True)
-        return None
+        response = self.request(method='POST', url=url, headers=headers, accept_json=True)
+        return response
 
     #########################
     # Custom corpora
@@ -979,7 +979,7 @@ class SpeechToTextV1(WatsonService):
         :param str corpus_file_content_type: The content type of corpus_file.
         :param str corpus_filename: The filename for corpus_file.
         :param dict headers: A `dict` containing the request headers
-        :rtype: None
+        :rtype: dict
         """
         if customization_id is None:
             raise ValueError('customization_id must be provided')
@@ -997,14 +997,14 @@ class SpeechToTextV1(WatsonService):
         corpus_file_tuple = (corpus_filename, corpus_file, mime_type)
         url = '/v1/customizations/{0}/corpora/{1}'.format(
             *self._encode_path_vars(customization_id, corpus_name))
-        self.request(
+        response = self.request(
             method='POST',
             url=url,
             headers=headers,
             params=params,
             files={'corpus_file': corpus_file_tuple},
             accept_json=True)
-        return None
+        return response
 
     def delete_corpus(self, customization_id, corpus_name, **kwargs):
         """
@@ -1021,7 +1021,7 @@ class SpeechToTextV1(WatsonService):
         :param str customization_id: The customization ID (GUID) of the custom language model. You must make the request with service credentials created for the instance of the service that owns the custom model.
         :param str corpus_name: The name of the corpus for the custom language model. When adding a corpus, do not include spaces in the name; use a localized name that matches the language of the custom model; and do not use the name `user`, which is reserved by the service to denote custom words added or modified by the user.
         :param dict headers: A `dict` containing the request headers
-        :rtype: None
+        :rtype: dict
         """
         if customization_id is None:
             raise ValueError('customization_id must be provided')
@@ -1032,9 +1032,9 @@ class SpeechToTextV1(WatsonService):
             headers.update(kwargs.get('headers'))
         url = '/v1/customizations/{0}/corpora/{1}'.format(
             *self._encode_path_vars(customization_id, corpus_name))
-        self.request(
+        response = self.request(
             method='DELETE', url=url, headers=headers, accept_json=True)
-        return None
+        return response
 
     def get_corpus(self, customization_id, corpus_name, **kwargs):
         """
@@ -1138,7 +1138,7 @@ class SpeechToTextV1(WatsonService):
         :param list[str] sounds_like: An array of sounds-like pronunciations for the custom word. Specify how words that are difficult to pronounce, foreign words, acronyms, and so on can be pronounced by users. For a word that is not in the service's base vocabulary, omit the parameter to have the service automatically generate a sounds-like pronunciation for the word. For a word that is in the service's base vocabulary, use the parameter to specify additional pronunciations for the word. You cannot override the default pronunciation of a word; pronunciations you add augment the pronunciation from the base vocabulary. A word can have at most five sounds-like pronunciations, and a pronunciation can include at most 40 characters not including spaces.
         :param str display_as: An alternative spelling for the custom word when it appears in a transcript. Use the parameter when you want the word to have a spelling that is different from its usual representation or from its spelling in corpora training data.
         :param dict headers: A `dict` containing the request headers
-        :rtype: None
+        :rtype: dict
         """
         if customization_id is None:
             raise ValueError('customization_id must be provided')
@@ -1154,9 +1154,9 @@ class SpeechToTextV1(WatsonService):
         }
         url = '/v1/customizations/{0}/words/{1}'.format(
             *self._encode_path_vars(customization_id, word_name))
-        self.request(
+        response = self.request(
             method='PUT', url=url, headers=headers, json=data, accept_json=True)
-        return None
+        return response
 
     @deprecated('Use add_word instead.')
     def add_custom_word(self, customization_id, custom_word):
@@ -1215,7 +1215,7 @@ class SpeechToTextV1(WatsonService):
         :param str customization_id: The customization ID (GUID) of the custom language model. You must make the request with service credentials created for the instance of the service that owns the custom model.
         :param list[CustomWord] words: An array of objects that provides information about each custom word that is to be added to or updated in the custom language model.
         :param dict headers: A `dict` containing the request headers
-        :rtype: None
+        :rtype: dict
         """
         if customization_id is None:
             raise ValueError('customization_id must be provided')
@@ -1228,13 +1228,13 @@ class SpeechToTextV1(WatsonService):
         data = {'words': words}
         url = '/v1/customizations/{0}/words'.format(
             *self._encode_path_vars(customization_id))
-        self.request(
+        response = self.request(
             method='POST',
             url=url,
             headers=headers,
             json=data,
             accept_json=True)
-        return None
+        return response
 
     @deprecated('Use add_words() instead.')
     def add_custom_words(self, customization_id, custom_words):
@@ -1255,7 +1255,7 @@ class SpeechToTextV1(WatsonService):
         :param str customization_id: The customization ID (GUID) of the custom language model. You must make the request with service credentials created for the instance of the service that owns the custom model.
         :param str word_name: The custom word for the custom language model. When you add or update a custom word with the **Add a custom word** method, do not include spaces in the word. Use a `-` (dash) or `_` (underscore) to connect the tokens of compound words.
         :param dict headers: A `dict` containing the request headers
-        :rtype: None
+        :rtype: dict
         """
         if customization_id is None:
             raise ValueError('customization_id must be provided')
@@ -1266,9 +1266,9 @@ class SpeechToTextV1(WatsonService):
             headers.update(kwargs.get('headers'))
         url = '/v1/customizations/{0}/words/{1}'.format(
             *self._encode_path_vars(customization_id, word_name))
-        self.request(
+        response = self.request(
             method='DELETE', url=url, headers=headers, accept_json=True)
-        return None
+        return response
 
     @deprecated('Use delete_word() instead.')
     def delete_custom_word(self, customization_id, custom_word):
@@ -1400,7 +1400,7 @@ class SpeechToTextV1(WatsonService):
 
         :param str customization_id: The customization ID (GUID) of the custom acoustic model. You must make the request with service credentials created for the instance of the service that owns the custom model.
         :param dict headers: A `dict` containing the request headers
-        :rtype: None
+        :rtype: dict
         """
         if customization_id is None:
             raise ValueError('customization_id must be provided')
@@ -1409,9 +1409,9 @@ class SpeechToTextV1(WatsonService):
             headers.update(kwargs.get('headers'))
         url = '/v1/acoustic_customizations/{0}'.format(
             *self._encode_path_vars(customization_id))
-        self.request(
+        response = self.request(
             method='DELETE', url=url, headers=headers, accept_json=True)
-        return None
+        return response
 
     def get_acoustic_model(self, customization_id, **kwargs):
         """
@@ -1477,7 +1477,7 @@ class SpeechToTextV1(WatsonService):
 
         :param str customization_id: The customization ID (GUID) of the custom acoustic model. You must make the request with service credentials created for the instance of the service that owns the custom model.
         :param dict headers: A `dict` containing the request headers
-        :rtype: None
+        :rtype: dict
         """
         if customization_id is None:
             raise ValueError('customization_id must be provided')
@@ -1486,8 +1486,8 @@ class SpeechToTextV1(WatsonService):
             headers.update(kwargs.get('headers'))
         url = '/v1/acoustic_customizations/{0}/reset'.format(
             *self._encode_path_vars(customization_id))
-        self.request(method='POST', url=url, headers=headers, accept_json=True)
-        return None
+        response = self.request(method='POST', url=url, headers=headers, accept_json=True)
+        return response
 
     def train_acoustic_model(self,
                              customization_id,
@@ -1531,7 +1531,7 @@ class SpeechToTextV1(WatsonService):
         :param str customization_id: The customization ID (GUID) of the custom acoustic model. You must make the request with service credentials created for the instance of the service that owns the custom model.
         :param str custom_language_model_id: The customization ID (GUID) of a custom language model that is to be used during training of the custom acoustic model. Specify a custom language model that has been trained with verbatim transcriptions of the audio resources or that contains words that are relevant to the contents of the audio resources.
         :param dict headers: A `dict` containing the request headers
-        :rtype: None
+        :rtype: dict
         """
         if customization_id is None:
             raise ValueError('customization_id must be provided')
@@ -1541,13 +1541,13 @@ class SpeechToTextV1(WatsonService):
         params = {'custom_language_model_id': custom_language_model_id}
         url = '/v1/acoustic_customizations/{0}/train'.format(
             *self._encode_path_vars(customization_id))
-        self.request(
+        response = self.request(
             method='POST',
             url=url,
             headers=headers,
             params=params,
             accept_json=True)
-        return None
+        return response
 
     def upgrade_acoustic_model(self,
                                customization_id,
@@ -1580,7 +1580,7 @@ class SpeechToTextV1(WatsonService):
         :param str customization_id: The customization ID (GUID) of the custom acoustic model. You must make the request with service credentials created for the instance of the service that owns the custom model.
         :param str custom_language_model_id: If the custom acoustic model was trained with a custom language model, the customization ID (GUID) of that custom language model. The custom language model must be upgraded before the custom acoustic model can be upgraded.
         :param dict headers: A `dict` containing the request headers
-        :rtype: None
+        :rtype: dict
         """
         if customization_id is None:
             raise ValueError('customization_id must be provided')
@@ -1590,13 +1590,13 @@ class SpeechToTextV1(WatsonService):
         params = {'custom_language_model_id': custom_language_model_id}
         url = '/v1/acoustic_customizations/{0}/upgrade_model'.format(
             *self._encode_path_vars(customization_id))
-        self.request(
+        response = self.request(
             method='POST',
             url=url,
             headers=headers,
             params=params,
             accept_json=True)
-        return None
+        return response
 
     #########################
     # Custom audio resources
@@ -1682,7 +1682,7 @@ class SpeechToTextV1(WatsonService):
         :param str contained_content_type: For an archive-type resource, specifies the format of the audio files contained in the archive file. The parameter accepts all of the audio formats supported for use with speech recognition, including the `rate`, `channels`, and `endianness` parameters that are used with some formats. For a complete list of supported audio formats, see [Audio formats](/docs/services/speech-to-text/input.html#formats).
         :param bool allow_overwrite: If `true`, the specified corpus or audio resource overwrites an existing corpus or audio resource with the same name. If `false` (the default), the request fails if a corpus or audio resource with the same name already exists. The parameter has no effect if a corpus or audio resource with the same name does not already exist.
         :param dict headers: A `dict` containing the request headers
-        :rtype: None
+        :rtype: dict
         """
         if customization_id is None:
             raise ValueError('customization_id must be provided')
@@ -1702,14 +1702,14 @@ class SpeechToTextV1(WatsonService):
         data = audio_resource
         url = '/v1/acoustic_customizations/{0}/audio/{1}'.format(
             *self._encode_path_vars(customization_id, audio_name))
-        self.request(
+        response = self.request(
             method='POST',
             url=url,
             headers=headers,
             params=params,
             data=data,
             accept_json=True)
-        return None
+        return response
 
     def delete_audio(self, customization_id, audio_name, **kwargs):
         """
@@ -1726,7 +1726,7 @@ class SpeechToTextV1(WatsonService):
         :param str customization_id: The customization ID (GUID) of the custom acoustic model. You must make the request with service credentials created for the instance of the service that owns the custom model.
         :param str audio_name: The name of the audio resource for the custom acoustic model. When adding an audio resource, do not include spaces in the name; use a localized name that matches the language of the custom model.
         :param dict headers: A `dict` containing the request headers
-        :rtype: None
+        :rtype: dict
         """
         if customization_id is None:
             raise ValueError('customization_id must be provided')
@@ -1737,9 +1737,9 @@ class SpeechToTextV1(WatsonService):
             headers.update(kwargs.get('headers'))
         url = '/v1/acoustic_customizations/{0}/audio/{1}'.format(
             *self._encode_path_vars(customization_id, audio_name))
-        self.request(
+        response = self.request(
             method='DELETE', url=url, headers=headers, accept_json=True)
-        return None
+        return response
 
     def get_audio(self, customization_id, audio_name, **kwargs):
         """

--- a/watson_developer_cloud/text_to_speech_v1.py
+++ b/watson_developer_cloud/text_to_speech_v1.py
@@ -346,7 +346,7 @@ class TextToSpeechV1(WatsonService):
 
         :param str customization_id: The customization ID (GUID) of the custom voice model. You must make the request with service credentials created for the instance of the service that owns the custom model.
         :param dict headers: A `dict` containing the request headers
-        :rtype: None
+        :rtype: dict
         """
         if customization_id is None:
             raise ValueError('customization_id must be provided')
@@ -355,9 +355,9 @@ class TextToSpeechV1(WatsonService):
             headers.update(kwargs.get('headers'))
         url = '/v1/customizations/{0}'.format(
             *self._encode_path_vars(customization_id))
-        self.request(
+        response = self.request(
             method='DELETE', url=url, headers=headers, accept_json=True)
-        return None
+        return response
 
     @deprecated('Use delete_voice_model() instead.')
     def delete_customization(self, customization_id):
@@ -449,7 +449,7 @@ class TextToSpeechV1(WatsonService):
         :param str description: A new description for the custom voice model.
         :param list[Word] words: An array of `Word` objects that provides the words and their translations that are to be added or updated for the custom voice model. Pass an empty array to make no additions or updates.
         :param dict headers: A `dict` containing the request headers
-        :rtype: None
+        :rtype: dict
         """
         if customization_id is None:
             raise ValueError('customization_id must be provided')
@@ -461,13 +461,13 @@ class TextToSpeechV1(WatsonService):
         data = {'name': name, 'description': description, 'words': words}
         url = '/v1/customizations/{0}'.format(
             *self._encode_path_vars(customization_id))
-        self.request(
+        response = self.request(
             method='POST',
             url=url,
             headers=headers,
             json=data,
             accept_json=True)
-        return None
+        return response
 
     @deprecated('Use update_voice_model() instead')
     def update_customization(self, customization_id, name=None,
@@ -499,7 +499,7 @@ class TextToSpeechV1(WatsonService):
         :param str translation: The phonetic or sounds-like translation for the word. A phonetic translation is based on the SSML format for representing the phonetic string of a word either as an IPA translation or as an IBM SPR translation. A sounds-like is one or more words that, when combined, sound like the word.
         :param str part_of_speech: **Japanese only.** The part of speech for the word. The service uses the value to produce the correct intonation for the word. You can create only a single entry, with or without a single part of speech, for any word; you cannot create multiple entries with different parts of speech for the same word. For more information, see [Working with Japanese entries](https://console.bluemix.net/docs/services/text-to-speech/custom-rules.html#jaNotes).
         :param dict headers: A `dict` containing the request headers
-        :rtype: None
+        :rtype: dict
         """
         if customization_id is None:
             raise ValueError('customization_id must be provided')
@@ -513,13 +513,13 @@ class TextToSpeechV1(WatsonService):
         data = {'translation': translation, 'part_of_speech': part_of_speech}
         url = '/v1/customizations/{0}/words/{1}'.format(
             *self._encode_path_vars(customization_id, word))
-        self.request(
+        response = self.request(
             method='PUT',
             url=url,
             headers=headers,
             json=data,
             accept_json=True)
-        return None
+        return response
 
     @deprecated('Use add_word() instead.')
     def set_customization_word(self, customization_id, word, translation):
@@ -539,7 +539,7 @@ class TextToSpeechV1(WatsonService):
         :param str customization_id: The customization ID (GUID) of the custom voice model. You must make the request with service credentials created for the instance of the service that owns the custom model.
         :param list[Word] words: The **Add custom words** method accepts an array of `Word` objects. Each object provides a word that is to be added or updated for the custom voice model and the word's translation.   The **List custom words** method returns an array of `Word` objects. Each object shows a word and its translation from the custom voice model. The words are listed in alphabetical order, with uppercase letters listed before lowercase letters. The array is empty if the custom model contains no words.
         :param dict headers: A `dict` containing the request headers
-        :rtype: None
+        :rtype: dict
         """
         if customization_id is None:
             raise ValueError('customization_id must be provided')
@@ -552,13 +552,13 @@ class TextToSpeechV1(WatsonService):
         data = {'words': words}
         url = '/v1/customizations/{0}/words'.format(
             *self._encode_path_vars(customization_id))
-        self.request(
+        response = self.request(
             method='POST',
             url=url,
             headers=headers,
             json=data,
             accept_json=True)
-        return None
+        return response
 
     @deprecated('Use add_words() instead.')
     def add_customization_words(self, customization_id, words):
@@ -575,7 +575,7 @@ class TextToSpeechV1(WatsonService):
         :param str customization_id: The customization ID (GUID) of the custom voice model. You must make the request with service credentials created for the instance of the service that owns the custom model.
         :param str word: The word that is to be deleted from the custom voice model.
         :param dict headers: A `dict` containing the request headers
-        :rtype: None
+        :rtype: dict
         """
         if customization_id is None:
             raise ValueError('customization_id must be provided')
@@ -586,9 +586,9 @@ class TextToSpeechV1(WatsonService):
             headers.update(kwargs.get('headers'))
         url = '/v1/customizations/{0}/words/{1}'.format(
             *self._encode_path_vars(customization_id, word))
-        self.request(
+        response = self.request(
             method='DELETE', url=url, headers=headers, accept_json=True)
-        return None
+        return response
 
     @deprecated('Use delete_word() instead.')
     def delete_customization_word(self, customization_id, word):

--- a/watson_developer_cloud/visual_recognition_v3.py
+++ b/watson_developer_cloud/visual_recognition_v3.py
@@ -265,7 +265,7 @@ class VisualRecognitionV3(WatsonService):
 
         :param str classifier_id: The ID of the classifier.
         :param dict headers: A `dict` containing the request headers
-        :rtype: None
+        :rtype: dict
         """
         if classifier_id is None:
             raise ValueError('classifier_id must be provided')
@@ -275,13 +275,13 @@ class VisualRecognitionV3(WatsonService):
         params = {'version': self.version}
         url = '/v3/classifiers/{0}'.format(
             *self._encode_path_vars(classifier_id))
-        self.request(
+        response = self.request(
             method='DELETE',
             url=url,
             headers=headers,
             params=params,
             accept_json=True)
-        return None
+        return response
 
     def get_classifier(self, classifier_id, **kwargs):
         """


### PR DESCRIPTION
Allow self.request to return an async coroutine, which then can be awaited.

Nota bene: none of these changes expose requests interface, since all of the update methods actually return a JSON dict. Moreover, it is unclear why this dict should not be returned in the sync case.