### PR TITLE
Python changes for 1.4.0

### DIFF
--- a/examples/speech_to_text_v1.py
+++ b/examples/speech_to_text_v1.py
@@ -50,6 +50,9 @@ class MyRecognizeCallback(RecognizeCallback):
     def on_hypothesis(self, hypothesis):
         print(hypothesis)
 
+    def on_data(self, data):
+        print(data)
+
 mycallback = MyRecognizeCallback()
 with open(join(dirname(__file__), '../resources/speech.wav'),
           'rb') as audio_file:

--- a/test/unit/test_language_translator_v3.py
+++ b/test/unit/test_language_translator_v3.py
@@ -1,0 +1,306 @@
+# coding=utf-8
+
+import json
+import os
+import responses
+import watson_developer_cloud
+from watson_developer_cloud.language_translator_v3 import TranslationResult, TranslationModels, TranslationModel, IdentifiedLanguages, IdentifiableLanguages, DeleteModelResult
+
+platform_url = 'https://gateway.watsonplatform.net'
+service_path = '/language-translator/api'
+base_url = '{0}{1}'.format(platform_url, service_path)
+
+iam_url = "https://iam.bluemix.net/identity/token"
+iam_token_response = """{
+    "access_token": "oAeisG8yqPY7sFR_x66Z15",
+    "token_type": "Bearer",
+    "expires_in": 3600,
+    "expiration": 1524167011,
+    "refresh_token": "jy4gl91BQ"
+}"""
+
+#########################
+# counterexamples
+#########################
+
+@responses.activate
+def test_translate_source_target():
+    service = watson_developer_cloud.LanguageTranslatorV3(
+        version='2018-05-01',
+        iam_api_key='iam_api_key')
+    endpoint = '/v3/translate'
+    url = '{0}{1}'.format(base_url, endpoint)
+    expected = {
+        "character_count": 19,
+        "translations": [{"translation": u"Hello, how are you ? \u20ac"}],
+        "word_count": 4
+    }
+    responses.add(
+        responses.POST,
+        url,
+        body=json.dumps(expected),
+        status=200,
+        content_type='application/json')
+    responses.add(responses.POST, url=iam_url, body=iam_token_response, status=200)
+
+    response = service.translate('Hola, cómo estás? €', source='es', target='en')
+    assert len(responses.calls) == 2
+    assert responses.calls[1].request.url.startswith(url)
+    assert response == expected
+    TranslationResult._from_dict(response)
+
+@responses.activate
+def test_translate_model_id():
+    service = watson_developer_cloud.LanguageTranslatorV3(
+        version='2018-05-01',
+        iam_api_key='iam_api_key')
+    endpoint = '/v3/translate'
+    url = '{0}{1}'.format(base_url, endpoint)
+    expected = {
+        "character_count": 22,
+        "translations": [
+            {
+                "translation": "Messi es el mejor"
+            }
+        ],
+        "word_count": 5
+    }
+    responses.add(
+        responses.POST,
+        url,
+        body=json.dumps(expected),
+        status=200,
+        content_type='application/json')
+    responses.add(responses.POST, url=iam_url, body=iam_token_response, status=200)
+    response = service.translate('Messi is the best ever',
+                                 model_id='en-es-conversational')
+
+    assert len(responses.calls) == 2
+    assert responses.calls[1].request.url.startswith(url)
+    assert response == expected
+    TranslationResult._from_dict(response)
+
+@responses.activate
+def test_identify():
+    service = watson_developer_cloud.LanguageTranslatorV3(
+        version='2018-05-01',
+        iam_api_key='iam_api_key')
+    endpoint = '/v3/identify'
+    url = '{0}{1}'.format(base_url, endpoint)
+    expected = {
+        "languages": [
+            {
+                "confidence": 0.477673,
+                "language": "zh"
+            },
+            {
+                "confidence": 0.262053,
+                "language": "zh-TW"
+            },
+            {
+                "confidence": 0.00958378,
+                "language": "en"
+            }
+        ]
+    }
+    responses.add(
+        responses.POST,
+        url,
+        body=json.dumps(expected),
+        status=200,
+        content_type='application/json')
+    responses.add(responses.POST, url=iam_url, body=iam_token_response, status=200)
+    response = service.identify('祝你有美好的一天')
+    assert len(responses.calls) == 2
+    assert responses.calls[1].request.url.startswith(url)
+    assert response == expected
+    IdentifiedLanguages._from_dict(response)
+
+@responses.activate
+def test_list_identifiable_languages():
+    service = watson_developer_cloud.LanguageTranslatorV3(
+        version='2018-05-01',
+        iam_api_key='iam_api_key')
+    endpoint = '/v3/identifiable_languages'
+    url = '{0}{1}'.format(base_url, endpoint)
+    expected = {
+        "languages": [
+            {
+                "name": "German",
+                "language": "de"
+            },
+            {
+                "name": "Greek",
+                "language": "el"
+            },
+            {
+                "name": "English",
+                "language": "en"
+            },
+            {
+                "name": "Esperanto",
+                "language": "eo"
+            },
+            {
+                "name": "Spanish",
+                "language": "es"
+            },
+            {
+                "name": "Chinese",
+                "language": "zh"
+            }
+            ]
+    }
+    responses.add(
+        responses.GET,
+        url,
+        body=json.dumps(expected),
+        status=200,
+        content_type='application/json')
+    responses.add(responses.POST, url=iam_url, body=iam_token_response, status=200)
+    response = service.list_identifiable_languages()
+    assert len(responses.calls) == 2
+    assert responses.calls[1].request.url.startswith(url)
+    assert response == expected
+    IdentifiableLanguages._from_dict(response)
+
+@responses.activate
+def test_create_model():
+    service = watson_developer_cloud.LanguageTranslatorV3(
+        version='2018-05-01',
+        username='xxx',
+        password='yyy'
+    )
+    endpoint = '/v3/models'
+    url = '{0}{1}'.format(base_url, endpoint)
+    expected = {
+        "status": "available",
+        "model_id": "en-es-conversational",
+        "domain": "conversational",
+        "target": "es",
+        "customizable": False,
+        "source": "en",
+        "base_model_id": "en-es-conversational",
+        "owner": "",
+        "default_model": False,
+        "name": "test_glossary"
+    }
+    responses.add(
+        responses.POST,
+        url,
+        body=json.dumps(expected),
+        status=200,
+        content_type='application/json')
+    with open(os.path.join(os.path.dirname(__file__), '../../resources/language_translator_model.tmx'), 'rb') as custom_model:
+        response = service.create_model('en-fr',
+                                        name='test_glossary',
+                                        forced_glossary=custom_model)
+    assert len(responses.calls) == 1
+    assert responses.calls[0].request.url.startswith(url)
+    assert response == expected
+    TranslationModel._from_dict(response)
+
+@responses.activate
+def test_delete_model():
+    service = watson_developer_cloud.LanguageTranslatorV3(
+        version='2018-05-01',
+        iam_api_key='iam_api_key')
+    model_id = 'en-es-conversational'
+    endpoint = '/v3/models/' + model_id
+    url = '{0}{1}'.format(base_url, endpoint)
+    expected = {
+        "status": "OK",
+    }
+    responses.add(
+        responses.DELETE,
+        url,
+        body=json.dumps(expected),
+        status=200,
+        content_type='application/json')
+    responses.add(responses.POST, url=iam_url, body=iam_token_response, status=200)
+    response = service.delete_model(model_id)
+    assert len(responses.calls) == 2
+    assert responses.calls[1].request.url.startswith(url)
+    assert response == expected
+    DeleteModelResult._from_dict(response)
+
+@responses.activate
+def test_get_model():
+    service = watson_developer_cloud.LanguageTranslatorV3(
+        version='2018-05-01',
+        iam_api_key='iam_api_key')
+    model_id = 'en-es-conversational'
+    endpoint = '/v3/models/' + model_id
+    url = '{0}{1}'.format(base_url, endpoint)
+    expected = {
+        "status": "available",
+        "model_id": "en-es-conversational",
+        "domain": "conversational",
+        "target": "es",
+        "customizable": False,
+        "source": "en",
+        "base_model_id": "",
+        "owner": "",
+        "default_model": False,
+        "name": "en-es-conversational"
+    }
+    responses.add(
+        responses.GET,
+        url,
+        body=json.dumps(expected),
+        status=200,
+        content_type='application/json')
+    responses.add(responses.POST, url=iam_url, body=iam_token_response, status=200)
+    response = service.get_model(model_id)
+    assert len(responses.calls) == 2
+    assert responses.calls[1].request.url.startswith(url)
+    assert response == expected
+    TranslationModel._from_dict(response)
+
+@responses.activate
+def test_list_models():
+    service = watson_developer_cloud.LanguageTranslatorV3(
+        version='2018-05-01',
+        iam_api_key='iam_api_key')
+    endpoint = '/v3/models'
+    url = '{0}{1}'.format(base_url, endpoint)
+    expected = {
+        "models": [
+            {
+                "status": "available",
+                "model_id": "en-es-conversational",
+                "domain": "conversational",
+                "target": "es",
+                "customizable": False,
+                "source": "en",
+                "base_model_id": "",
+                "owner": "",
+                "default_model": False,
+                "name": "en-es-conversational"
+            },
+            {
+                "status": "available",
+                "model_id": "es-en",
+                "domain": "news",
+                "target": "en",
+                "customizable": True,
+                "source": "es",
+                "base_model_id": "",
+                "owner": "",
+                "default_model": True,
+                "name": "es-en"
+            }
+        ]
+    }
+    responses.add(
+        responses.GET,
+        url,
+        body=json.dumps(expected),
+        status=200,
+        content_type='application/json')
+    responses.add(responses.POST, url=iam_url, body=iam_token_response, status=200)
+    response = service.list_models()
+    assert len(responses.calls) == 2
+    assert responses.calls[1].request.url.startswith(url)
+    assert response == expected
+    TranslationModels._from_dict(response)

--- a/watson_developer_cloud/__init__.py
+++ b/watson_developer_cloud/__init__.py
@@ -22,6 +22,7 @@ from .conversation_v1 import ConversationV1
 from .assistant_v1 import AssistantV1
 from .language_translation_v2 import LanguageTranslationV2
 from .language_translator_v2 import LanguageTranslatorV2
+from .language_translator_v3 import LanguageTranslatorV3
 from .natural_language_classifier_v1 import NaturalLanguageClassifierV1
 from .natural_language_understanding_v1 import NaturalLanguageUnderstandingV1
 from .personality_insights_v2 import PersonalityInsightsV2

--- a/watson_developer_cloud/assistant_v1.py
+++ b/watson_developer_cloud/assistant_v1.py
@@ -5256,7 +5256,7 @@ class OutputData(object):
         if hasattr(self, 'nodes_visited') and self.nodes_visited is not None:
             _dict['nodes_visited'] = self.nodes_visited
         if hasattr(self, 'nodes_visited_details'
-                   ) and self.nodes_visited_details is not None:
+                  ) and self.nodes_visited_details is not None:
             _dict['nodes_visited_details'] = [
                 x._to_dict() for x in self.nodes_visited_details
             ]

--- a/watson_developer_cloud/assistant_v1.py
+++ b/watson_developer_cloud/assistant_v1.py
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """
-The IBM Watson Assistant service combines machine learning, natural language
+The IBM Watson&trade; Assistant service combines machine learning, natural language
 understanding, and integrated dialog tools to create conversation flows between your apps
 and your users.
 """
@@ -117,16 +117,26 @@ class AssistantV1(WatsonService):
         """
         Get response to user input.
 
-        Get a response to a user's input.    There is no rate limit for this operation.
+        Get a response to a user's input.
+        There is no rate limit for this operation.
 
         :param str workspace_id: Unique identifier of the workspace.
         :param InputData input: An input object that includes the input text.
-        :param bool alternate_intents: Whether to return more than one intent. Set to `true` to return all matching intents.
-        :param Context context: State information for the conversation. Continue a conversation by including the context object from the previous response.
-        :param list[RuntimeEntity] entities: Entities to use when evaluating the message. Include entities from the previous response to continue using those entities rather than detecting entities in the new input.
-        :param list[RuntimeIntent] intents: Intents to use when evaluating the user input. Include intents from the previous response to continue using those intents rather than trying to recognize intents in the new input.
-        :param OutputData output: System output. Include the output from the previous response to maintain intermediate information over multiple requests.
-        :param bool nodes_visited_details: Whether to include additional diagnostic information about the dialog nodes that were visited during processing of the message.
+        :param bool alternate_intents: Whether to return more than one intent. Set to
+        `true` to return all matching intents.
+        :param Context context: State information for the conversation. Continue a
+        conversation by including the context object from the previous response.
+        :param list[RuntimeEntity] entities: Entities to use when evaluating the message.
+        Include entities from the previous response to continue using those entities
+        rather than detecting entities in the new input.
+        :param list[RuntimeIntent] intents: Intents to use when evaluating the user input.
+        Include intents from the previous response to continue using those intents rather
+        than trying to recognize intents in the new input.
+        :param OutputData output: System output. Include the output from the previous
+        response to maintain intermediate information over multiple requests.
+        :param bool nodes_visited_details: Whether to include additional diagnostic
+        information about the dialog nodes that were visited during processing of the
+        message.
         :param dict headers: A `dict` containing the request headers
         :return: A `dict` containing the `MessageResponse` response.
         :rtype: dict
@@ -190,18 +200,28 @@ class AssistantV1(WatsonService):
         Create workspace.
 
         Create a workspace based on component objects. You must provide workspace
-        components defining the content of the new workspace.    This operation is limited
-        to 30 requests per 30 minutes. For more information, see **Rate limiting**.
+        components defining the content of the new workspace.
+        This operation is limited to 30 requests per 30 minutes. For more information, see
+        **Rate limiting**.
 
-        :param str name: The name of the workspace. This string cannot contain carriage return, newline, or tab characters, and it must be no longer than 64 characters.
-        :param str description: The description of the workspace. This string cannot contain carriage return, newline, or tab characters, and it must be no longer than 128 characters.
+        :param str name: The name of the workspace. This string cannot contain carriage
+        return, newline, or tab characters, and it must be no longer than 64 characters.
+        :param str description: The description of the workspace. This string cannot
+        contain carriage return, newline, or tab characters, and it must be no longer than
+        128 characters.
         :param str language: The language of the workspace.
-        :param list[CreateIntent] intents: An array of objects defining the intents for the workspace.
-        :param list[CreateEntity] entities: An array of objects defining the entities for the workspace.
-        :param list[CreateDialogNode] dialog_nodes: An array of objects defining the nodes in the workspace dialog.
-        :param list[CreateCounterexample] counterexamples: An array of objects defining input examples that have been marked as irrelevant input.
+        :param list[CreateIntent] intents: An array of objects defining the intents for
+        the workspace.
+        :param list[CreateEntity] entities: An array of objects defining the entities for
+        the workspace.
+        :param list[CreateDialogNode] dialog_nodes: An array of objects defining the nodes
+        in the workspace dialog.
+        :param list[CreateCounterexample] counterexamples: An array of objects defining
+        input examples that have been marked as irrelevant input.
         :param object metadata: Any metadata related to the workspace.
-        :param bool learning_opt_out: Whether training data from the workspace can be used by IBM for general service improvements. `true` indicates that workspace training data is not to be used.
+        :param bool learning_opt_out: Whether training data from the workspace can be used
+        by IBM for general service improvements. `true` indicates that workspace training
+        data is not to be used.
         :param dict headers: A `dict` containing the request headers
         :return: A `dict` containing the `Workspace` response.
         :rtype: dict
@@ -248,8 +268,9 @@ class AssistantV1(WatsonService):
         """
         Delete workspace.
 
-        Delete a workspace from the service instance.    This operation is limited to 30
-        requests per 30 minutes. For more information, see **Rate limiting**.
+        Delete a workspace from the service instance.
+        This operation is limited to 30 requests per 30 minutes. For more information, see
+        **Rate limiting**.
 
         :param str workspace_id: Unique identifier of the workspace.
         :param dict headers: A `dict` containing the request headers
@@ -285,8 +306,12 @@ class AssistantV1(WatsonService):
         information, see **Rate limiting**.
 
         :param str workspace_id: Unique identifier of the workspace.
-        :param bool export: Whether to include all element content in the returned data. If **export**=`false`, the returned data includes only information about the element itself. If **export**=`true`, all content, including subelements, is included.
-        :param bool include_audit: Whether to include the audit properties (`created` and `updated` timestamps) in the response.
+        :param bool export: Whether to include all element content in the returned data.
+        If **export**=`false`, the returned data includes only information about the
+        element itself. If **export**=`true`, all content, including subelements, is
+        included.
+        :param bool include_audit: Whether to include the audit properties (`created` and
+        `updated` timestamps) in the response.
         :param dict headers: A `dict` containing the request headers
         :return: A `dict` containing the `WorkspaceExport` response.
         :rtype: dict
@@ -321,15 +346,19 @@ class AssistantV1(WatsonService):
         """
         List workspaces.
 
-        List the workspaces associated with a Watson Assistant service instance.    This
-        operation is limited to 500 requests per 30 minutes. For more information, see
-        **Rate limiting**.
+        List the workspaces associated with a Watson Assistant service instance.
+        This operation is limited to 500 requests per 30 minutes. For more information,
+        see **Rate limiting**.
 
         :param int page_limit: The number of records to return in each page of results.
-        :param bool include_count: Whether to include information about the number of records returned.
-        :param str sort: The attribute by which returned results will be sorted. To reverse the sort order, prefix the value with a minus sign (`-`). Supported values are `name`, `updated`, and `workspace_id`.
+        :param bool include_count: Whether to include information about the number of
+        records returned.
+        :param str sort: The attribute by which returned results will be sorted. To
+        reverse the sort order, prefix the value with a minus sign (`-`). Supported values
+        are `name`, `updated`, and `workspace_id`.
         :param str cursor: A token identifying the page of results to retrieve.
-        :param bool include_audit: Whether to include the audit properties (`created` and `updated` timestamps) in the response.
+        :param bool include_audit: Whether to include the audit properties (`created` and
+        `updated` timestamps) in the response.
         :param dict headers: A `dict` containing the request headers
         :return: A `dict` containing the `WorkspaceCollection` response.
         :rtype: dict
@@ -371,20 +400,38 @@ class AssistantV1(WatsonService):
         Update workspace.
 
         Update an existing workspace with new or modified data. You must provide component
-        objects defining the content of the updated workspace.    This operation is
-        limited to 30 request per 30 minutes. For more information, see **Rate limiting**.
+        objects defining the content of the updated workspace.
+        This operation is limited to 30 request per 30 minutes. For more information, see
+        **Rate limiting**.
 
         :param str workspace_id: Unique identifier of the workspace.
-        :param str name: The name of the workspace. This string cannot contain carriage return, newline, or tab characters, and it must be no longer than 64 characters.
-        :param str description: The description of the workspace. This string cannot contain carriage return, newline, or tab characters, and it must be no longer than 128 characters.
+        :param str name: The name of the workspace. This string cannot contain carriage
+        return, newline, or tab characters, and it must be no longer than 64 characters.
+        :param str description: The description of the workspace. This string cannot
+        contain carriage return, newline, or tab characters, and it must be no longer than
+        128 characters.
         :param str language: The language of the workspace.
-        :param list[CreateIntent] intents: An array of objects defining the intents for the workspace.
-        :param list[CreateEntity] entities: An array of objects defining the entities for the workspace.
-        :param list[CreateDialogNode] dialog_nodes: An array of objects defining the nodes in the workspace dialog.
-        :param list[CreateCounterexample] counterexamples: An array of objects defining input examples that have been marked as irrelevant input.
+        :param list[CreateIntent] intents: An array of objects defining the intents for
+        the workspace.
+        :param list[CreateEntity] entities: An array of objects defining the entities for
+        the workspace.
+        :param list[CreateDialogNode] dialog_nodes: An array of objects defining the nodes
+        in the workspace dialog.
+        :param list[CreateCounterexample] counterexamples: An array of objects defining
+        input examples that have been marked as irrelevant input.
         :param object metadata: Any metadata related to the workspace.
-        :param bool learning_opt_out: Whether training data from the workspace can be used by IBM for general service improvements. `true` indicates that workspace training data is not to be used.
-        :param bool append: Whether the new data is to be appended to the existing data in the workspace. If **append**=`false`, elements included in the new data completely replace the corresponding existing elements, including all subelements. For example, if the new data includes **entities** and **append**=`false`, all existing entities in the workspace are discarded and replaced with the new entities.    If **append**=`true`, existing elements are preserved, and the new elements are added. If any elements in the new data collide with existing elements, the update request fails.
+        :param bool learning_opt_out: Whether training data from the workspace can be used
+        by IBM for general service improvements. `true` indicates that workspace training
+        data is not to be used.
+        :param bool append: Whether the new data is to be appended to the existing data in
+        the workspace. If **append**=`false`, elements included in the new data completely
+        replace the corresponding existing elements, including all subelements. For
+        example, if the new data includes **entities** and **append**=`false`, all
+        existing entities in the workspace are discarded and replaced with the new
+        entities.
+        If **append**=`true`, existing elements are preserved, and the new elements are
+        added. If any elements in the new data collide with existing elements, the update
+        request fails.
         :param dict headers: A `dict` containing the request headers
         :return: A `dict` containing the `Workspace` response.
         :rtype: dict
@@ -443,13 +490,22 @@ class AssistantV1(WatsonService):
         """
         Create intent.
 
-        Create a new intent.    This operation is limited to 2000 requests per 30 minutes.
-        For more information, see **Rate limiting**.
+        Create a new intent.
+        This operation is limited to 2000 requests per 30 minutes. For more information,
+        see **Rate limiting**.
 
         :param str workspace_id: Unique identifier of the workspace.
-        :param str intent: The name of the intent. This string must conform to the following restrictions:  - It can contain only Unicode alphanumeric, underscore, hyphen, and dot characters.  - It cannot begin with the reserved prefix `sys-`.  - It must be no longer than 128 characters.
-        :param str description: The description of the intent. This string cannot contain carriage return, newline, or tab characters, and it must be no longer than 128 characters.
-        :param list[CreateExample] examples: An array of user input examples for the intent.
+        :param str intent: The name of the intent. This string must conform to the
+        following restrictions:
+        - It can contain only Unicode alphanumeric, underscore, hyphen, and dot
+        characters.
+        - It cannot begin with the reserved prefix `sys-`.
+        - It must be no longer than 128 characters.
+        :param str description: The description of the intent. This string cannot contain
+        carriage return, newline, or tab characters, and it must be no longer than 128
+        characters.
+        :param list[CreateExample] examples: An array of user input examples for the
+        intent.
         :param dict headers: A `dict` containing the request headers
         :return: A `dict` containing the `Intent` response.
         :rtype: dict
@@ -486,8 +542,9 @@ class AssistantV1(WatsonService):
         """
         Delete intent.
 
-        Delete an intent from a workspace.    This operation is limited to 2000 requests
-        per 30 minutes. For more information, see **Rate limiting**.
+        Delete an intent from a workspace.
+        This operation is limited to 2000 requests per 30 minutes. For more information,
+        see **Rate limiting**.
 
         :param str workspace_id: Unique identifier of the workspace.
         :param str intent: The intent name.
@@ -521,15 +578,19 @@ class AssistantV1(WatsonService):
         """
         Get intent.
 
-        Get information about an intent, optionally including all intent content.    With
-        **export**=`false`, this operation is limited to 6000 requests per 5 minutes. With
-        **export**=`true`, the limit is 400 requests per 30 minutes. For more information,
-        see **Rate limiting**.
+        Get information about an intent, optionally including all intent content.
+        With **export**=`false`, this operation is limited to 6000 requests per 5 minutes.
+        With **export**=`true`, the limit is 400 requests per 30 minutes. For more
+        information, see **Rate limiting**.
 
         :param str workspace_id: Unique identifier of the workspace.
         :param str intent: The intent name.
-        :param bool export: Whether to include all element content in the returned data. If **export**=`false`, the returned data includes only information about the element itself. If **export**=`true`, all content, including subelements, is included.
-        :param bool include_audit: Whether to include the audit properties (`created` and `updated` timestamps) in the response.
+        :param bool export: Whether to include all element content in the returned data.
+        If **export**=`false`, the returned data includes only information about the
+        element itself. If **export**=`true`, all content, including subelements, is
+        included.
+        :param bool include_audit: Whether to include the audit properties (`created` and
+        `updated` timestamps) in the response.
         :param dict headers: A `dict` containing the request headers
         :return: A `dict` containing the `IntentExport` response.
         :rtype: dict
@@ -568,17 +629,25 @@ class AssistantV1(WatsonService):
         """
         List intents.
 
-        List the intents for a workspace.    With **export**=`false`, this operation is
-        limited to 2000 requests per 30 minutes. With **export**=`true`, the limit is 400
-        requests per 30 minutes. For more information, see **Rate limiting**.
+        List the intents for a workspace.
+        With **export**=`false`, this operation is limited to 2000 requests per 30
+        minutes. With **export**=`true`, the limit is 400 requests per 30 minutes. For
+        more information, see **Rate limiting**.
 
         :param str workspace_id: Unique identifier of the workspace.
-        :param bool export: Whether to include all element content in the returned data. If **export**=`false`, the returned data includes only information about the element itself. If **export**=`true`, all content, including subelements, is included.
+        :param bool export: Whether to include all element content in the returned data.
+        If **export**=`false`, the returned data includes only information about the
+        element itself. If **export**=`true`, all content, including subelements, is
+        included.
         :param int page_limit: The number of records to return in each page of results.
-        :param bool include_count: Whether to include information about the number of records returned.
-        :param str sort: The attribute by which returned results will be sorted. To reverse the sort order, prefix the value with a minus sign (`-`). Supported values are `name`, `updated`, and `workspace_id`.
+        :param bool include_count: Whether to include information about the number of
+        records returned.
+        :param str sort: The attribute by which returned results will be sorted. To
+        reverse the sort order, prefix the value with a minus sign (`-`). Supported values
+        are `name`, `updated`, and `workspace_id`.
         :param str cursor: A token identifying the page of results to retrieve.
-        :param bool include_audit: Whether to include the audit properties (`created` and `updated` timestamps) in the response.
+        :param bool include_audit: Whether to include the audit properties (`created` and
+        `updated` timestamps) in the response.
         :param dict headers: A `dict` containing the request headers
         :return: A `dict` containing the `IntentCollection` response.
         :rtype: dict
@@ -618,14 +687,21 @@ class AssistantV1(WatsonService):
         Update intent.
 
         Update an existing intent with new or modified data. You must provide component
-        objects defining the content of the updated intent.    This operation is limited
-        to 2000 requests per 30 minutes. For more information, see **Rate limiting**.
+        objects defining the content of the updated intent.
+        This operation is limited to 2000 requests per 30 minutes. For more information,
+        see **Rate limiting**.
 
         :param str workspace_id: Unique identifier of the workspace.
         :param str intent: The intent name.
-        :param str new_intent: The name of the intent. This string must conform to the following restrictions:  - It can contain only Unicode alphanumeric, underscore, hyphen, and dot characters.  - It cannot begin with the reserved prefix `sys-`.  - It must be no longer than 128 characters.
+        :param str new_intent: The name of the intent. This string must conform to the
+        following restrictions:
+        - It can contain only Unicode alphanumeric, underscore, hyphen, and dot
+        characters.
+        - It cannot begin with the reserved prefix `sys-`.
+        - It must be no longer than 128 characters.
         :param str new_description: The description of the intent.
-        :param list[CreateExample] new_examples: An array of user input examples for the intent.
+        :param list[CreateExample] new_examples: An array of user input examples for the
+        intent.
         :param dict headers: A `dict` containing the request headers
         :return: A `dict` containing the `Intent` response.
         :rtype: dict
@@ -666,12 +742,17 @@ class AssistantV1(WatsonService):
         """
         Create user input example.
 
-        Add a new user input example to an intent.    This operation is limited to 1000
-        requests per 30 minutes. For more information, see **Rate limiting**.
+        Add a new user input example to an intent.
+        This operation is limited to 1000 requests per 30 minutes. For more information,
+        see **Rate limiting**.
 
         :param str workspace_id: Unique identifier of the workspace.
         :param str intent: The intent name.
-        :param str text: The text of a user input example. This string must conform to the following restrictions:  - It cannot contain carriage return, newline, or tab characters.  - It cannot consist of only whitespace characters.  - It must be no longer than 1024 characters.
+        :param str text: The text of a user input example. This string must conform to the
+        following restrictions:
+        - It cannot contain carriage return, newline, or tab characters.
+        - It cannot consist of only whitespace characters.
+        - It must be no longer than 1024 characters.
         :param dict headers: A `dict` containing the request headers
         :return: A `dict` containing the `Example` response.
         :rtype: dict
@@ -702,8 +783,9 @@ class AssistantV1(WatsonService):
         """
         Delete user input example.
 
-        Delete a user input example from an intent.    This operation is limited to 1000
-        requests per 30 minutes. For more information, see **Rate limiting**.
+        Delete a user input example from an intent.
+        This operation is limited to 1000 requests per 30 minutes. For more information,
+        see **Rate limiting**.
 
         :param str workspace_id: Unique identifier of the workspace.
         :param str intent: The intent name.
@@ -740,13 +822,15 @@ class AssistantV1(WatsonService):
         """
         Get user input example.
 
-        Get information about a user input example.    This operation is limited to 6000
-        requests per 5 minutes. For more information, see **Rate limiting**.
+        Get information about a user input example.
+        This operation is limited to 6000 requests per 5 minutes. For more information,
+        see **Rate limiting**.
 
         :param str workspace_id: Unique identifier of the workspace.
         :param str intent: The intent name.
         :param str text: The text of the user input example.
-        :param bool include_audit: Whether to include the audit properties (`created` and `updated` timestamps) in the response.
+        :param bool include_audit: Whether to include the audit properties (`created` and
+        `updated` timestamps) in the response.
         :param dict headers: A `dict` containing the request headers
         :return: A `dict` containing the `Example` response.
         :rtype: dict
@@ -783,16 +867,21 @@ class AssistantV1(WatsonService):
         """
         List user input examples.
 
-        List the user input examples for an intent.    This operation is limited to 2500
-        requests per 30 minutes. For more information, see **Rate limiting**.
+        List the user input examples for an intent.
+        This operation is limited to 2500 requests per 30 minutes. For more information,
+        see **Rate limiting**.
 
         :param str workspace_id: Unique identifier of the workspace.
         :param str intent: The intent name.
         :param int page_limit: The number of records to return in each page of results.
-        :param bool include_count: Whether to include information about the number of records returned.
-        :param str sort: The attribute by which returned results will be sorted. To reverse the sort order, prefix the value with a minus sign (`-`). Supported values are `name`, `updated`, and `workspace_id`.
+        :param bool include_count: Whether to include information about the number of
+        records returned.
+        :param str sort: The attribute by which returned results will be sorted. To
+        reverse the sort order, prefix the value with a minus sign (`-`). Supported values
+        are `name`, `updated`, and `workspace_id`.
         :param str cursor: A token identifying the page of results to retrieve.
-        :param bool include_audit: Whether to include the audit properties (`created` and `updated` timestamps) in the response.
+        :param bool include_audit: Whether to include the audit properties (`created` and
+        `updated` timestamps) in the response.
         :param dict headers: A `dict` containing the request headers
         :return: A `dict` containing the `ExampleCollection` response.
         :rtype: dict
@@ -831,13 +920,18 @@ class AssistantV1(WatsonService):
         """
         Update user input example.
 
-        Update the text of a user input example.    This operation is limited to 1000
-        requests per 30 minutes. For more information, see **Rate limiting**.
+        Update the text of a user input example.
+        This operation is limited to 1000 requests per 30 minutes. For more information,
+        see **Rate limiting**.
 
         :param str workspace_id: Unique identifier of the workspace.
         :param str intent: The intent name.
         :param str text: The text of the user input example.
-        :param str new_text: The text of the user input example. This string must conform to the following restrictions:  - It cannot contain carriage return, newline, or tab characters.  - It cannot consist of only whitespace characters.  - It must be no longer than 1024 characters.
+        :param str new_text: The text of the user input example. This string must conform
+        to the following restrictions:
+        - It cannot contain carriage return, newline, or tab characters.
+        - It cannot consist of only whitespace characters.
+        - It must be no longer than 1024 characters.
         :param dict headers: A `dict` containing the request headers
         :return: A `dict` containing the `Example` response.
         :rtype: dict
@@ -873,11 +967,16 @@ class AssistantV1(WatsonService):
         Create counterexample.
 
         Add a new counterexample to a workspace. Counterexamples are examples that have
-        been marked as irrelevant input.    This operation is limited to 1000 requests per
-        30 minutes. For more information, see **Rate limiting**.
+        been marked as irrelevant input.
+        This operation is limited to 1000 requests per 30 minutes. For more information,
+        see **Rate limiting**.
 
         :param str workspace_id: Unique identifier of the workspace.
-        :param str text: The text of a user input marked as irrelevant input. This string must conform to the following restrictions:  - It cannot contain carriage return, newline, or tab characters  - It cannot consist of only whitespace characters  - It must be no longer than 1024 characters.
+        :param str text: The text of a user input marked as irrelevant input. This string
+        must conform to the following restrictions:
+        - It cannot contain carriage return, newline, or tab characters
+        - It cannot consist of only whitespace characters
+        - It must be no longer than 1024 characters.
         :param dict headers: A `dict` containing the request headers
         :return: A `dict` containing the `Counterexample` response.
         :rtype: dict
@@ -907,11 +1006,13 @@ class AssistantV1(WatsonService):
         Delete counterexample.
 
         Delete a counterexample from a workspace. Counterexamples are examples that have
-        been marked as irrelevant input.    This operation is limited to 1000 requests per
-        30 minutes. For more information, see **Rate limiting**.
+        been marked as irrelevant input.
+        This operation is limited to 1000 requests per 30 minutes. For more information,
+        see **Rate limiting**.
 
         :param str workspace_id: Unique identifier of the workspace.
-        :param str text: The text of a user input counterexample (for example, `What are you wearing?`).
+        :param str text: The text of a user input counterexample (for example, `What are
+        you wearing?`).
         :param dict headers: A `dict` containing the request headers
         :rtype: None
         """
@@ -942,12 +1043,15 @@ class AssistantV1(WatsonService):
         Get counterexample.
 
         Get information about a counterexample. Counterexamples are examples that have
-        been marked as irrelevant input.    This operation is limited to 6000 requests per
-        5 minutes. For more information, see **Rate limiting**.
+        been marked as irrelevant input.
+        This operation is limited to 6000 requests per 5 minutes. For more information,
+        see **Rate limiting**.
 
         :param str workspace_id: Unique identifier of the workspace.
-        :param str text: The text of a user input counterexample (for example, `What are you wearing?`).
-        :param bool include_audit: Whether to include the audit properties (`created` and `updated` timestamps) in the response.
+        :param str text: The text of a user input counterexample (for example, `What are
+        you wearing?`).
+        :param bool include_audit: Whether to include the audit properties (`created` and
+        `updated` timestamps) in the response.
         :param dict headers: A `dict` containing the request headers
         :return: A `dict` containing the `Counterexample` response.
         :rtype: dict
@@ -982,15 +1086,20 @@ class AssistantV1(WatsonService):
         List counterexamples.
 
         List the counterexamples for a workspace. Counterexamples are examples that have
-        been marked as irrelevant input.    This operation is limited to 2500 requests per
-        30 minutes. For more information, see **Rate limiting**.
+        been marked as irrelevant input.
+        This operation is limited to 2500 requests per 30 minutes. For more information,
+        see **Rate limiting**.
 
         :param str workspace_id: Unique identifier of the workspace.
         :param int page_limit: The number of records to return in each page of results.
-        :param bool include_count: Whether to include information about the number of records returned.
-        :param str sort: The attribute by which returned results will be sorted. To reverse the sort order, prefix the value with a minus sign (`-`). Supported values are `name`, `updated`, and `workspace_id`.
+        :param bool include_count: Whether to include information about the number of
+        records returned.
+        :param str sort: The attribute by which returned results will be sorted. To
+        reverse the sort order, prefix the value with a minus sign (`-`). Supported values
+        are `name`, `updated`, and `workspace_id`.
         :param str cursor: A token identifying the page of results to retrieve.
-        :param bool include_audit: Whether to include the audit properties (`created` and `updated` timestamps) in the response.
+        :param bool include_audit: Whether to include the audit properties (`created` and
+        `updated` timestamps) in the response.
         :param dict headers: A `dict` containing the request headers
         :return: A `dict` containing the `CounterexampleCollection` response.
         :rtype: dict
@@ -1027,11 +1136,13 @@ class AssistantV1(WatsonService):
         Update counterexample.
 
         Update the text of a counterexample. Counterexamples are examples that have been
-        marked as irrelevant input.    This operation is limited to 1000 requests per 30
-        minutes. For more information, see **Rate limiting**.
+        marked as irrelevant input.
+        This operation is limited to 1000 requests per 30 minutes. For more information,
+        see **Rate limiting**.
 
         :param str workspace_id: Unique identifier of the workspace.
-        :param str text: The text of a user input counterexample (for example, `What are you wearing?`).
+        :param str text: The text of a user input counterexample (for example, `What are
+        you wearing?`).
         :param str new_text: The text of a user input counterexample.
         :param dict headers: A `dict` containing the request headers
         :return: A `dict` containing the `Counterexample` response.
@@ -1072,12 +1183,19 @@ class AssistantV1(WatsonService):
         """
         Create entity.
 
-        Create a new entity.    This operation is limited to 1000 requests per 30 minutes.
-        For more information, see **Rate limiting**.
+        Create a new entity.
+        This operation is limited to 1000 requests per 30 minutes. For more information,
+        see **Rate limiting**.
 
         :param str workspace_id: Unique identifier of the workspace.
-        :param str entity: The name of the entity. This string must conform to the following restrictions:  - It can contain only Unicode alphanumeric, underscore, and hyphen characters.  - It cannot begin with the reserved prefix `sys-`.  - It must be no longer than 64 characters.
-        :param str description: The description of the entity. This string cannot contain carriage return, newline, or tab characters, and it must be no longer than 128 characters.
+        :param str entity: The name of the entity. This string must conform to the
+        following restrictions:
+        - It can contain only Unicode alphanumeric, underscore, and hyphen characters.
+        - It cannot begin with the reserved prefix `sys-`.
+        - It must be no longer than 64 characters.
+        :param str description: The description of the entity. This string cannot contain
+        carriage return, newline, or tab characters, and it must be no longer than 128
+        characters.
         :param object metadata: Any metadata related to the value.
         :param list[CreateValue] values: An array of objects describing the entity values.
         :param bool fuzzy_match: Whether to use fuzzy matching for the entity.
@@ -1117,8 +1235,9 @@ class AssistantV1(WatsonService):
         """
         Delete entity.
 
-        Delete an entity from a workspace.    This operation is limited to 1000 requests
-        per 30 minutes. For more information, see **Rate limiting**.
+        Delete an entity from a workspace.
+        This operation is limited to 1000 requests per 30 minutes. For more information,
+        see **Rate limiting**.
 
         :param str workspace_id: Unique identifier of the workspace.
         :param str entity: The name of the entity.
@@ -1152,15 +1271,19 @@ class AssistantV1(WatsonService):
         """
         Get entity.
 
-        Get information about an entity, optionally including all entity content.    With
-        **export**=`false`, this operation is limited to 6000 requests per 5 minutes. With
-        **export**=`true`, the limit is 200 requests per 30 minutes. For more information,
-        see **Rate limiting**.
+        Get information about an entity, optionally including all entity content.
+        With **export**=`false`, this operation is limited to 6000 requests per 5 minutes.
+        With **export**=`true`, the limit is 200 requests per 30 minutes. For more
+        information, see **Rate limiting**.
 
         :param str workspace_id: Unique identifier of the workspace.
         :param str entity: The name of the entity.
-        :param bool export: Whether to include all element content in the returned data. If **export**=`false`, the returned data includes only information about the element itself. If **export**=`true`, all content, including subelements, is included.
-        :param bool include_audit: Whether to include the audit properties (`created` and `updated` timestamps) in the response.
+        :param bool export: Whether to include all element content in the returned data.
+        If **export**=`false`, the returned data includes only information about the
+        element itself. If **export**=`true`, all content, including subelements, is
+        included.
+        :param bool include_audit: Whether to include the audit properties (`created` and
+        `updated` timestamps) in the response.
         :param dict headers: A `dict` containing the request headers
         :return: A `dict` containing the `EntityExport` response.
         :rtype: dict
@@ -1199,17 +1322,25 @@ class AssistantV1(WatsonService):
         """
         List entities.
 
-        List the entities for a workspace.    With **export**=`false`, this operation is
-        limited to 1000 requests per 30 minutes. With **export**=`true`, the limit is 200
-        requests per 30 minutes. For more information, see **Rate limiting**.
+        List the entities for a workspace.
+        With **export**=`false`, this operation is limited to 1000 requests per 30
+        minutes. With **export**=`true`, the limit is 200 requests per 30 minutes. For
+        more information, see **Rate limiting**.
 
         :param str workspace_id: Unique identifier of the workspace.
-        :param bool export: Whether to include all element content in the returned data. If **export**=`false`, the returned data includes only information about the element itself. If **export**=`true`, all content, including subelements, is included.
+        :param bool export: Whether to include all element content in the returned data.
+        If **export**=`false`, the returned data includes only information about the
+        element itself. If **export**=`true`, all content, including subelements, is
+        included.
         :param int page_limit: The number of records to return in each page of results.
-        :param bool include_count: Whether to include information about the number of records returned.
-        :param str sort: The attribute by which returned results will be sorted. To reverse the sort order, prefix the value with a minus sign (`-`). Supported values are `name`, `updated`, and `workspace_id`.
+        :param bool include_count: Whether to include information about the number of
+        records returned.
+        :param str sort: The attribute by which returned results will be sorted. To
+        reverse the sort order, prefix the value with a minus sign (`-`). Supported values
+        are `name`, `updated`, and `workspace_id`.
         :param str cursor: A token identifying the page of results to retrieve.
-        :param bool include_audit: Whether to include the audit properties (`created` and `updated` timestamps) in the response.
+        :param bool include_audit: Whether to include the audit properties (`created` and
+        `updated` timestamps) in the response.
         :param dict headers: A `dict` containing the request headers
         :return: A `dict` containing the `EntityCollection` response.
         :rtype: dict
@@ -1251,13 +1382,20 @@ class AssistantV1(WatsonService):
         Update entity.
 
         Update an existing entity with new or modified data. You must provide component
-        objects defining the content of the updated entity.    This operation is limited
-        to 1000 requests per 30 minutes. For more information, see **Rate limiting**.
+        objects defining the content of the updated entity.
+        This operation is limited to 1000 requests per 30 minutes. For more information,
+        see **Rate limiting**.
 
         :param str workspace_id: Unique identifier of the workspace.
         :param str entity: The name of the entity.
-        :param str new_entity: The name of the entity. This string must conform to the following restrictions:  - It can contain only Unicode alphanumeric, underscore, and hyphen characters.  - It cannot begin with the reserved prefix `sys-`.  - It must be no longer than 64 characters.
-        :param str new_description: The description of the entity. This string cannot contain carriage return, newline, or tab characters, and it must be no longer than 128 characters.
+        :param str new_entity: The name of the entity. This string must conform to the
+        following restrictions:
+        - It can contain only Unicode alphanumeric, underscore, and hyphen characters.
+        - It cannot begin with the reserved prefix `sys-`.
+        - It must be no longer than 64 characters.
+        :param str new_description: The description of the entity. This string cannot
+        contain carriage return, newline, or tab characters, and it must be no longer than
+        128 characters.
         :param object new_metadata: Any metadata related to the entity.
         :param bool new_fuzzy_match: Whether to use fuzzy matching for the entity.
         :param list[CreateValue] new_values: An array of entity values.
@@ -1311,15 +1449,29 @@ class AssistantV1(WatsonService):
         """
         Add entity value.
 
-        Create a new value for an entity.    This operation is limited to 1000 requests
-        per 30 minutes. For more information, see **Rate limiting**.
+        Create a new value for an entity.
+        This operation is limited to 1000 requests per 30 minutes. For more information,
+        see **Rate limiting**.
 
         :param str workspace_id: Unique identifier of the workspace.
         :param str entity: The name of the entity.
-        :param str value: The text of the entity value. This string must conform to the following restrictions:  - It cannot contain carriage return, newline, or tab characters.  - It cannot consist of only whitespace characters.  - It must be no longer than 64 characters.
+        :param str value: The text of the entity value. This string must conform to the
+        following restrictions:
+        - It cannot contain carriage return, newline, or tab characters.
+        - It cannot consist of only whitespace characters.
+        - It must be no longer than 64 characters.
         :param object metadata: Any metadata related to the entity value.
-        :param list[str] synonyms: An array containing any synonyms for the entity value. You can provide either synonyms or patterns (as indicated by **type**), but not both. A synonym must conform to the following restrictions:  - It cannot contain carriage return, newline, or tab characters.  - It cannot consist of only whitespace characters.  - It must be no longer than 64 characters.
-        :param list[str] patterns: An array of patterns for the entity value. You can provide either synonyms or patterns (as indicated by **type**), but not both. A pattern is a regular expression no longer than 128 characters. For more information about how to specify a pattern, see the [documentation](https://console.bluemix.net/docs/services/conversation/entities.html#creating-entities).
+        :param list[str] synonyms: An array containing any synonyms for the entity value.
+        You can provide either synonyms or patterns (as indicated by **type**), but not
+        both. A synonym must conform to the following restrictions:
+        - It cannot contain carriage return, newline, or tab characters.
+        - It cannot consist of only whitespace characters.
+        - It must be no longer than 64 characters.
+        :param list[str] patterns: An array of patterns for the entity value. You can
+        provide either synonyms or patterns (as indicated by **type**), but not both. A
+        pattern is a regular expression no longer than 128 characters. For more
+        information about how to specify a pattern, see the
+        [documentation](https://console.bluemix.net/docs/services/conversation/entities.html#creating-entities).
         :param str value_type: Specifies the type of value.
         :param dict headers: A `dict` containing the request headers
         :return: A `dict` containing the `Value` response.
@@ -1357,8 +1509,9 @@ class AssistantV1(WatsonService):
         """
         Delete entity value.
 
-        Delete a value from an entity.    This operation is limited to 1000 requests per
-        30 minutes. For more information, see **Rate limiting**.
+        Delete a value from an entity.
+        This operation is limited to 1000 requests per 30 minutes. For more information,
+        see **Rate limiting**.
 
         :param str workspace_id: Unique identifier of the workspace.
         :param str entity: The name of the entity.
@@ -1396,14 +1549,19 @@ class AssistantV1(WatsonService):
         """
         Get entity value.
 
-        Get information about an entity value.    This operation is limited to 6000
-        requests per 5 minutes. For more information, see **Rate limiting**.
+        Get information about an entity value.
+        This operation is limited to 6000 requests per 5 minutes. For more information,
+        see **Rate limiting**.
 
         :param str workspace_id: Unique identifier of the workspace.
         :param str entity: The name of the entity.
         :param str value: The text of the entity value.
-        :param bool export: Whether to include all element content in the returned data. If **export**=`false`, the returned data includes only information about the element itself. If **export**=`true`, all content, including subelements, is included.
-        :param bool include_audit: Whether to include the audit properties (`created` and `updated` timestamps) in the response.
+        :param bool export: Whether to include all element content in the returned data.
+        If **export**=`false`, the returned data includes only information about the
+        element itself. If **export**=`true`, all content, including subelements, is
+        included.
+        :param bool include_audit: Whether to include the audit properties (`created` and
+        `updated` timestamps) in the response.
         :param dict headers: A `dict` containing the request headers
         :return: A `dict` containing the `ValueExport` response.
         :rtype: dict
@@ -1445,17 +1603,25 @@ class AssistantV1(WatsonService):
         """
         List entity values.
 
-        List the values for an entity.    This operation is limited to 2500 requests per
-        30 minutes. For more information, see **Rate limiting**.
+        List the values for an entity.
+        This operation is limited to 2500 requests per 30 minutes. For more information,
+        see **Rate limiting**.
 
         :param str workspace_id: Unique identifier of the workspace.
         :param str entity: The name of the entity.
-        :param bool export: Whether to include all element content in the returned data. If **export**=`false`, the returned data includes only information about the element itself. If **export**=`true`, all content, including subelements, is included.
+        :param bool export: Whether to include all element content in the returned data.
+        If **export**=`false`, the returned data includes only information about the
+        element itself. If **export**=`true`, all content, including subelements, is
+        included.
         :param int page_limit: The number of records to return in each page of results.
-        :param bool include_count: Whether to include information about the number of records returned.
-        :param str sort: The attribute by which returned results will be sorted. To reverse the sort order, prefix the value with a minus sign (`-`). Supported values are `name`, `updated`, and `workspace_id`.
+        :param bool include_count: Whether to include information about the number of
+        records returned.
+        :param str sort: The attribute by which returned results will be sorted. To
+        reverse the sort order, prefix the value with a minus sign (`-`). Supported values
+        are `name`, `updated`, and `workspace_id`.
         :param str cursor: A token identifying the page of results to retrieve.
-        :param bool include_audit: Whether to include the audit properties (`created` and `updated` timestamps) in the response.
+        :param bool include_audit: Whether to include the audit properties (`created` and
+        `updated` timestamps) in the response.
         :param dict headers: A `dict` containing the request headers
         :return: A `dict` containing the `ValueCollection` response.
         :rtype: dict
@@ -1500,18 +1666,31 @@ class AssistantV1(WatsonService):
         Update entity value.
 
         Update an existing entity value with new or modified data. You must provide
-        component objects defining the content of the updated entity value.    This
-        operation is limited to 1000 requests per 30 minutes. For more information, see
-        **Rate limiting**.
+        component objects defining the content of the updated entity value.
+        This operation is limited to 1000 requests per 30 minutes. For more information,
+        see **Rate limiting**.
 
         :param str workspace_id: Unique identifier of the workspace.
         :param str entity: The name of the entity.
         :param str value: The text of the entity value.
-        :param str new_value: The text of the entity value. This string must conform to the following restrictions:  - It cannot contain carriage return, newline, or tab characters.  - It cannot consist of only whitespace characters.  - It must be no longer than 64 characters.
+        :param str new_value: The text of the entity value. This string must conform to
+        the following restrictions:
+        - It cannot contain carriage return, newline, or tab characters.
+        - It cannot consist of only whitespace characters.
+        - It must be no longer than 64 characters.
         :param object new_metadata: Any metadata related to the entity value.
         :param str new_type: Specifies the type of value.
-        :param list[str] new_synonyms: An array of synonyms for the entity value. You can provide either synonyms or patterns (as indicated by **type**), but not both. A synonym must conform to the following resrictions:  - It cannot contain carriage return, newline, or tab characters.  - It cannot consist of only whitespace characters.  - It must be no longer than 64 characters.
-        :param list[str] new_patterns: An array of patterns for the entity value. You can provide either synonyms or patterns (as indicated by **type**), but not both. A pattern is a regular expression no longer than 128 characters. For more information about how to specify a pattern, see the [documentation](https://console.bluemix.net/docs/services/conversation/entities.html#creating-entities).
+        :param list[str] new_synonyms: An array of synonyms for the entity value. You can
+        provide either synonyms or patterns (as indicated by **type**), but not both. A
+        synonym must conform to the following resrictions:
+        - It cannot contain carriage return, newline, or tab characters.
+        - It cannot consist of only whitespace characters.
+        - It must be no longer than 64 characters.
+        :param list[str] new_patterns: An array of patterns for the entity value. You can
+        provide either synonyms or patterns (as indicated by **type**), but not both. A
+        pattern is a regular expression no longer than 128 characters. For more
+        information about how to specify a pattern, see the
+        [documentation](https://console.bluemix.net/docs/services/conversation/entities.html#creating-entities).
         :param dict headers: A `dict` containing the request headers
         :return: A `dict` containing the `Value` response.
         :rtype: dict
@@ -1552,13 +1731,18 @@ class AssistantV1(WatsonService):
         """
         Add entity value synonym.
 
-        Add a new synonym to an entity value.    This operation is limited to 1000
-        requests per 30 minutes. For more information, see **Rate limiting**.
+        Add a new synonym to an entity value.
+        This operation is limited to 1000 requests per 30 minutes. For more information,
+        see **Rate limiting**.
 
         :param str workspace_id: Unique identifier of the workspace.
         :param str entity: The name of the entity.
         :param str value: The text of the entity value.
-        :param str synonym: The text of the synonym. This string must conform to the following restrictions:  - It cannot contain carriage return, newline, or tab characters.  - It cannot consist of only whitespace characters.  - It must be no longer than 64 characters.
+        :param str synonym: The text of the synonym. This string must conform to the
+        following restrictions:
+        - It cannot contain carriage return, newline, or tab characters.
+        - It cannot consist of only whitespace characters.
+        - It must be no longer than 64 characters.
         :param dict headers: A `dict` containing the request headers
         :return: A `dict` containing the `Synonym` response.
         :rtype: dict
@@ -1591,8 +1775,9 @@ class AssistantV1(WatsonService):
         """
         Delete entity value synonym.
 
-        Delete a synonym from an entity value.    This operation is limited to 1000
-        requests per 30 minutes. For more information, see **Rate limiting**.
+        Delete a synonym from an entity value.
+        This operation is limited to 1000 requests per 30 minutes. For more information,
+        see **Rate limiting**.
 
         :param str workspace_id: Unique identifier of the workspace.
         :param str entity: The name of the entity.
@@ -1633,14 +1818,16 @@ class AssistantV1(WatsonService):
         """
         Get entity value synonym.
 
-        Get information about a synonym of an entity value.    This operation is limited
-        to 6000 requests per 5 minutes. For more information, see **Rate limiting**.
+        Get information about a synonym of an entity value.
+        This operation is limited to 6000 requests per 5 minutes. For more information,
+        see **Rate limiting**.
 
         :param str workspace_id: Unique identifier of the workspace.
         :param str entity: The name of the entity.
         :param str value: The text of the entity value.
         :param str synonym: The text of the synonym.
-        :param bool include_audit: Whether to include the audit properties (`created` and `updated` timestamps) in the response.
+        :param bool include_audit: Whether to include the audit properties (`created` and
+        `updated` timestamps) in the response.
         :param dict headers: A `dict` containing the request headers
         :return: A `dict` containing the `Synonym` response.
         :rtype: dict
@@ -1680,17 +1867,22 @@ class AssistantV1(WatsonService):
         """
         List entity value synonyms.
 
-        List the synonyms for an entity value.    This operation is limited to 2500
-        requests per 30 minutes. For more information, see **Rate limiting**.
+        List the synonyms for an entity value.
+        This operation is limited to 2500 requests per 30 minutes. For more information,
+        see **Rate limiting**.
 
         :param str workspace_id: Unique identifier of the workspace.
         :param str entity: The name of the entity.
         :param str value: The text of the entity value.
         :param int page_limit: The number of records to return in each page of results.
-        :param bool include_count: Whether to include information about the number of records returned.
-        :param str sort: The attribute by which returned results will be sorted. To reverse the sort order, prefix the value with a minus sign (`-`). Supported values are `name`, `updated`, and `workspace_id`.
+        :param bool include_count: Whether to include information about the number of
+        records returned.
+        :param str sort: The attribute by which returned results will be sorted. To
+        reverse the sort order, prefix the value with a minus sign (`-`). Supported values
+        are `name`, `updated`, and `workspace_id`.
         :param str cursor: A token identifying the page of results to retrieve.
-        :param bool include_audit: Whether to include the audit properties (`created` and `updated` timestamps) in the response.
+        :param bool include_audit: Whether to include the audit properties (`created` and
+        `updated` timestamps) in the response.
         :param dict headers: A `dict` containing the request headers
         :return: A `dict` containing the `SynonymCollection` response.
         :rtype: dict
@@ -1732,15 +1924,19 @@ class AssistantV1(WatsonService):
         """
         Update entity value synonym.
 
-        Update an existing entity value synonym with new text.    This operation is
-        limited to 1000 requests per 30 minutes. For more information, see **Rate
-        limiting**.
+        Update an existing entity value synonym with new text.
+        This operation is limited to 1000 requests per 30 minutes. For more information,
+        see **Rate limiting**.
 
         :param str workspace_id: Unique identifier of the workspace.
         :param str entity: The name of the entity.
         :param str value: The text of the entity value.
         :param str synonym: The text of the synonym.
-        :param str new_synonym: The text of the synonym. This string must conform to the following restrictions:  - It cannot contain carriage return, newline, or tab characters.  - It cannot consist of only whitespace characters.  - It must be no longer than 64 characters.
+        :param str new_synonym: The text of the synonym. This string must conform to the
+        following restrictions:
+        - It cannot contain carriage return, newline, or tab characters.
+        - It cannot consist of only whitespace characters.
+        - It must be no longer than 64 characters.
         :param dict headers: A `dict` containing the request headers
         :return: A `dict` containing the `Synonym` response.
         :rtype: dict
@@ -1796,27 +1992,46 @@ class AssistantV1(WatsonService):
         """
         Create dialog node.
 
-        Create a new dialog node.    This operation is limited to 500 requests per 30
-        minutes. For more information, see **Rate limiting**.
+        Create a new dialog node.
+        This operation is limited to 500 requests per 30 minutes. For more information,
+        see **Rate limiting**.
 
         :param str workspace_id: Unique identifier of the workspace.
-        :param str dialog_node: The dialog node ID. This string must conform to the following restrictions:  - It can contain only Unicode alphanumeric, space, underscore, hyphen, and dot characters.  - It must be no longer than 1024 characters.
-        :param str description: The description of the dialog node. This string cannot contain carriage return, newline, or tab characters, and it must be no longer than 128 characters.
-        :param str conditions: The condition that will trigger the dialog node. This string cannot contain carriage return, newline, or tab characters, and it must be no longer than 2048 characters.
+        :param str dialog_node: The dialog node ID. This string must conform to the
+        following restrictions:
+        - It can contain only Unicode alphanumeric, space, underscore, hyphen, and dot
+        characters.
+        - It must be no longer than 1024 characters.
+        :param str description: The description of the dialog node. This string cannot
+        contain carriage return, newline, or tab characters, and it must be no longer than
+        128 characters.
+        :param str conditions: The condition that will trigger the dialog node. This
+        string cannot contain carriage return, newline, or tab characters, and it must be
+        no longer than 2048 characters.
         :param str parent: The ID of the parent dialog node.
         :param str previous_sibling: The ID of the previous dialog node.
-        :param object output: The output of the dialog node. For more information about how to specify dialog node output, see the [documentation](https://console.bluemix.net/docs/services/conversation/dialog-overview.html#complex).
+        :param object output: The output of the dialog node. For more information about
+        how to specify dialog node output, see the
+        [documentation](https://console.bluemix.net/docs/services/conversation/dialog-overview.html#complex).
         :param object context: The context for the dialog node.
         :param object metadata: The metadata for the dialog node.
-        :param DialogNodeNextStep next_step: The next step to be executed in dialog processing.
-        :param list[DialogNodeAction] actions: An array of objects describing any actions to be invoked by the dialog node.
-        :param str title: The alias used to identify the dialog node. This string must conform to the following restrictions:  - It can contain only Unicode alphanumeric, space, underscore, hyphen, and dot characters.  - It must be no longer than 64 characters.
+        :param DialogNodeNextStep next_step: The next step to be executed in dialog
+        processing.
+        :param list[DialogNodeAction] actions: An array of objects describing any actions
+        to be invoked by the dialog node.
+        :param str title: The alias used to identify the dialog node. This string must
+        conform to the following restrictions:
+        - It can contain only Unicode alphanumeric, space, underscore, hyphen, and dot
+        characters.
+        - It must be no longer than 64 characters.
         :param str node_type: How the dialog node is processed.
         :param str event_name: How an `event_handler` node is processed.
         :param str variable: The location in the dialog context where output is stored.
         :param str digress_in: Whether this top-level dialog node can be digressed into.
-        :param str digress_out: Whether this dialog node can be returned to after a digression.
-        :param str digress_out_slots: Whether the user can digress to top-level nodes while filling out slots.
+        :param str digress_out: Whether this dialog node can be returned to after a
+        digression.
+        :param str digress_out_slots: Whether the user can digress to top-level nodes
+        while filling out slots.
         :param dict headers: A `dict` containing the request headers
         :return: A `dict` containing the `DialogNode` response.
         :rtype: dict
@@ -1869,8 +2084,9 @@ class AssistantV1(WatsonService):
         """
         Delete dialog node.
 
-        Delete a dialog node from a workspace.    This operation is limited to 500
-        requests per 30 minutes. For more information, see **Rate limiting**.
+        Delete a dialog node from a workspace.
+        This operation is limited to 500 requests per 30 minutes. For more information,
+        see **Rate limiting**.
 
         :param str workspace_id: Unique identifier of the workspace.
         :param str dialog_node: The dialog node ID (for example, `get_order`).
@@ -1903,12 +2119,14 @@ class AssistantV1(WatsonService):
         """
         Get dialog node.
 
-        Get information about a dialog node.    This operation is limited to 6000 requests
-        per 5 minutes. For more information, see **Rate limiting**.
+        Get information about a dialog node.
+        This operation is limited to 6000 requests per 5 minutes. For more information,
+        see **Rate limiting**.
 
         :param str workspace_id: Unique identifier of the workspace.
         :param str dialog_node: The dialog node ID (for example, `get_order`).
-        :param bool include_audit: Whether to include the audit properties (`created` and `updated` timestamps) in the response.
+        :param bool include_audit: Whether to include the audit properties (`created` and
+        `updated` timestamps) in the response.
         :param dict headers: A `dict` containing the request headers
         :return: A `dict` containing the `DialogNode` response.
         :rtype: dict
@@ -1942,15 +2160,20 @@ class AssistantV1(WatsonService):
         """
         List dialog nodes.
 
-        List the dialog nodes for a workspace.    This operation is limited to 2500
-        requests per 30 minutes. For more information, see **Rate limiting**.
+        List the dialog nodes for a workspace.
+        This operation is limited to 2500 requests per 30 minutes. For more information,
+        see **Rate limiting**.
 
         :param str workspace_id: Unique identifier of the workspace.
         :param int page_limit: The number of records to return in each page of results.
-        :param bool include_count: Whether to include information about the number of records returned.
-        :param str sort: The attribute by which returned results will be sorted. To reverse the sort order, prefix the value with a minus sign (`-`). Supported values are `name`, `updated`, and `workspace_id`.
+        :param bool include_count: Whether to include information about the number of
+        records returned.
+        :param str sort: The attribute by which returned results will be sorted. To
+        reverse the sort order, prefix the value with a minus sign (`-`). Supported values
+        are `name`, `updated`, and `workspace_id`.
         :param str cursor: A token identifying the page of results to retrieve.
-        :param bool include_audit: Whether to include the audit properties (`created` and `updated` timestamps) in the response.
+        :param bool include_audit: Whether to include the audit properties (`created` and
+        `updated` timestamps) in the response.
         :param dict headers: A `dict` containing the request headers
         :return: A `dict` containing the `DialogNodeCollection` response.
         :rtype: dict
@@ -2002,29 +2225,49 @@ class AssistantV1(WatsonService):
         """
         Update dialog node.
 
-        Update an existing dialog node with new or modified data.    This operation is
-        limited to 500 requests per 30 minutes. For more information, see **Rate
-        limiting**.
+        Update an existing dialog node with new or modified data.
+        This operation is limited to 500 requests per 30 minutes. For more information,
+        see **Rate limiting**.
 
         :param str workspace_id: Unique identifier of the workspace.
         :param str dialog_node: The dialog node ID (for example, `get_order`).
-        :param str new_dialog_node: The dialog node ID. This string must conform to the following restrictions:  - It can contain only Unicode alphanumeric, space, underscore, hyphen, and dot characters.  - It must be no longer than 1024 characters.
-        :param str new_description: The description of the dialog node. This string cannot contain carriage return, newline, or tab characters, and it must be no longer than 128 characters.
-        :param str new_conditions: The condition that will trigger the dialog node. This string cannot contain carriage return, newline, or tab characters, and it must be no longer than 2048 characters.
+        :param str new_dialog_node: The dialog node ID. This string must conform to the
+        following restrictions:
+        - It can contain only Unicode alphanumeric, space, underscore, hyphen, and dot
+        characters.
+        - It must be no longer than 1024 characters.
+        :param str new_description: The description of the dialog node. This string cannot
+        contain carriage return, newline, or tab characters, and it must be no longer than
+        128 characters.
+        :param str new_conditions: The condition that will trigger the dialog node. This
+        string cannot contain carriage return, newline, or tab characters, and it must be
+        no longer than 2048 characters.
         :param str new_parent: The ID of the parent dialog node.
         :param str new_previous_sibling: The ID of the previous sibling dialog node.
-        :param object new_output: The output of the dialog node. For more information about how to specify dialog node output, see the [documentation](https://console.bluemix.net/docs/services/conversation/dialog-overview.html#complex).
+        :param object new_output: The output of the dialog node. For more information
+        about how to specify dialog node output, see the
+        [documentation](https://console.bluemix.net/docs/services/conversation/dialog-overview.html#complex).
         :param object new_context: The context for the dialog node.
         :param object new_metadata: The metadata for the dialog node.
-        :param DialogNodeNextStep new_next_step: The next step to be executed in dialog processing.
-        :param str new_title: The alias used to identify the dialog node. This string must conform to the following restrictions:  - It can contain only Unicode alphanumeric, space, underscore, hyphen, and dot characters.  - It must be no longer than 64 characters.
+        :param DialogNodeNextStep new_next_step: The next step to be executed in dialog
+        processing.
+        :param str new_title: The alias used to identify the dialog node. This string must
+        conform to the following restrictions:
+        - It can contain only Unicode alphanumeric, space, underscore, hyphen, and dot
+        characters.
+        - It must be no longer than 64 characters.
         :param str new_type: How the dialog node is processed.
         :param str new_event_name: How an `event_handler` node is processed.
-        :param str new_variable: The location in the dialog context where output is stored.
-        :param list[DialogNodeAction] new_actions: An array of objects describing any actions to be invoked by the dialog node.
-        :param str new_digress_in: Whether this top-level dialog node can be digressed into.
-        :param str new_digress_out: Whether this dialog node can be returned to after a digression.
-        :param str new_digress_out_slots: Whether the user can digress to top-level nodes while filling out slots.
+        :param str new_variable: The location in the dialog context where output is
+        stored.
+        :param list[DialogNodeAction] new_actions: An array of objects describing any
+        actions to be invoked by the dialog node.
+        :param str new_digress_in: Whether this top-level dialog node can be digressed
+        into.
+        :param str new_digress_out: Whether this dialog node can be returned to after a
+        digression.
+        :param str new_digress_out_slots: Whether the user can digress to top-level nodes
+        while filling out slots.
         :param dict headers: A `dict` containing the request headers
         :return: A `dict` containing the `DialogNode` response.
         :rtype: dict
@@ -2087,13 +2330,19 @@ class AssistantV1(WatsonService):
         """
         List log events in all workspaces.
 
-        List the events from the logs of all workspaces in the service instance.    If
-        **cursor** is not specified, this operation is limited to 40 requests per 30
+        List the events from the logs of all workspaces in the service instance.
+        If **cursor** is not specified, this operation is limited to 40 requests per 30
         minutes. If **cursor** is specified, the limit is 120 requests per minute. For
         more information, see **Rate limiting**.
 
-        :param str filter: A cacheable parameter that limits the results to those matching the specified filter. You must specify a filter query that includes a value for `language`, as well as a value for `workspace_id` or `request.context.metadata.deployment`. For more information, see the [documentation](https://console.bluemix.net/docs/services/conversation/filter-reference.html#filter-query-syntax).
-        :param str sort: The attribute by which returned results will be sorted. To reverse the sort order, prefix the value with a minus sign (`-`). Supported values are `name`, `updated`, and `workspace_id`.
+        :param str filter: A cacheable parameter that limits the results to those matching
+        the specified filter. You must specify a filter query that includes a value for
+        `language`, as well as a value for `workspace_id` or
+        `request.context.metadata.deployment`. For more information, see the
+        [documentation](https://console.bluemix.net/docs/services/conversation/filter-reference.html#filter-query-syntax).
+        :param str sort: The attribute by which returned results will be sorted. To
+        reverse the sort order, prefix the value with a minus sign (`-`). Supported values
+        are `name`, `updated`, and `workspace_id`.
         :param int page_limit: The number of records to return in each page of results.
         :param str cursor: A token identifying the page of results to retrieve.
         :param dict headers: A `dict` containing the request headers
@@ -2131,14 +2380,18 @@ class AssistantV1(WatsonService):
         """
         List log events in a workspace.
 
-        List the events from the log of a specific workspace.    If **cursor** is not
-        specified, this operation is limited to 40 requests per 30 minutes. If **cursor**
-        is specified, the limit is 120 requests per minute. For more information, see
-        **Rate limiting**.
+        List the events from the log of a specific workspace.
+        If **cursor** is not specified, this operation is limited to 40 requests per 30
+        minutes. If **cursor** is specified, the limit is 120 requests per minute. For
+        more information, see **Rate limiting**.
 
         :param str workspace_id: Unique identifier of the workspace.
-        :param str sort: The attribute by which returned results will be sorted. To reverse the sort order, prefix the value with a minus sign (`-`). Supported values are `name`, `updated`, and `workspace_id`.
-        :param str filter: A cacheable parameter that limits the results to those matching the specified filter. For more information, see the [documentation](https://console.bluemix.net/docs/services/conversation/filter-reference.html#filter-query-syntax).
+        :param str sort: The attribute by which returned results will be sorted. To
+        reverse the sort order, prefix the value with a minus sign (`-`). Supported values
+        are `name`, `updated`, and `workspace_id`.
+        :param str filter: A cacheable parameter that limits the results to those matching
+        the specified filter. For more information, see the
+        [documentation](https://console.bluemix.net/docs/services/conversation/filter-reference.html#filter-query-syntax).
         :param int page_limit: The number of records to return in each page of results.
         :param str cursor: A token identifying the page of results to retrieve.
         :param dict headers: A `dict` containing the request headers
@@ -2176,9 +2429,10 @@ class AssistantV1(WatsonService):
         Delete labeled data.
 
         Deletes all data associated with a specified customer ID. The method has no effect
-        if no data is associated with the customer ID.   You associate a customer ID with
-        data by passing the `X-Watson-Metadata` header with a request that passes data.
-        For more information about personal data and customer IDs, see [Information
+        if no data is associated with the customer ID.
+        You associate a customer ID with data by passing the `X-Watson-Metadata` header
+        with a request that passes data. For more information about personal data and
+        customer IDs, see [Information
         security](https://console.bluemix.net/docs/services/conversation/information-security.html).
 
         :param str customer_id: The customer ID for which all data is to be deleted.
@@ -2211,7 +2465,8 @@ class CaptureGroup(object):
     CaptureGroup.
 
     :attr str group: A recognized capture group for the entity.
-    :attr list[int] location: (optional) Zero-based character offsets that indicate where the entity value begins and ends in the input text.
+    :attr list[int] location: (optional) Zero-based character offsets that indicate where
+    the entity value begins and ends in the input text.
     """
 
     def __init__(self, group, location=None):
@@ -2219,7 +2474,8 @@ class CaptureGroup(object):
         Initialize a CaptureGroup object.
 
         :param str group: A recognized capture group for the entity.
-        :param list[int] location: (optional) Zero-based character offsets that indicate where the entity value begins and ends in the input text.
+        :param list[int] location: (optional) Zero-based character offsets that indicate
+        where the entity value begins and ends in the input text.
         """
         self.group = group
         self.location = location
@@ -2341,7 +2597,8 @@ class Counterexample(object):
 
     :attr str text: The text of the counterexample.
     :attr datetime created: (optional) The timestamp for creation of the counterexample.
-    :attr datetime updated: (optional) The timestamp for the last update to the counterexample.
+    :attr datetime updated: (optional) The timestamp for the last update to the
+    counterexample.
     """
 
     def __init__(self, text, created=None, updated=None):
@@ -2349,8 +2606,10 @@ class Counterexample(object):
         Initialize a Counterexample object.
 
         :param str text: The text of the counterexample.
-        :param datetime created: (optional) The timestamp for creation of the counterexample.
-        :param datetime updated: (optional) The timestamp for the last update to the counterexample.
+        :param datetime created: (optional) The timestamp for creation of the
+        counterexample.
+        :param datetime updated: (optional) The timestamp for the last update to the
+        counterexample.
         """
         self.text = text
         self.created = created
@@ -2402,7 +2661,8 @@ class CounterexampleCollection(object):
     """
     CounterexampleCollection.
 
-    :attr list[Counterexample] counterexamples: An array of objects describing the examples marked as irrelevant input.
+    :attr list[Counterexample] counterexamples: An array of objects describing the
+    examples marked as irrelevant input.
     :attr Pagination pagination: The pagination data for the returned objects.
     """
 
@@ -2410,7 +2670,8 @@ class CounterexampleCollection(object):
         """
         Initialize a CounterexampleCollection object.
 
-        :param list[Counterexample] counterexamples: An array of objects describing the examples marked as irrelevant input.
+        :param list[Counterexample] counterexamples: An array of objects describing the
+        examples marked as irrelevant input.
         :param Pagination pagination: The pagination data for the returned objects.
         """
         self.counterexamples = counterexamples
@@ -2468,14 +2729,22 @@ class CreateCounterexample(object):
     """
     CreateCounterexample.
 
-    :attr str text: The text of a user input marked as irrelevant input. This string must conform to the following restrictions:  - It cannot contain carriage return, newline, or tab characters  - It cannot consist of only whitespace characters  - It must be no longer than 1024 characters.
+    :attr str text: The text of a user input marked as irrelevant input. This string must
+    conform to the following restrictions:
+    - It cannot contain carriage return, newline, or tab characters
+    - It cannot consist of only whitespace characters
+    - It must be no longer than 1024 characters.
     """
 
     def __init__(self, text):
         """
         Initialize a CreateCounterexample object.
 
-        :param str text: The text of a user input marked as irrelevant input. This string must conform to the following restrictions:  - It cannot contain carriage return, newline, or tab characters  - It cannot consist of only whitespace characters  - It must be no longer than 1024 characters.
+        :param str text: The text of a user input marked as irrelevant input. This string
+        must conform to the following restrictions:
+        - It cannot contain carriage return, newline, or tab characters
+        - It cannot consist of only whitespace characters
+        - It must be no longer than 1024 characters.
         """
         self.text = text
 
@@ -2517,23 +2786,43 @@ class CreateDialogNode(object):
     """
     CreateDialogNode.
 
-    :attr str dialog_node: The dialog node ID. This string must conform to the following restrictions:  - It can contain only Unicode alphanumeric, space, underscore, hyphen, and dot characters.  - It must be no longer than 1024 characters.
-    :attr str description: (optional) The description of the dialog node. This string cannot contain carriage return, newline, or tab characters, and it must be no longer than 128 characters.
-    :attr str conditions: (optional) The condition that will trigger the dialog node. This string cannot contain carriage return, newline, or tab characters, and it must be no longer than 2048 characters.
+    :attr str dialog_node: The dialog node ID. This string must conform to the following
+    restrictions:
+    - It can contain only Unicode alphanumeric, space, underscore, hyphen, and dot
+    characters.
+    - It must be no longer than 1024 characters.
+    :attr str description: (optional) The description of the dialog node. This string
+    cannot contain carriage return, newline, or tab characters, and it must be no longer
+    than 128 characters.
+    :attr str conditions: (optional) The condition that will trigger the dialog node. This
+    string cannot contain carriage return, newline, or tab characters, and it must be no
+    longer than 2048 characters.
     :attr str parent: (optional) The ID of the parent dialog node.
     :attr str previous_sibling: (optional) The ID of the previous dialog node.
-    :attr object output: (optional) The output of the dialog node. For more information about how to specify dialog node output, see the [documentation](https://console.bluemix.net/docs/services/conversation/dialog-overview.html#complex).
+    :attr object output: (optional) The output of the dialog node. For more information
+    about how to specify dialog node output, see the
+    [documentation](https://console.bluemix.net/docs/services/conversation/dialog-overview.html#complex).
     :attr object context: (optional) The context for the dialog node.
     :attr object metadata: (optional) The metadata for the dialog node.
-    :attr DialogNodeNextStep next_step: (optional) The next step to be executed in dialog processing.
-    :attr list[DialogNodeAction] actions: (optional) An array of objects describing any actions to be invoked by the dialog node.
-    :attr str title: (optional) The alias used to identify the dialog node. This string must conform to the following restrictions:  - It can contain only Unicode alphanumeric, space, underscore, hyphen, and dot characters.  - It must be no longer than 64 characters.
+    :attr DialogNodeNextStep next_step: (optional) The next step to be executed in dialog
+    processing.
+    :attr list[DialogNodeAction] actions: (optional) An array of objects describing any
+    actions to be invoked by the dialog node.
+    :attr str title: (optional) The alias used to identify the dialog node. This string
+    must conform to the following restrictions:
+    - It can contain only Unicode alphanumeric, space, underscore, hyphen, and dot
+    characters.
+    - It must be no longer than 64 characters.
     :attr str node_type: (optional) How the dialog node is processed.
     :attr str event_name: (optional) How an `event_handler` node is processed.
-    :attr str variable: (optional) The location in the dialog context where output is stored.
-    :attr str digress_in: (optional) Whether this top-level dialog node can be digressed into.
-    :attr str digress_out: (optional) Whether this dialog node can be returned to after a digression.
-    :attr str digress_out_slots: (optional) Whether the user can digress to top-level nodes while filling out slots.
+    :attr str variable: (optional) The location in the dialog context where output is
+    stored.
+    :attr str digress_in: (optional) Whether this top-level dialog node can be digressed
+    into.
+    :attr str digress_out: (optional) Whether this dialog node can be returned to after a
+    digression.
+    :attr str digress_out_slots: (optional) Whether the user can digress to top-level
+    nodes while filling out slots.
     """
 
     def __init__(self,
@@ -2557,23 +2846,43 @@ class CreateDialogNode(object):
         """
         Initialize a CreateDialogNode object.
 
-        :param str dialog_node: The dialog node ID. This string must conform to the following restrictions:  - It can contain only Unicode alphanumeric, space, underscore, hyphen, and dot characters.  - It must be no longer than 1024 characters.
-        :param str description: (optional) The description of the dialog node. This string cannot contain carriage return, newline, or tab characters, and it must be no longer than 128 characters.
-        :param str conditions: (optional) The condition that will trigger the dialog node. This string cannot contain carriage return, newline, or tab characters, and it must be no longer than 2048 characters.
+        :param str dialog_node: The dialog node ID. This string must conform to the
+        following restrictions:
+        - It can contain only Unicode alphanumeric, space, underscore, hyphen, and dot
+        characters.
+        - It must be no longer than 1024 characters.
+        :param str description: (optional) The description of the dialog node. This string
+        cannot contain carriage return, newline, or tab characters, and it must be no
+        longer than 128 characters.
+        :param str conditions: (optional) The condition that will trigger the dialog node.
+        This string cannot contain carriage return, newline, or tab characters, and it
+        must be no longer than 2048 characters.
         :param str parent: (optional) The ID of the parent dialog node.
         :param str previous_sibling: (optional) The ID of the previous dialog node.
-        :param object output: (optional) The output of the dialog node. For more information about how to specify dialog node output, see the [documentation](https://console.bluemix.net/docs/services/conversation/dialog-overview.html#complex).
+        :param object output: (optional) The output of the dialog node. For more
+        information about how to specify dialog node output, see the
+        [documentation](https://console.bluemix.net/docs/services/conversation/dialog-overview.html#complex).
         :param object context: (optional) The context for the dialog node.
         :param object metadata: (optional) The metadata for the dialog node.
-        :param DialogNodeNextStep next_step: (optional) The next step to be executed in dialog processing.
-        :param list[DialogNodeAction] actions: (optional) An array of objects describing any actions to be invoked by the dialog node.
-        :param str title: (optional) The alias used to identify the dialog node. This string must conform to the following restrictions:  - It can contain only Unicode alphanumeric, space, underscore, hyphen, and dot characters.  - It must be no longer than 64 characters.
+        :param DialogNodeNextStep next_step: (optional) The next step to be executed in
+        dialog processing.
+        :param list[DialogNodeAction] actions: (optional) An array of objects describing
+        any actions to be invoked by the dialog node.
+        :param str title: (optional) The alias used to identify the dialog node. This
+        string must conform to the following restrictions:
+        - It can contain only Unicode alphanumeric, space, underscore, hyphen, and dot
+        characters.
+        - It must be no longer than 64 characters.
         :param str node_type: (optional) How the dialog node is processed.
         :param str event_name: (optional) How an `event_handler` node is processed.
-        :param str variable: (optional) The location in the dialog context where output is stored.
-        :param str digress_in: (optional) Whether this top-level dialog node can be digressed into.
-        :param str digress_out: (optional) Whether this dialog node can be returned to after a digression.
-        :param str digress_out_slots: (optional) Whether the user can digress to top-level nodes while filling out slots.
+        :param str variable: (optional) The location in the dialog context where output is
+        stored.
+        :param str digress_in: (optional) Whether this top-level dialog node can be
+        digressed into.
+        :param str digress_out: (optional) Whether this dialog node can be returned to
+        after a digression.
+        :param str digress_out_slots: (optional) Whether the user can digress to top-level
+        nodes while filling out slots.
         """
         self.dialog_node = dialog_node
         self.description = description
@@ -2700,10 +3009,17 @@ class CreateEntity(object):
     """
     CreateEntity.
 
-    :attr str entity: The name of the entity. This string must conform to the following restrictions:  - It can contain only Unicode alphanumeric, underscore, and hyphen characters.  - It cannot begin with the reserved prefix `sys-`.  - It must be no longer than 64 characters.
-    :attr str description: (optional) The description of the entity. This string cannot contain carriage return, newline, or tab characters, and it must be no longer than 128 characters.
+    :attr str entity: The name of the entity. This string must conform to the following
+    restrictions:
+    - It can contain only Unicode alphanumeric, underscore, and hyphen characters.
+    - It cannot begin with the reserved prefix `sys-`.
+    - It must be no longer than 64 characters.
+    :attr str description: (optional) The description of the entity. This string cannot
+    contain carriage return, newline, or tab characters, and it must be no longer than 128
+    characters.
     :attr object metadata: (optional) Any metadata related to the value.
-    :attr list[CreateValue] values: (optional) An array of objects describing the entity values.
+    :attr list[CreateValue] values: (optional) An array of objects describing the entity
+    values.
     :attr bool fuzzy_match: (optional) Whether to use fuzzy matching for the entity.
     """
 
@@ -2716,10 +3032,17 @@ class CreateEntity(object):
         """
         Initialize a CreateEntity object.
 
-        :param str entity: The name of the entity. This string must conform to the following restrictions:  - It can contain only Unicode alphanumeric, underscore, and hyphen characters.  - It cannot begin with the reserved prefix `sys-`.  - It must be no longer than 64 characters.
-        :param str description: (optional) The description of the entity. This string cannot contain carriage return, newline, or tab characters, and it must be no longer than 128 characters.
+        :param str entity: The name of the entity. This string must conform to the
+        following restrictions:
+        - It can contain only Unicode alphanumeric, underscore, and hyphen characters.
+        - It cannot begin with the reserved prefix `sys-`.
+        - It must be no longer than 64 characters.
+        :param str description: (optional) The description of the entity. This string
+        cannot contain carriage return, newline, or tab characters, and it must be no
+        longer than 128 characters.
         :param object metadata: (optional) Any metadata related to the value.
-        :param list[CreateValue] values: (optional) An array of objects describing the entity values.
+        :param list[CreateValue] values: (optional) An array of objects describing the
+        entity values.
         :param bool fuzzy_match: (optional) Whether to use fuzzy matching for the entity.
         """
         self.entity = entity
@@ -2784,14 +3107,22 @@ class CreateExample(object):
     """
     CreateExample.
 
-    :attr str text: The text of a user input example. This string must conform to the following restrictions:  - It cannot contain carriage return, newline, or tab characters.  - It cannot consist of only whitespace characters.  - It must be no longer than 1024 characters.
+    :attr str text: The text of a user input example. This string must conform to the
+    following restrictions:
+    - It cannot contain carriage return, newline, or tab characters.
+    - It cannot consist of only whitespace characters.
+    - It must be no longer than 1024 characters.
     """
 
     def __init__(self, text):
         """
         Initialize a CreateExample object.
 
-        :param str text: The text of a user input example. This string must conform to the following restrictions:  - It cannot contain carriage return, newline, or tab characters.  - It cannot consist of only whitespace characters.  - It must be no longer than 1024 characters.
+        :param str text: The text of a user input example. This string must conform to the
+        following restrictions:
+        - It cannot contain carriage return, newline, or tab characters.
+        - It cannot consist of only whitespace characters.
+        - It must be no longer than 1024 characters.
         """
         self.text = text
 
@@ -2832,18 +3163,33 @@ class CreateIntent(object):
     """
     CreateIntent.
 
-    :attr str intent: The name of the intent. This string must conform to the following restrictions:  - It can contain only Unicode alphanumeric, underscore, hyphen, and dot characters.  - It cannot begin with the reserved prefix `sys-`.  - It must be no longer than 128 characters.
-    :attr str description: (optional) The description of the intent. This string cannot contain carriage return, newline, or tab characters, and it must be no longer than 128 characters.
-    :attr list[CreateExample] examples: (optional) An array of user input examples for the intent.
+    :attr str intent: The name of the intent. This string must conform to the following
+    restrictions:
+    - It can contain only Unicode alphanumeric, underscore, hyphen, and dot characters.
+    - It cannot begin with the reserved prefix `sys-`.
+    - It must be no longer than 128 characters.
+    :attr str description: (optional) The description of the intent. This string cannot
+    contain carriage return, newline, or tab characters, and it must be no longer than 128
+    characters.
+    :attr list[CreateExample] examples: (optional) An array of user input examples for the
+    intent.
     """
 
     def __init__(self, intent, description=None, examples=None):
         """
         Initialize a CreateIntent object.
 
-        :param str intent: The name of the intent. This string must conform to the following restrictions:  - It can contain only Unicode alphanumeric, underscore, hyphen, and dot characters.  - It cannot begin with the reserved prefix `sys-`.  - It must be no longer than 128 characters.
-        :param str description: (optional) The description of the intent. This string cannot contain carriage return, newline, or tab characters, and it must be no longer than 128 characters.
-        :param list[CreateExample] examples: (optional) An array of user input examples for the intent.
+        :param str intent: The name of the intent. This string must conform to the
+        following restrictions:
+        - It can contain only Unicode alphanumeric, underscore, hyphen, and dot
+        characters.
+        - It cannot begin with the reserved prefix `sys-`.
+        - It must be no longer than 128 characters.
+        :param str description: (optional) The description of the intent. This string
+        cannot contain carriage return, newline, or tab characters, and it must be no
+        longer than 128 characters.
+        :param list[CreateExample] examples: (optional) An array of user input examples
+        for the intent.
         """
         self.intent = intent
         self.description = description
@@ -2897,10 +3243,23 @@ class CreateValue(object):
     """
     CreateValue.
 
-    :attr str value: The text of the entity value. This string must conform to the following restrictions:  - It cannot contain carriage return, newline, or tab characters.  - It cannot consist of only whitespace characters.  - It must be no longer than 64 characters.
+    :attr str value: The text of the entity value. This string must conform to the
+    following restrictions:
+    - It cannot contain carriage return, newline, or tab characters.
+    - It cannot consist of only whitespace characters.
+    - It must be no longer than 64 characters.
     :attr object metadata: (optional) Any metadata related to the entity value.
-    :attr list[str] synonyms: (optional) An array containing any synonyms for the entity value. You can provide either synonyms or patterns (as indicated by **type**), but not both. A synonym must conform to the following restrictions:  - It cannot contain carriage return, newline, or tab characters.  - It cannot consist of only whitespace characters.  - It must be no longer than 64 characters.
-    :attr list[str] patterns: (optional) An array of patterns for the entity value. You can provide either synonyms or patterns (as indicated by **type**), but not both. A pattern is a regular expression no longer than 128 characters. For more information about how to specify a pattern, see the [documentation](https://console.bluemix.net/docs/services/conversation/entities.html#creating-entities).
+    :attr list[str] synonyms: (optional) An array containing any synonyms for the entity
+    value. You can provide either synonyms or patterns (as indicated by **type**), but not
+    both. A synonym must conform to the following restrictions:
+    - It cannot contain carriage return, newline, or tab characters.
+    - It cannot consist of only whitespace characters.
+    - It must be no longer than 64 characters.
+    :attr list[str] patterns: (optional) An array of patterns for the entity value. You
+    can provide either synonyms or patterns (as indicated by **type**), but not both. A
+    pattern is a regular expression no longer than 128 characters. For more information
+    about how to specify a pattern, see the
+    [documentation](https://console.bluemix.net/docs/services/conversation/entities.html#creating-entities).
     :attr str value_type: (optional) Specifies the type of value.
     """
 
@@ -2913,10 +3272,23 @@ class CreateValue(object):
         """
         Initialize a CreateValue object.
 
-        :param str value: The text of the entity value. This string must conform to the following restrictions:  - It cannot contain carriage return, newline, or tab characters.  - It cannot consist of only whitespace characters.  - It must be no longer than 64 characters.
+        :param str value: The text of the entity value. This string must conform to the
+        following restrictions:
+        - It cannot contain carriage return, newline, or tab characters.
+        - It cannot consist of only whitespace characters.
+        - It must be no longer than 64 characters.
         :param object metadata: (optional) Any metadata related to the entity value.
-        :param list[str] synonyms: (optional) An array containing any synonyms for the entity value. You can provide either synonyms or patterns (as indicated by **type**), but not both. A synonym must conform to the following restrictions:  - It cannot contain carriage return, newline, or tab characters.  - It cannot consist of only whitespace characters.  - It must be no longer than 64 characters.
-        :param list[str] patterns: (optional) An array of patterns for the entity value. You can provide either synonyms or patterns (as indicated by **type**), but not both. A pattern is a regular expression no longer than 128 characters. For more information about how to specify a pattern, see the [documentation](https://console.bluemix.net/docs/services/conversation/entities.html#creating-entities).
+        :param list[str] synonyms: (optional) An array containing any synonyms for the
+        entity value. You can provide either synonyms or patterns (as indicated by
+        **type**), but not both. A synonym must conform to the following restrictions:
+        - It cannot contain carriage return, newline, or tab characters.
+        - It cannot consist of only whitespace characters.
+        - It must be no longer than 64 characters.
+        :param list[str] patterns: (optional) An array of patterns for the entity value.
+        You can provide either synonyms or patterns (as indicated by **type**), but not
+        both. A pattern is a regular expression no longer than 128 characters. For more
+        information about how to specify a pattern, see the
+        [documentation](https://console.bluemix.net/docs/services/conversation/entities.html#creating-entities).
         :param str value_type: (optional) Specifies the type of value.
         """
         self.value = value
@@ -2981,22 +3353,30 @@ class DialogNode(object):
     :attr str dialog_node_id: The dialog node ID.
     :attr str description: (optional) The description of the dialog node.
     :attr str conditions: (optional) The condition that triggers the dialog node.
-    :attr str parent: (optional) The ID of the parent dialog node. This property is not returned if the dialog node has no parent.
-    :attr str previous_sibling: (optional) The ID of the previous sibling dialog node. This property is not returned if the dialog node has no previous sibling.
+    :attr str parent: (optional) The ID of the parent dialog node. This property is not
+    returned if the dialog node has no parent.
+    :attr str previous_sibling: (optional) The ID of the previous sibling dialog node.
+    This property is not returned if the dialog node has no previous sibling.
     :attr object output: (optional) The output of the dialog node.
     :attr object context: (optional) The context (if defined) for the dialog node.
     :attr object metadata: (optional) Any metadata for the dialog node.
-    :attr DialogNodeNextStep next_step: (optional) The next step to execute following this dialog node.
+    :attr DialogNodeNextStep next_step: (optional) The next step to execute following this
+    dialog node.
     :attr datetime created: (optional) The timestamp for creation of the dialog node.
-    :attr datetime updated: (optional) The timestamp for the most recent update to the dialog node.
+    :attr datetime updated: (optional) The timestamp for the most recent update to the
+    dialog node.
     :attr list[DialogNodeAction] actions: (optional) The actions for the dialog node.
     :attr str title: (optional) The alias used to identify the dialog node.
     :attr str node_type: (optional) How the dialog node is processed.
     :attr str event_name: (optional) How an `event_handler` node is processed.
-    :attr str variable: (optional) The location in the dialog context where output is stored.
-    :attr str digress_in: (optional) Whether this top-level dialog node can be digressed into.
-    :attr str digress_out: (optional) Whether this dialog node can be returned to after a digression.
-    :attr str digress_out_slots: (optional) Whether the user can digress to top-level nodes while filling out slots.
+    :attr str variable: (optional) The location in the dialog context where output is
+    stored.
+    :attr str digress_in: (optional) Whether this top-level dialog node can be digressed
+    into.
+    :attr str digress_out: (optional) Whether this dialog node can be returned to after a
+    digression.
+    :attr str digress_out_slots: (optional) Whether the user can digress to top-level
+    nodes while filling out slots.
     """
 
     def __init__(self,
@@ -3025,22 +3405,30 @@ class DialogNode(object):
         :param str dialog_node_id: The dialog node ID.
         :param str description: (optional) The description of the dialog node.
         :param str conditions: (optional) The condition that triggers the dialog node.
-        :param str parent: (optional) The ID of the parent dialog node. This property is not returned if the dialog node has no parent.
-        :param str previous_sibling: (optional) The ID of the previous sibling dialog node. This property is not returned if the dialog node has no previous sibling.
+        :param str parent: (optional) The ID of the parent dialog node. This property is
+        not returned if the dialog node has no parent.
+        :param str previous_sibling: (optional) The ID of the previous sibling dialog
+        node. This property is not returned if the dialog node has no previous sibling.
         :param object output: (optional) The output of the dialog node.
         :param object context: (optional) The context (if defined) for the dialog node.
         :param object metadata: (optional) Any metadata for the dialog node.
-        :param DialogNodeNextStep next_step: (optional) The next step to execute following this dialog node.
+        :param DialogNodeNextStep next_step: (optional) The next step to execute following
+        this dialog node.
         :param datetime created: (optional) The timestamp for creation of the dialog node.
-        :param datetime updated: (optional) The timestamp for the most recent update to the dialog node.
+        :param datetime updated: (optional) The timestamp for the most recent update to
+        the dialog node.
         :param list[DialogNodeAction] actions: (optional) The actions for the dialog node.
         :param str title: (optional) The alias used to identify the dialog node.
         :param str node_type: (optional) How the dialog node is processed.
         :param str event_name: (optional) How an `event_handler` node is processed.
-        :param str variable: (optional) The location in the dialog context where output is stored.
-        :param str digress_in: (optional) Whether this top-level dialog node can be digressed into.
-        :param str digress_out: (optional) Whether this dialog node can be returned to after a digression.
-        :param str digress_out_slots: (optional) Whether the user can digress to top-level nodes while filling out slots.
+        :param str variable: (optional) The location in the dialog context where output is
+        stored.
+        :param str digress_in: (optional) Whether this top-level dialog node can be
+        digressed into.
+        :param str digress_out: (optional) Whether this dialog node can be returned to
+        after a digression.
+        :param str digress_out_slots: (optional) Whether the user can digress to top-level
+        nodes while filling out slots.
         """
         self.dialog_node_id = dialog_node_id
         self.description = description
@@ -3180,9 +3568,12 @@ class DialogNodeAction(object):
 
     :attr str name: The name of the action.
     :attr str action_type: (optional) The type of action to invoke.
-    :attr object parameters: (optional) A map of key/value pairs to be provided to the action.
-    :attr str result_variable: The location in the dialog context where the result of the action is stored.
-    :attr str credentials: (optional) The name of the context variable that the client application will use to pass in credentials for the action.
+    :attr object parameters: (optional) A map of key/value pairs to be provided to the
+    action.
+    :attr str result_variable: The location in the dialog context where the result of the
+    action is stored.
+    :attr str credentials: (optional) The name of the context variable that the client
+    application will use to pass in credentials for the action.
     """
 
     def __init__(self,
@@ -3195,10 +3586,13 @@ class DialogNodeAction(object):
         Initialize a DialogNodeAction object.
 
         :param str name: The name of the action.
-        :param str result_variable: The location in the dialog context where the result of the action is stored.
+        :param str result_variable: The location in the dialog context where the result of
+        the action is stored.
         :param str action_type: (optional) The type of action to invoke.
-        :param object parameters: (optional) A map of key/value pairs to be provided to the action.
-        :param str credentials: (optional) The name of the context variable that the client application will use to pass in credentials for the action.
+        :param object parameters: (optional) A map of key/value pairs to be provided to
+        the action.
+        :param str credentials: (optional) The name of the context variable that the
+        client application will use to pass in credentials for the action.
         """
         self.name = name
         self.action_type = action_type
@@ -3265,7 +3659,8 @@ class DialogNodeCollection(object):
     """
     An array of dialog nodes.
 
-    :attr list[DialogNode] dialog_nodes: An array of objects describing the dialog nodes defined for the workspace.
+    :attr list[DialogNode] dialog_nodes: An array of objects describing the dialog nodes
+    defined for the workspace.
     :attr Pagination pagination: The pagination data for the returned objects.
     """
 
@@ -3273,7 +3668,8 @@ class DialogNodeCollection(object):
         """
         Initialize a DialogNodeCollection object.
 
-        :param list[DialogNode] dialog_nodes: An array of objects describing the dialog nodes defined for the workspace.
+        :param list[DialogNode] dialog_nodes: An array of objects describing the dialog
+        nodes defined for the workspace.
         :param Pagination pagination: The pagination data for the returned objects.
         """
         self.dialog_nodes = dialog_nodes
@@ -3327,8 +3723,29 @@ class DialogNodeNextStep(object):
     """
     The next step to execute following this dialog node.
 
-    :attr str behavior: What happens after the dialog node completes. The valid values depend on the node type:  - The following values are valid for any node:    - `get_user_input`    - `skip_user_input`    - `jump_to`  - If the node is of type `event_handler` and its parent node is of type `slot` or `frame`, additional values are also valid:    - if **event_name**=`filled` and the type of the parent node is `slot`:      - `reprompt`      - `skip_all_slots`  - if **event_name**=`nomatch` and the type of the parent node is `slot`:      - `reprompt`      - `skip_slot`      - `skip_all_slots`  - if **event_name**=`generic` and the type of the parent node is `frame`:      - `reprompt`      - `skip_slot`      - `skip_all_slots`        If you specify `jump_to`, then you must also specify a value for the `dialog_node` property.
-    :attr str dialog_node: (optional) The ID of the dialog node to process next. This parameter is required if **behavior**=`jump_to`.
+    :attr str behavior: What happens after the dialog node completes. The valid values
+    depend on the node type:
+    - The following values are valid for any node:
+      - `get_user_input`
+      - `skip_user_input`
+      - `jump_to`
+    - If the node is of type `event_handler` and its parent node is of type `slot` or
+    `frame`, additional values are also valid:
+      - if **event_name**=`filled` and the type of the parent node is `slot`:
+        - `reprompt`
+        - `skip_all_slots`
+    - if **event_name**=`nomatch` and the type of the parent node is `slot`:
+        - `reprompt`
+        - `skip_slot`
+        - `skip_all_slots`
+    - if **event_name**=`generic` and the type of the parent node is `frame`:
+        - `reprompt`
+        - `skip_slot`
+        - `skip_all_slots`
+    If you specify `jump_to`, then you must also specify a value for the `dialog_node`
+    property.
+    :attr str dialog_node: (optional) The ID of the dialog node to process next. This
+    parameter is required if **behavior**=`jump_to`.
     :attr str selector: (optional) Which part of the dialog node to process next.
     """
 
@@ -3336,8 +3753,29 @@ class DialogNodeNextStep(object):
         """
         Initialize a DialogNodeNextStep object.
 
-        :param str behavior: What happens after the dialog node completes. The valid values depend on the node type:  - The following values are valid for any node:    - `get_user_input`    - `skip_user_input`    - `jump_to`  - If the node is of type `event_handler` and its parent node is of type `slot` or `frame`, additional values are also valid:    - if **event_name**=`filled` and the type of the parent node is `slot`:      - `reprompt`      - `skip_all_slots`  - if **event_name**=`nomatch` and the type of the parent node is `slot`:      - `reprompt`      - `skip_slot`      - `skip_all_slots`  - if **event_name**=`generic` and the type of the parent node is `frame`:      - `reprompt`      - `skip_slot`      - `skip_all_slots`        If you specify `jump_to`, then you must also specify a value for the `dialog_node` property.
-        :param str dialog_node: (optional) The ID of the dialog node to process next. This parameter is required if **behavior**=`jump_to`.
+        :param str behavior: What happens after the dialog node completes. The valid
+        values depend on the node type:
+        - The following values are valid for any node:
+          - `get_user_input`
+          - `skip_user_input`
+          - `jump_to`
+        - If the node is of type `event_handler` and its parent node is of type `slot` or
+        `frame`, additional values are also valid:
+          - if **event_name**=`filled` and the type of the parent node is `slot`:
+            - `reprompt`
+            - `skip_all_slots`
+        - if **event_name**=`nomatch` and the type of the parent node is `slot`:
+            - `reprompt`
+            - `skip_slot`
+            - `skip_all_slots`
+        - if **event_name**=`generic` and the type of the parent node is `frame`:
+            - `reprompt`
+            - `skip_slot`
+            - `skip_all_slots`
+        If you specify `jump_to`, then you must also specify a value for the `dialog_node`
+        property.
+        :param str dialog_node: (optional) The ID of the dialog node to process next. This
+        parameter is required if **behavior**=`jump_to`.
         :param str selector: (optional) Which part of the dialog node to process next.
         """
         self.behavior = behavior
@@ -3390,7 +3828,8 @@ class DialogNodeVisitedDetails(object):
     """
     DialogNodeVisitedDetails.
 
-    :attr str dialog_node: (optional) A dialog node that was triggered during processing of the input message.
+    :attr str dialog_node: (optional) A dialog node that was triggered during processing
+    of the input message.
     :attr str title: (optional) The title of the dialog node.
     :attr str conditions: (optional) The conditions that trigger the dialog node.
     """
@@ -3399,7 +3838,8 @@ class DialogNodeVisitedDetails(object):
         """
         Initialize a DialogNodeVisitedDetails object.
 
-        :param str dialog_node: (optional) A dialog node that was triggered during processing of the input message.
+        :param str dialog_node: (optional) A dialog node that was triggered during
+        processing of the input message.
         :param str title: (optional) The title of the dialog node.
         :param str conditions: (optional) The conditions that trigger the dialog node.
         """
@@ -3469,7 +3909,8 @@ class Entity(object):
 
         :param str entity_name: The name of the entity.
         :param datetime created: (optional) The timestamp for creation of the entity.
-        :param datetime updated: (optional) The timestamp for the last update to the entity.
+        :param datetime updated: (optional) The timestamp for the last update to the
+        entity.
         :param str description: (optional) The description of the entity.
         :param object metadata: (optional) Any metadata related to the entity.
         :param bool fuzzy_match: (optional) Whether fuzzy matching is used for the entity.
@@ -3539,7 +3980,8 @@ class EntityCollection(object):
     """
     An array of entities.
 
-    :attr list[EntityExport] entities: An array of objects describing the entities defined for the workspace.
+    :attr list[EntityExport] entities: An array of objects describing the entities defined
+    for the workspace.
     :attr Pagination pagination: The pagination data for the returned objects.
     """
 
@@ -3547,7 +3989,8 @@ class EntityCollection(object):
         """
         Initialize a EntityCollection object.
 
-        :param list[EntityExport] entities: An array of objects describing the entities defined for the workspace.
+        :param list[EntityExport] entities: An array of objects describing the entities
+        defined for the workspace.
         :param Pagination pagination: The pagination data for the returned objects.
         """
         self.entities = entities
@@ -3607,7 +4050,8 @@ class EntityExport(object):
     :attr str description: (optional) The description of the entity.
     :attr object metadata: (optional) Any metadata related to the entity.
     :attr bool fuzzy_match: (optional) Whether fuzzy matching is used for the entity.
-    :attr list[ValueExport] values: (optional) An array objects describing the entity values.
+    :attr list[ValueExport] values: (optional) An array objects describing the entity
+    values.
     """
 
     def __init__(self,
@@ -3623,11 +4067,13 @@ class EntityExport(object):
 
         :param str entity_name: The name of the entity.
         :param datetime created: (optional) The timestamp for creation of the entity.
-        :param datetime updated: (optional) The timestamp for the last update to the entity.
+        :param datetime updated: (optional) The timestamp for the last update to the
+        entity.
         :param str description: (optional) The description of the entity.
         :param object metadata: (optional) Any metadata related to the entity.
         :param bool fuzzy_match: (optional) Whether fuzzy matching is used for the entity.
-        :param list[ValueExport] values: (optional) An array objects describing the entity values.
+        :param list[ValueExport] values: (optional) An array objects describing the entity
+        values.
         """
         self.entity_name = entity_name
         self.created = created
@@ -3713,7 +4159,8 @@ class Example(object):
 
         :param str example_text: The text of the user input example.
         :param datetime created: (optional) The timestamp for creation of the example.
-        :param datetime updated: (optional) The timestamp for the last update to the example.
+        :param datetime updated: (optional) The timestamp for the last update to the
+        example.
         """
         self.example_text = example_text
         self.created = created
@@ -3765,7 +4212,8 @@ class ExampleCollection(object):
     """
     ExampleCollection.
 
-    :attr list[Example] examples: An array of objects describing the examples defined for the intent.
+    :attr list[Example] examples: An array of objects describing the examples defined for
+    the intent.
     :attr Pagination pagination: The pagination data for the returned objects.
     """
 
@@ -3773,7 +4221,8 @@ class ExampleCollection(object):
         """
         Initialize a ExampleCollection object.
 
-        :param list[Example] examples: An array of objects describing the examples defined for the intent.
+        :param list[Example] examples: An array of objects describing the examples defined
+        for the intent.
         :param Pagination pagination: The pagination data for the returned objects.
         """
         self.examples = examples
@@ -3827,14 +4276,16 @@ class InputData(object):
     """
     The user input.
 
-    :attr str text: The text of the user input. This string cannot contain carriage return, newline, or tab characters, and it must be no longer than 2048 characters.
+    :attr str text: The text of the user input. This string cannot contain carriage
+    return, newline, or tab characters, and it must be no longer than 2048 characters.
     """
 
     def __init__(self, text):
         """
         Initialize a InputData object.
 
-        :param str text: The text of the user input. This string cannot contain carriage return, newline, or tab characters, and it must be no longer than 2048 characters.
+        :param str text: The text of the user input. This string cannot contain carriage
+        return, newline, or tab characters, and it must be no longer than 2048 characters.
         """
         self.text = text
 
@@ -3891,7 +4342,8 @@ class Intent(object):
 
         :param str intent_name: The name of the intent.
         :param datetime created: (optional) The timestamp for creation of the intent.
-        :param datetime updated: (optional) The timestamp for the last update to the intent.
+        :param datetime updated: (optional) The timestamp for the last update to the
+        intent.
         :param str description: (optional) The description of the intent.
         """
         self.intent_name = intent_name
@@ -3949,7 +4401,8 @@ class IntentCollection(object):
     """
     IntentCollection.
 
-    :attr list[IntentExport] intents: An array of objects describing the intents defined for the workspace.
+    :attr list[IntentExport] intents: An array of objects describing the intents defined
+    for the workspace.
     :attr Pagination pagination: The pagination data for the returned objects.
     """
 
@@ -3957,7 +4410,8 @@ class IntentCollection(object):
         """
         Initialize a IntentCollection object.
 
-        :param list[IntentExport] intents: An array of objects describing the intents defined for the workspace.
+        :param list[IntentExport] intents: An array of objects describing the intents
+        defined for the workspace.
         :param Pagination pagination: The pagination data for the returned objects.
         """
         self.intents = intents
@@ -4015,7 +4469,8 @@ class IntentExport(object):
     :attr datetime created: (optional) The timestamp for creation of the intent.
     :attr datetime updated: (optional) The timestamp for the last update to the intent.
     :attr str description: (optional) The description of the intent.
-    :attr list[Example] examples: (optional) An array of objects describing the user input examples for the intent.
+    :attr list[Example] examples: (optional) An array of objects describing the user input
+    examples for the intent.
     """
 
     def __init__(self,
@@ -4029,9 +4484,11 @@ class IntentExport(object):
 
         :param str intent_name: The name of the intent.
         :param datetime created: (optional) The timestamp for creation of the intent.
-        :param datetime updated: (optional) The timestamp for the last update to the intent.
+        :param datetime updated: (optional) The timestamp for the last update to the
+        intent.
         :param str description: (optional) The description of the intent.
-        :param list[Example] examples: (optional) An array of objects describing the user input examples for the intent.
+        :param list[Example] examples: (optional) An array of objects describing the user
+        input examples for the intent.
         """
         self.intent_name = intent_name
         self.created = created
@@ -4158,12 +4615,15 @@ class LogExport(object):
     """
     LogExport.
 
-    :attr MessageRequest request: A request received by the workspace, including the user input and context.
-    :attr MessageResponse response: The response sent by the workspace, including the output text, detected intents and entities, and context.
+    :attr MessageRequest request: A request received by the workspace, including the user
+    input and context.
+    :attr MessageResponse response: The response sent by the workspace, including the
+    output text, detected intents and entities, and context.
     :attr str log_id: A unique identifier for the logged event.
     :attr str request_timestamp: The timestamp for receipt of the message.
     :attr str response_timestamp: The timestamp for the system response to the message.
-    :attr str workspace_id: The unique identifier of the workspace where the request was made.
+    :attr str workspace_id: The unique identifier of the workspace where the request was
+    made.
     :attr str language: The language of the workspace where the message request was made.
     """
 
@@ -4172,13 +4632,18 @@ class LogExport(object):
         """
         Initialize a LogExport object.
 
-        :param MessageRequest request: A request received by the workspace, including the user input and context.
-        :param MessageResponse response: The response sent by the workspace, including the output text, detected intents and entities, and context.
+        :param MessageRequest request: A request received by the workspace, including the
+        user input and context.
+        :param MessageResponse response: The response sent by the workspace, including the
+        output text, detected intents and entities, and context.
         :param str log_id: A unique identifier for the logged event.
         :param str request_timestamp: The timestamp for receipt of the message.
-        :param str response_timestamp: The timestamp for the system response to the message.
-        :param str workspace_id: The unique identifier of the workspace where the request was made.
-        :param str language: The language of the workspace where the message request was made.
+        :param str response_timestamp: The timestamp for the system response to the
+        message.
+        :param str workspace_id: The unique identifier of the workspace where the request
+        was made.
+        :param str language: The language of the workspace where the message request was
+        made.
         """
         self.request = request
         self.response = response
@@ -4352,7 +4817,8 @@ class LogPagination(object):
     """
     The pagination data for the returned objects.
 
-    :attr str next_url: (optional) The URL that will return the next page of results, if any.
+    :attr str next_url: (optional) The URL that will return the next page of results, if
+    any.
     :attr int matched: (optional) Reserved for future use.
     :attr str next_cursor: (optional) A token identifying the next page of results.
     """
@@ -4361,7 +4827,8 @@ class LogPagination(object):
         """
         Initialize a LogPagination object.
 
-        :param str next_url: (optional) The URL that will return the next page of results, if any.
+        :param str next_url: (optional) The URL that will return the next page of results,
+        if any.
         :param int matched: (optional) Reserved for future use.
         :param str next_cursor: (optional) A token identifying the next page of results.
         """
@@ -4457,11 +4924,18 @@ class MessageRequest(object):
     A request formatted for the Watson Assistant service.
 
     :attr InputData input: (optional) An input object that includes the input text.
-    :attr bool alternate_intents: (optional) Whether to return more than one intent. Set to `true` to return all matching intents.
-    :attr Context context: (optional) State information for the conversation. Continue a conversation by including the context object from the previous response.
-    :attr list[RuntimeEntity] entities: (optional) Entities to use when evaluating the message. Include entities from the previous response to continue using those entities rather than detecting entities in the new input.
-    :attr list[RuntimeIntent] intents: (optional) Intents to use when evaluating the user input. Include intents from the previous response to continue using those intents rather than trying to recognize intents in the new input.
-    :attr OutputData output: (optional) System output. Include the output from the previous response to maintain intermediate information over multiple requests.
+    :attr bool alternate_intents: (optional) Whether to return more than one intent. Set
+    to `true` to return all matching intents.
+    :attr Context context: (optional) State information for the conversation. Continue a
+    conversation by including the context object from the previous response.
+    :attr list[RuntimeEntity] entities: (optional) Entities to use when evaluating the
+    message. Include entities from the previous response to continue using those entities
+    rather than detecting entities in the new input.
+    :attr list[RuntimeIntent] intents: (optional) Intents to use when evaluating the user
+    input. Include intents from the previous response to continue using those intents
+    rather than trying to recognize intents in the new input.
+    :attr OutputData output: (optional) System output. Include the output from the
+    previous response to maintain intermediate information over multiple requests.
     """
 
     def __init__(self,
@@ -4475,11 +4949,19 @@ class MessageRequest(object):
         Initialize a MessageRequest object.
 
         :param InputData input: (optional) An input object that includes the input text.
-        :param bool alternate_intents: (optional) Whether to return more than one intent. Set to `true` to return all matching intents.
-        :param Context context: (optional) State information for the conversation. Continue a conversation by including the context object from the previous response.
-        :param list[RuntimeEntity] entities: (optional) Entities to use when evaluating the message. Include entities from the previous response to continue using those entities rather than detecting entities in the new input.
-        :param list[RuntimeIntent] intents: (optional) Intents to use when evaluating the user input. Include intents from the previous response to continue using those intents rather than trying to recognize intents in the new input.
-        :param OutputData output: (optional) System output. Include the output from the previous response to maintain intermediate information over multiple requests.
+        :param bool alternate_intents: (optional) Whether to return more than one intent.
+        Set to `true` to return all matching intents.
+        :param Context context: (optional) State information for the conversation.
+        Continue a conversation by including the context object from the previous
+        response.
+        :param list[RuntimeEntity] entities: (optional) Entities to use when evaluating
+        the message. Include entities from the previous response to continue using those
+        entities rather than detecting entities in the new input.
+        :param list[RuntimeIntent] intents: (optional) Intents to use when evaluating the
+        user input. Include intents from the previous response to continue using those
+        intents rather than trying to recognize intents in the new input.
+        :param OutputData output: (optional) System output. Include the output from the
+        previous response to maintain intermediate information over multiple requests.
         """
         self.input = input
         self.alternate_intents = alternate_intents
@@ -4548,11 +5030,14 @@ class MessageResponse(object):
     A response from the Watson Assistant service.
 
     :attr MessageInput input: (optional) The user input from the request.
-    :attr list[RuntimeIntent] intents: An array of intents recognized in the user input, sorted in descending order of confidence.
+    :attr list[RuntimeIntent] intents: An array of intents recognized in the user input,
+    sorted in descending order of confidence.
     :attr list[RuntimeEntity] entities: An array of entities identified in the user input.
-    :attr bool alternate_intents: (optional) Whether to return more than one intent. A value of `true` indicates that all matching intents are returned.
+    :attr bool alternate_intents: (optional) Whether to return more than one intent. A
+    value of `true` indicates that all matching intents are returned.
     :attr Context context: State information for the conversation.
-    :attr OutputData output: Output from the dialog, including the response to the user, the nodes that were triggered, and log messages.
+    :attr OutputData output: Output from the dialog, including the response to the user,
+    the nodes that were triggered, and log messages.
     """
 
     def __init__(self,
@@ -4566,12 +5051,16 @@ class MessageResponse(object):
         """
         Initialize a MessageResponse object.
 
-        :param list[RuntimeIntent] intents: An array of intents recognized in the user input, sorted in descending order of confidence.
-        :param list[RuntimeEntity] entities: An array of entities identified in the user input.
+        :param list[RuntimeIntent] intents: An array of intents recognized in the user
+        input, sorted in descending order of confidence.
+        :param list[RuntimeEntity] entities: An array of entities identified in the user
+        input.
         :param Context context: State information for the conversation.
-        :param OutputData output: Output from the dialog, including the response to the user, the nodes that were triggered, and log messages.
+        :param OutputData output: Output from the dialog, including the response to the
+        user, the nodes that were triggered, and log messages.
         :param MessageInput input: (optional) The user input from the request.
-        :param bool alternate_intents: (optional) Whether to return more than one intent. A value of `true` indicates that all matching intents are returned.
+        :param bool alternate_intents: (optional) Whether to return more than one intent.
+        A value of `true` indicates that all matching intents are returned.
         :param **kwargs: (optional) Any additional properties.
         """
         self.input = input
@@ -4684,10 +5173,16 @@ class OutputData(object):
     An output object that includes the response to the user, the nodes that were hit, and
     messages from the log.
 
-    :attr list[LogMessage] log_messages: An array of up to 50 messages logged with the request.
+    :attr list[LogMessage] log_messages: An array of up to 50 messages logged with the
+    request.
     :attr list[str] text: An array of responses to the user.
-    :attr list[str] nodes_visited: (optional) An array of the nodes that were triggered to create the response, in the order in which they were visited. This information is useful for debugging and for tracing the path taken through the node tree.
-    :attr list[DialogNodeVisitedDetails] nodes_visited_details: (optional) An array of objects containing detailed diagnostic information about the nodes that were triggered during processing of the input message. Included only if **nodes_visited_details** is set to `true` in the message request.
+    :attr list[str] nodes_visited: (optional) An array of the nodes that were triggered to
+    create the response, in the order in which they were visited. This information is
+    useful for debugging and for tracing the path taken through the node tree.
+    :attr list[DialogNodeVisitedDetails] nodes_visited_details: (optional) An array of
+    objects containing detailed diagnostic information about the nodes that were triggered
+    during processing of the input message. Included only if **nodes_visited_details** is
+    set to `true` in the message request.
     """
 
     def __init__(self,
@@ -4699,10 +5194,17 @@ class OutputData(object):
         """
         Initialize a OutputData object.
 
-        :param list[LogMessage] log_messages: An array of up to 50 messages logged with the request.
+        :param list[LogMessage] log_messages: An array of up to 50 messages logged with
+        the request.
         :param list[str] text: An array of responses to the user.
-        :param list[str] nodes_visited: (optional) An array of the nodes that were triggered to create the response, in the order in which they were visited. This information is useful for debugging and for tracing the path taken through the node tree.
-        :param list[DialogNodeVisitedDetails] nodes_visited_details: (optional) An array of objects containing detailed diagnostic information about the nodes that were triggered during processing of the input message. Included only if **nodes_visited_details** is set to `true` in the message request.
+        :param list[str] nodes_visited: (optional) An array of the nodes that were
+        triggered to create the response, in the order in which they were visited. This
+        information is useful for debugging and for tracing the path taken through the
+        node tree.
+        :param list[DialogNodeVisitedDetails] nodes_visited_details: (optional) An array
+        of objects containing detailed diagnostic information about the nodes that were
+        triggered during processing of the input message. Included only if
+        **nodes_visited_details** is set to `true` in the message request.
         :param **kwargs: (optional) Any additional properties.
         """
         self.log_messages = log_messages
@@ -4754,7 +5256,7 @@ class OutputData(object):
         if hasattr(self, 'nodes_visited') and self.nodes_visited is not None:
             _dict['nodes_visited'] = self.nodes_visited
         if hasattr(self, 'nodes_visited_details'
-                  ) and self.nodes_visited_details is not None:
+                   ) and self.nodes_visited_details is not None:
             _dict['nodes_visited_details'] = [
                 x._to_dict() for x in self.nodes_visited_details
             ]
@@ -4816,7 +5318,8 @@ class Pagination(object):
         :param str next_url: (optional) The URL that will return the next page of results.
         :param int total: (optional) Reserved for future use.
         :param int matched: (optional) Reserved for future use.
-        :param str refresh_cursor: (optional) A token identifying the current page of results.
+        :param str refresh_cursor: (optional) A token identifying the current page of
+        results.
         :param str next_cursor: (optional) A token identifying the next page of results.
         """
         self.refresh_url = refresh_url
@@ -4885,11 +5388,14 @@ class RuntimeEntity(object):
     A term from the request that was identified as an entity.
 
     :attr str entity: An entity detected in the input.
-    :attr list[int] location: An array of zero-based character offsets that indicate where the detected entity values begin and end in the input text.
+    :attr list[int] location: An array of zero-based character offsets that indicate where
+    the detected entity values begin and end in the input text.
     :attr str value: The term in the input text that was recognized as an entity value.
-    :attr float confidence: (optional) A decimal percentage that represents Watson's confidence in the entity.
+    :attr float confidence: (optional) A decimal percentage that represents Watson's
+    confidence in the entity.
     :attr object metadata: (optional) Any metadata for the entity.
-    :attr list[CaptureGroup] groups: (optional) The recognized capture groups for the entity, as defined by the entity pattern.
+    :attr list[CaptureGroup] groups: (optional) The recognized capture groups for the
+    entity, as defined by the entity pattern.
     """
 
     def __init__(self,
@@ -4904,11 +5410,15 @@ class RuntimeEntity(object):
         Initialize a RuntimeEntity object.
 
         :param str entity: An entity detected in the input.
-        :param list[int] location: An array of zero-based character offsets that indicate where the detected entity values begin and end in the input text.
-        :param str value: The term in the input text that was recognized as an entity value.
-        :param float confidence: (optional) A decimal percentage that represents Watson's confidence in the entity.
+        :param list[int] location: An array of zero-based character offsets that indicate
+        where the detected entity values begin and end in the input text.
+        :param str value: The term in the input text that was recognized as an entity
+        value.
+        :param float confidence: (optional) A decimal percentage that represents Watson's
+        confidence in the entity.
         :param object metadata: (optional) Any metadata for the entity.
-        :param list[CaptureGroup] groups: (optional) The recognized capture groups for the entity, as defined by the entity pattern.
+        :param list[CaptureGroup] groups: (optional) The recognized capture groups for the
+        entity, as defined by the entity pattern.
         :param **kwargs: (optional) Any additional properties.
         """
         self.entity = entity
@@ -5013,7 +5523,8 @@ class RuntimeIntent(object):
     An intent identified in the user input.
 
     :attr str intent: The name of the recognized intent.
-    :attr float confidence: A decimal percentage that represents Watson's confidence in the intent.
+    :attr float confidence: A decimal percentage that represents Watson's confidence in
+    the intent.
     """
 
     def __init__(self, intent, confidence, **kwargs):
@@ -5021,7 +5532,8 @@ class RuntimeIntent(object):
         Initialize a RuntimeIntent object.
 
         :param str intent: The name of the recognized intent.
-        :param float confidence: A decimal percentage that represents Watson's confidence in the intent.
+        :param float confidence: A decimal percentage that represents Watson's confidence
+        in the intent.
         :param **kwargs: (optional) Any additional properties.
         """
         self.intent = intent
@@ -5095,7 +5607,8 @@ class Synonym(object):
 
     :attr str synonym_text: The text of the synonym.
     :attr datetime created: (optional) The timestamp for creation of the synonym.
-    :attr datetime updated: (optional) The timestamp for the most recent update to the synonym.
+    :attr datetime updated: (optional) The timestamp for the most recent update to the
+    synonym.
     """
 
     def __init__(self, synonym_text, created=None, updated=None):
@@ -5104,7 +5617,8 @@ class Synonym(object):
 
         :param str synonym_text: The text of the synonym.
         :param datetime created: (optional) The timestamp for creation of the synonym.
-        :param datetime updated: (optional) The timestamp for the most recent update to the synonym.
+        :param datetime updated: (optional) The timestamp for the most recent update to
+        the synonym.
         """
         self.synonym_text = synonym_text
         self.created = created
@@ -5278,9 +5792,12 @@ class Value(object):
     :attr str value_text: The text of the entity value.
     :attr object metadata: (optional) Any metadata related to the entity value.
     :attr datetime created: (optional) The timestamp for creation of the entity value.
-    :attr datetime updated: (optional) The timestamp for the last update to the entity value.
-    :attr list[str] synonyms: (optional) An array containing any synonyms for the entity value.
-    :attr list[str] patterns: (optional) An array containing any patterns for the entity value.
+    :attr datetime updated: (optional) The timestamp for the last update to the entity
+    value.
+    :attr list[str] synonyms: (optional) An array containing any synonyms for the entity
+    value.
+    :attr list[str] patterns: (optional) An array containing any patterns for the entity
+    value.
     :attr str value_type: Specifies the type of value.
     """
 
@@ -5298,10 +5815,14 @@ class Value(object):
         :param str value_text: The text of the entity value.
         :param str value_type: Specifies the type of value.
         :param object metadata: (optional) Any metadata related to the entity value.
-        :param datetime created: (optional) The timestamp for creation of the entity value.
-        :param datetime updated: (optional) The timestamp for the last update to the entity value.
-        :param list[str] synonyms: (optional) An array containing any synonyms for the entity value.
-        :param list[str] patterns: (optional) An array containing any patterns for the entity value.
+        :param datetime created: (optional) The timestamp for creation of the entity
+        value.
+        :param datetime updated: (optional) The timestamp for the last update to the
+        entity value.
+        :param list[str] synonyms: (optional) An array containing any synonyms for the
+        entity value.
+        :param list[str] patterns: (optional) An array containing any patterns for the
+        entity value.
         """
         self.value_text = value_text
         self.metadata = metadata
@@ -5376,7 +5897,8 @@ class ValueCollection(object):
     ValueCollection.
 
     :attr list[ValueExport] values: An array of entity values.
-    :attr Pagination pagination: An object defining the pagination data for the returned objects.
+    :attr Pagination pagination: An object defining the pagination data for the returned
+    objects.
     """
 
     def __init__(self, values, pagination):
@@ -5384,7 +5906,8 @@ class ValueCollection(object):
         Initialize a ValueCollection object.
 
         :param list[ValueExport] values: An array of entity values.
-        :param Pagination pagination: An object defining the pagination data for the returned objects.
+        :param Pagination pagination: An object defining the pagination data for the
+        returned objects.
         """
         self.values = values
         self.pagination = pagination
@@ -5440,9 +5963,12 @@ class ValueExport(object):
     :attr str value_text: The text of the entity value.
     :attr object metadata: (optional) Any metadata related to the entity value.
     :attr datetime created: (optional) The timestamp for creation of the entity value.
-    :attr datetime updated: (optional) The timestamp for the last update to the entity value.
-    :attr list[str] synonyms: (optional) An array containing any synonyms for the entity value.
-    :attr list[str] patterns: (optional) An array containing any patterns for the entity value.
+    :attr datetime updated: (optional) The timestamp for the last update to the entity
+    value.
+    :attr list[str] synonyms: (optional) An array containing any synonyms for the entity
+    value.
+    :attr list[str] patterns: (optional) An array containing any patterns for the entity
+    value.
     :attr str value_type: Specifies the type of value.
     """
 
@@ -5460,10 +5986,14 @@ class ValueExport(object):
         :param str value_text: The text of the entity value.
         :param str value_type: Specifies the type of value.
         :param object metadata: (optional) Any metadata related to the entity value.
-        :param datetime created: (optional) The timestamp for creation of the entity value.
-        :param datetime updated: (optional) The timestamp for the last update to the entity value.
-        :param list[str] synonyms: (optional) An array containing any synonyms for the entity value.
-        :param list[str] patterns: (optional) An array containing any patterns for the entity value.
+        :param datetime created: (optional) The timestamp for creation of the entity
+        value.
+        :param datetime updated: (optional) The timestamp for the last update to the
+        entity value.
+        :param list[str] synonyms: (optional) An array containing any synonyms for the
+        entity value.
+        :param list[str] patterns: (optional) An array containing any patterns for the
+        entity value.
         """
         self.value_text = value_text
         self.metadata = metadata
@@ -5544,7 +6074,9 @@ class Workspace(object):
     :attr str workspace_id: The workspace ID.
     :attr str description: (optional) The description of the workspace.
     :attr object metadata: (optional) Any metadata related to the workspace.
-    :attr bool learning_opt_out: (optional) Whether training data from the workspace (including artifacts such as intents and entities) can be used by IBM for general service improvements. `true` indicates that workspace training data is not to be used.
+    :attr bool learning_opt_out: (optional) Whether training data from the workspace
+    (including artifacts such as intents and entities) can be used by IBM for general
+    service improvements. `true` indicates that workspace training data is not to be used.
     """
 
     def __init__(self,
@@ -5563,10 +6095,14 @@ class Workspace(object):
         :param str language: The language of the workspace.
         :param str workspace_id: The workspace ID.
         :param datetime created: (optional) The timestamp for creation of the workspace.
-        :param datetime updated: (optional) The timestamp for the last update to the workspace.
+        :param datetime updated: (optional) The timestamp for the last update to the
+        workspace.
         :param str description: (optional) The description of the workspace.
         :param object metadata: (optional) Any metadata related to the workspace.
-        :param bool learning_opt_out: (optional) Whether training data from the workspace (including artifacts such as intents and entities) can be used by IBM for general service improvements. `true` indicates that workspace training data is not to be used.
+        :param bool learning_opt_out: (optional) Whether training data from the workspace
+        (including artifacts such as intents and entities) can be used by IBM for general
+        service improvements. `true` indicates that workspace training data is not to be
+        used.
         """
         self.name = name
         self.language = language
@@ -5650,16 +6186,20 @@ class WorkspaceCollection(object):
     """
     WorkspaceCollection.
 
-    :attr list[Workspace] workspaces: An array of objects describing the workspaces associated with the service instance.
-    :attr Pagination pagination: An object defining the pagination data for the returned objects.
+    :attr list[Workspace] workspaces: An array of objects describing the workspaces
+    associated with the service instance.
+    :attr Pagination pagination: An object defining the pagination data for the returned
+    objects.
     """
 
     def __init__(self, workspaces, pagination):
         """
         Initialize a WorkspaceCollection object.
 
-        :param list[Workspace] workspaces: An array of objects describing the workspaces associated with the service instance.
-        :param Pagination pagination: An object defining the pagination data for the returned objects.
+        :param list[Workspace] workspaces: An array of objects describing the workspaces
+        associated with the service instance.
+        :param Pagination pagination: An object defining the pagination data for the
+        returned objects.
         """
         self.workspaces = workspaces
         self.pagination = pagination
@@ -5720,11 +6260,14 @@ class WorkspaceExport(object):
     :attr datetime updated: (optional) The timestamp for the last update to the workspace.
     :attr str workspace_id: The workspace ID.
     :attr str status: The current status of the workspace.
-    :attr bool learning_opt_out: Whether training data from the workspace can be used by IBM for general service improvements. `true` indicates that workspace training data is not to be used.
+    :attr bool learning_opt_out: Whether training data from the workspace can be used by
+    IBM for general service improvements. `true` indicates that workspace training data is
+    not to be used.
     :attr list[IntentExport] intents: (optional) An array of intents.
     :attr list[EntityExport] entities: (optional) An array of entities.
     :attr list[Counterexample] counterexamples: (optional) An array of counterexamples.
-    :attr list[DialogNode] dialog_nodes: (optional) An array of objects describing the dialog nodes in the workspace.
+    :attr list[DialogNode] dialog_nodes: (optional) An array of objects describing the
+    dialog nodes in the workspace.
     """
 
     def __init__(self,
@@ -5750,13 +6293,18 @@ class WorkspaceExport(object):
         :param object metadata: Any metadata that is required by the workspace.
         :param str workspace_id: The workspace ID.
         :param str status: The current status of the workspace.
-        :param bool learning_opt_out: Whether training data from the workspace can be used by IBM for general service improvements. `true` indicates that workspace training data is not to be used.
+        :param bool learning_opt_out: Whether training data from the workspace can be used
+        by IBM for general service improvements. `true` indicates that workspace training
+        data is not to be used.
         :param datetime created: (optional) The timestamp for creation of the workspace.
-        :param datetime updated: (optional) The timestamp for the last update to the workspace.
+        :param datetime updated: (optional) The timestamp for the last update to the
+        workspace.
         :param list[IntentExport] intents: (optional) An array of intents.
         :param list[EntityExport] entities: (optional) An array of entities.
-        :param list[Counterexample] counterexamples: (optional) An array of counterexamples.
-        :param list[DialogNode] dialog_nodes: (optional) An array of objects describing the dialog nodes in the workspace.
+        :param list[Counterexample] counterexamples: (optional) An array of
+        counterexamples.
+        :param list[DialogNode] dialog_nodes: (optional) An array of objects describing
+        the dialog nodes in the workspace.
         """
         self.name = name
         self.description = description

--- a/watson_developer_cloud/conversation_v1.py
+++ b/watson_developer_cloud/conversation_v1.py
@@ -5256,7 +5256,7 @@ class OutputData(object):
         if hasattr(self, 'nodes_visited') and self.nodes_visited is not None:
             _dict['nodes_visited'] = self.nodes_visited
         if hasattr(self, 'nodes_visited_details'
-                   ) and self.nodes_visited_details is not None:
+                  ) and self.nodes_visited_details is not None:
             _dict['nodes_visited_details'] = [
                 x._to_dict() for x in self.nodes_visited_details
             ]

--- a/watson_developer_cloud/conversation_v1.py
+++ b/watson_developer_cloud/conversation_v1.py
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """
-The IBM Watson Conversation service combines machine learning, natural language
+The IBM Watson&trade; Conversation service combines machine learning, natural language
 understanding, and integrated dialog tools to create conversation flows between your apps
 and your users.
 """
@@ -117,16 +117,26 @@ class ConversationV1(WatsonService):
         """
         Get response to user input.
 
-        Get a response to a user's input.    There is no rate limit for this operation.
+        Get a response to a user's input.
+        There is no rate limit for this operation.
 
         :param str workspace_id: Unique identifier of the workspace.
         :param InputData input: An input object that includes the input text.
-        :param bool alternate_intents: Whether to return more than one intent. Set to `true` to return all matching intents.
-        :param Context context: State information for the conversation. Continue a conversation by including the context object from the previous response.
-        :param list[RuntimeEntity] entities: Entities to use when evaluating the message. Include entities from the previous response to continue using those entities rather than detecting entities in the new input.
-        :param list[RuntimeIntent] intents: Intents to use when evaluating the user input. Include intents from the previous response to continue using those intents rather than trying to recognize intents in the new input.
-        :param OutputData output: System output. Include the output from the previous response to maintain intermediate information over multiple requests.
-        :param bool nodes_visited_details: Whether to include additional diagnostic information about the dialog nodes that were visited during processing of the message.
+        :param bool alternate_intents: Whether to return more than one intent. Set to
+        `true` to return all matching intents.
+        :param Context context: State information for the conversation. Continue a
+        conversation by including the context object from the previous response.
+        :param list[RuntimeEntity] entities: Entities to use when evaluating the message.
+        Include entities from the previous response to continue using those entities
+        rather than detecting entities in the new input.
+        :param list[RuntimeIntent] intents: Intents to use when evaluating the user input.
+        Include intents from the previous response to continue using those intents rather
+        than trying to recognize intents in the new input.
+        :param OutputData output: System output. Include the output from the previous
+        response to maintain intermediate information over multiple requests.
+        :param bool nodes_visited_details: Whether to include additional diagnostic
+        information about the dialog nodes that were visited during processing of the
+        message.
         :param dict headers: A `dict` containing the request headers
         :return: A `dict` containing the `MessageResponse` response.
         :rtype: dict
@@ -190,18 +200,28 @@ class ConversationV1(WatsonService):
         Create workspace.
 
         Create a workspace based on component objects. You must provide workspace
-        components defining the content of the new workspace.    This operation is limited
-        to 30 requests per 30 minutes. For more information, see **Rate limiting**.
+        components defining the content of the new workspace.
+        This operation is limited to 30 requests per 30 minutes. For more information, see
+        **Rate limiting**.
 
-        :param str name: The name of the workspace. This string cannot contain carriage return, newline, or tab characters, and it must be no longer than 64 characters.
-        :param str description: The description of the workspace. This string cannot contain carriage return, newline, or tab characters, and it must be no longer than 128 characters.
+        :param str name: The name of the workspace. This string cannot contain carriage
+        return, newline, or tab characters, and it must be no longer than 64 characters.
+        :param str description: The description of the workspace. This string cannot
+        contain carriage return, newline, or tab characters, and it must be no longer than
+        128 characters.
         :param str language: The language of the workspace.
-        :param list[CreateIntent] intents: An array of objects defining the intents for the workspace.
-        :param list[CreateEntity] entities: An array of objects defining the entities for the workspace.
-        :param list[CreateDialogNode] dialog_nodes: An array of objects defining the nodes in the workspace dialog.
-        :param list[CreateCounterexample] counterexamples: An array of objects defining input examples that have been marked as irrelevant input.
+        :param list[CreateIntent] intents: An array of objects defining the intents for
+        the workspace.
+        :param list[CreateEntity] entities: An array of objects defining the entities for
+        the workspace.
+        :param list[CreateDialogNode] dialog_nodes: An array of objects defining the nodes
+        in the workspace dialog.
+        :param list[CreateCounterexample] counterexamples: An array of objects defining
+        input examples that have been marked as irrelevant input.
         :param object metadata: Any metadata related to the workspace.
-        :param bool learning_opt_out: Whether training data from the workspace can be used by IBM for general service improvements. `true` indicates that workspace training data is not to be used.
+        :param bool learning_opt_out: Whether training data from the workspace can be used
+        by IBM for general service improvements. `true` indicates that workspace training
+        data is not to be used.
         :param dict headers: A `dict` containing the request headers
         :return: A `dict` containing the `Workspace` response.
         :rtype: dict
@@ -248,8 +268,9 @@ class ConversationV1(WatsonService):
         """
         Delete workspace.
 
-        Delete a workspace from the service instance.    This operation is limited to 30
-        requests per 30 minutes. For more information, see **Rate limiting**.
+        Delete a workspace from the service instance.
+        This operation is limited to 30 requests per 30 minutes. For more information, see
+        **Rate limiting**.
 
         :param str workspace_id: Unique identifier of the workspace.
         :param dict headers: A `dict` containing the request headers
@@ -285,8 +306,12 @@ class ConversationV1(WatsonService):
         information, see **Rate limiting**.
 
         :param str workspace_id: Unique identifier of the workspace.
-        :param bool export: Whether to include all element content in the returned data. If **export**=`false`, the returned data includes only information about the element itself. If **export**=`true`, all content, including subelements, is included.
-        :param bool include_audit: Whether to include the audit properties (`created` and `updated` timestamps) in the response.
+        :param bool export: Whether to include all element content in the returned data.
+        If **export**=`false`, the returned data includes only information about the
+        element itself. If **export**=`true`, all content, including subelements, is
+        included.
+        :param bool include_audit: Whether to include the audit properties (`created` and
+        `updated` timestamps) in the response.
         :param dict headers: A `dict` containing the request headers
         :return: A `dict` containing the `WorkspaceExport` response.
         :rtype: dict
@@ -321,15 +346,19 @@ class ConversationV1(WatsonService):
         """
         List workspaces.
 
-        List the workspaces associated with a Conversation service instance.    This
-        operation is limited to 500 requests per 30 minutes. For more information, see
-        **Rate limiting**.
+        List the workspaces associated with a Conversation service instance.
+        This operation is limited to 500 requests per 30 minutes. For more information,
+        see **Rate limiting**.
 
         :param int page_limit: The number of records to return in each page of results.
-        :param bool include_count: Whether to include information about the number of records returned.
-        :param str sort: The attribute by which returned results will be sorted. To reverse the sort order, prefix the value with a minus sign (`-`). Supported values are `name`, `updated`, and `workspace_id`.
+        :param bool include_count: Whether to include information about the number of
+        records returned.
+        :param str sort: The attribute by which returned results will be sorted. To
+        reverse the sort order, prefix the value with a minus sign (`-`). Supported values
+        are `name`, `updated`, and `workspace_id`.
         :param str cursor: A token identifying the page of results to retrieve.
-        :param bool include_audit: Whether to include the audit properties (`created` and `updated` timestamps) in the response.
+        :param bool include_audit: Whether to include the audit properties (`created` and
+        `updated` timestamps) in the response.
         :param dict headers: A `dict` containing the request headers
         :return: A `dict` containing the `WorkspaceCollection` response.
         :rtype: dict
@@ -371,20 +400,38 @@ class ConversationV1(WatsonService):
         Update workspace.
 
         Update an existing workspace with new or modified data. You must provide component
-        objects defining the content of the updated workspace.    This operation is
-        limited to 30 request per 30 minutes. For more information, see **Rate limiting**.
+        objects defining the content of the updated workspace.
+        This operation is limited to 30 request per 30 minutes. For more information, see
+        **Rate limiting**.
 
         :param str workspace_id: Unique identifier of the workspace.
-        :param str name: The name of the workspace. This string cannot contain carriage return, newline, or tab characters, and it must be no longer than 64 characters.
-        :param str description: The description of the workspace. This string cannot contain carriage return, newline, or tab characters, and it must be no longer than 128 characters.
+        :param str name: The name of the workspace. This string cannot contain carriage
+        return, newline, or tab characters, and it must be no longer than 64 characters.
+        :param str description: The description of the workspace. This string cannot
+        contain carriage return, newline, or tab characters, and it must be no longer than
+        128 characters.
         :param str language: The language of the workspace.
-        :param list[CreateIntent] intents: An array of objects defining the intents for the workspace.
-        :param list[CreateEntity] entities: An array of objects defining the entities for the workspace.
-        :param list[CreateDialogNode] dialog_nodes: An array of objects defining the nodes in the workspace dialog.
-        :param list[CreateCounterexample] counterexamples: An array of objects defining input examples that have been marked as irrelevant input.
+        :param list[CreateIntent] intents: An array of objects defining the intents for
+        the workspace.
+        :param list[CreateEntity] entities: An array of objects defining the entities for
+        the workspace.
+        :param list[CreateDialogNode] dialog_nodes: An array of objects defining the nodes
+        in the workspace dialog.
+        :param list[CreateCounterexample] counterexamples: An array of objects defining
+        input examples that have been marked as irrelevant input.
         :param object metadata: Any metadata related to the workspace.
-        :param bool learning_opt_out: Whether training data from the workspace can be used by IBM for general service improvements. `true` indicates that workspace training data is not to be used.
-        :param bool append: Whether the new data is to be appended to the existing data in the workspace. If **append**=`false`, elements included in the new data completely replace the corresponding existing elements, including all subelements. For example, if the new data includes **entities** and **append**=`false`, all existing entities in the workspace are discarded and replaced with the new entities.    If **append**=`true`, existing elements are preserved, and the new elements are added. If any elements in the new data collide with existing elements, the update request fails.
+        :param bool learning_opt_out: Whether training data from the workspace can be used
+        by IBM for general service improvements. `true` indicates that workspace training
+        data is not to be used.
+        :param bool append: Whether the new data is to be appended to the existing data in
+        the workspace. If **append**=`false`, elements included in the new data completely
+        replace the corresponding existing elements, including all subelements. For
+        example, if the new data includes **entities** and **append**=`false`, all
+        existing entities in the workspace are discarded and replaced with the new
+        entities.
+        If **append**=`true`, existing elements are preserved, and the new elements are
+        added. If any elements in the new data collide with existing elements, the update
+        request fails.
         :param dict headers: A `dict` containing the request headers
         :return: A `dict` containing the `Workspace` response.
         :rtype: dict
@@ -443,13 +490,22 @@ class ConversationV1(WatsonService):
         """
         Create intent.
 
-        Create a new intent.    This operation is limited to 2000 requests per 30 minutes.
-        For more information, see **Rate limiting**.
+        Create a new intent.
+        This operation is limited to 2000 requests per 30 minutes. For more information,
+        see **Rate limiting**.
 
         :param str workspace_id: Unique identifier of the workspace.
-        :param str intent: The name of the intent. This string must conform to the following restrictions:  - It can contain only Unicode alphanumeric, underscore, hyphen, and dot characters.  - It cannot begin with the reserved prefix `sys-`.  - It must be no longer than 128 characters.
-        :param str description: The description of the intent. This string cannot contain carriage return, newline, or tab characters, and it must be no longer than 128 characters.
-        :param list[CreateExample] examples: An array of user input examples for the intent.
+        :param str intent: The name of the intent. This string must conform to the
+        following restrictions:
+        - It can contain only Unicode alphanumeric, underscore, hyphen, and dot
+        characters.
+        - It cannot begin with the reserved prefix `sys-`.
+        - It must be no longer than 128 characters.
+        :param str description: The description of the intent. This string cannot contain
+        carriage return, newline, or tab characters, and it must be no longer than 128
+        characters.
+        :param list[CreateExample] examples: An array of user input examples for the
+        intent.
         :param dict headers: A `dict` containing the request headers
         :return: A `dict` containing the `Intent` response.
         :rtype: dict
@@ -486,8 +542,9 @@ class ConversationV1(WatsonService):
         """
         Delete intent.
 
-        Delete an intent from a workspace.    This operation is limited to 2000 requests
-        per 30 minutes. For more information, see **Rate limiting**.
+        Delete an intent from a workspace.
+        This operation is limited to 2000 requests per 30 minutes. For more information,
+        see **Rate limiting**.
 
         :param str workspace_id: Unique identifier of the workspace.
         :param str intent: The intent name.
@@ -521,15 +578,19 @@ class ConversationV1(WatsonService):
         """
         Get intent.
 
-        Get information about an intent, optionally including all intent content.    With
-        **export**=`false`, this operation is limited to 6000 requests per 5 minutes. With
-        **export**=`true`, the limit is 400 requests per 30 minutes. For more information,
-        see **Rate limiting**.
+        Get information about an intent, optionally including all intent content.
+        With **export**=`false`, this operation is limited to 6000 requests per 5 minutes.
+        With **export**=`true`, the limit is 400 requests per 30 minutes. For more
+        information, see **Rate limiting**.
 
         :param str workspace_id: Unique identifier of the workspace.
         :param str intent: The intent name.
-        :param bool export: Whether to include all element content in the returned data. If **export**=`false`, the returned data includes only information about the element itself. If **export**=`true`, all content, including subelements, is included.
-        :param bool include_audit: Whether to include the audit properties (`created` and `updated` timestamps) in the response.
+        :param bool export: Whether to include all element content in the returned data.
+        If **export**=`false`, the returned data includes only information about the
+        element itself. If **export**=`true`, all content, including subelements, is
+        included.
+        :param bool include_audit: Whether to include the audit properties (`created` and
+        `updated` timestamps) in the response.
         :param dict headers: A `dict` containing the request headers
         :return: A `dict` containing the `IntentExport` response.
         :rtype: dict
@@ -568,17 +629,25 @@ class ConversationV1(WatsonService):
         """
         List intents.
 
-        List the intents for a workspace.    With **export**=`false`, this operation is
-        limited to 2000 requests per 30 minutes. With **export**=`true`, the limit is 400
-        requests per 30 minutes. For more information, see **Rate limiting**.
+        List the intents for a workspace.
+        With **export**=`false`, this operation is limited to 2000 requests per 30
+        minutes. With **export**=`true`, the limit is 400 requests per 30 minutes. For
+        more information, see **Rate limiting**.
 
         :param str workspace_id: Unique identifier of the workspace.
-        :param bool export: Whether to include all element content in the returned data. If **export**=`false`, the returned data includes only information about the element itself. If **export**=`true`, all content, including subelements, is included.
+        :param bool export: Whether to include all element content in the returned data.
+        If **export**=`false`, the returned data includes only information about the
+        element itself. If **export**=`true`, all content, including subelements, is
+        included.
         :param int page_limit: The number of records to return in each page of results.
-        :param bool include_count: Whether to include information about the number of records returned.
-        :param str sort: The attribute by which returned results will be sorted. To reverse the sort order, prefix the value with a minus sign (`-`). Supported values are `name`, `updated`, and `workspace_id`.
+        :param bool include_count: Whether to include information about the number of
+        records returned.
+        :param str sort: The attribute by which returned results will be sorted. To
+        reverse the sort order, prefix the value with a minus sign (`-`). Supported values
+        are `name`, `updated`, and `workspace_id`.
         :param str cursor: A token identifying the page of results to retrieve.
-        :param bool include_audit: Whether to include the audit properties (`created` and `updated` timestamps) in the response.
+        :param bool include_audit: Whether to include the audit properties (`created` and
+        `updated` timestamps) in the response.
         :param dict headers: A `dict` containing the request headers
         :return: A `dict` containing the `IntentCollection` response.
         :rtype: dict
@@ -618,14 +687,21 @@ class ConversationV1(WatsonService):
         Update intent.
 
         Update an existing intent with new or modified data. You must provide component
-        objects defining the content of the updated intent.    This operation is limited
-        to 2000 requests per 30 minutes. For more information, see **Rate limiting**.
+        objects defining the content of the updated intent.
+        This operation is limited to 2000 requests per 30 minutes. For more information,
+        see **Rate limiting**.
 
         :param str workspace_id: Unique identifier of the workspace.
         :param str intent: The intent name.
-        :param str new_intent: The name of the intent. This string must conform to the following restrictions:  - It can contain only Unicode alphanumeric, underscore, hyphen, and dot characters.  - It cannot begin with the reserved prefix `sys-`.  - It must be no longer than 128 characters.
+        :param str new_intent: The name of the intent. This string must conform to the
+        following restrictions:
+        - It can contain only Unicode alphanumeric, underscore, hyphen, and dot
+        characters.
+        - It cannot begin with the reserved prefix `sys-`.
+        - It must be no longer than 128 characters.
         :param str new_description: The description of the intent.
-        :param list[CreateExample] new_examples: An array of user input examples for the intent.
+        :param list[CreateExample] new_examples: An array of user input examples for the
+        intent.
         :param dict headers: A `dict` containing the request headers
         :return: A `dict` containing the `Intent` response.
         :rtype: dict
@@ -666,12 +742,17 @@ class ConversationV1(WatsonService):
         """
         Create user input example.
 
-        Add a new user input example to an intent.    This operation is limited to 1000
-        requests per 30 minutes. For more information, see **Rate limiting**.
+        Add a new user input example to an intent.
+        This operation is limited to 1000 requests per 30 minutes. For more information,
+        see **Rate limiting**.
 
         :param str workspace_id: Unique identifier of the workspace.
         :param str intent: The intent name.
-        :param str text: The text of a user input example. This string must conform to the following restrictions:  - It cannot contain carriage return, newline, or tab characters.  - It cannot consist of only whitespace characters.  - It must be no longer than 1024 characters.
+        :param str text: The text of a user input example. This string must conform to the
+        following restrictions:
+        - It cannot contain carriage return, newline, or tab characters.
+        - It cannot consist of only whitespace characters.
+        - It must be no longer than 1024 characters.
         :param dict headers: A `dict` containing the request headers
         :return: A `dict` containing the `Example` response.
         :rtype: dict
@@ -702,8 +783,9 @@ class ConversationV1(WatsonService):
         """
         Delete user input example.
 
-        Delete a user input example from an intent.    This operation is limited to 1000
-        requests per 30 minutes. For more information, see **Rate limiting**.
+        Delete a user input example from an intent.
+        This operation is limited to 1000 requests per 30 minutes. For more information,
+        see **Rate limiting**.
 
         :param str workspace_id: Unique identifier of the workspace.
         :param str intent: The intent name.
@@ -740,13 +822,15 @@ class ConversationV1(WatsonService):
         """
         Get user input example.
 
-        Get information about a user input example.    This operation is limited to 6000
-        requests per 5 minutes. For more information, see **Rate limiting**.
+        Get information about a user input example.
+        This operation is limited to 6000 requests per 5 minutes. For more information,
+        see **Rate limiting**.
 
         :param str workspace_id: Unique identifier of the workspace.
         :param str intent: The intent name.
         :param str text: The text of the user input example.
-        :param bool include_audit: Whether to include the audit properties (`created` and `updated` timestamps) in the response.
+        :param bool include_audit: Whether to include the audit properties (`created` and
+        `updated` timestamps) in the response.
         :param dict headers: A `dict` containing the request headers
         :return: A `dict` containing the `Example` response.
         :rtype: dict
@@ -783,16 +867,21 @@ class ConversationV1(WatsonService):
         """
         List user input examples.
 
-        List the user input examples for an intent.    This operation is limited to 2500
-        requests per 30 minutes. For more information, see **Rate limiting**.
+        List the user input examples for an intent.
+        This operation is limited to 2500 requests per 30 minutes. For more information,
+        see **Rate limiting**.
 
         :param str workspace_id: Unique identifier of the workspace.
         :param str intent: The intent name.
         :param int page_limit: The number of records to return in each page of results.
-        :param bool include_count: Whether to include information about the number of records returned.
-        :param str sort: The attribute by which returned results will be sorted. To reverse the sort order, prefix the value with a minus sign (`-`). Supported values are `name`, `updated`, and `workspace_id`.
+        :param bool include_count: Whether to include information about the number of
+        records returned.
+        :param str sort: The attribute by which returned results will be sorted. To
+        reverse the sort order, prefix the value with a minus sign (`-`). Supported values
+        are `name`, `updated`, and `workspace_id`.
         :param str cursor: A token identifying the page of results to retrieve.
-        :param bool include_audit: Whether to include the audit properties (`created` and `updated` timestamps) in the response.
+        :param bool include_audit: Whether to include the audit properties (`created` and
+        `updated` timestamps) in the response.
         :param dict headers: A `dict` containing the request headers
         :return: A `dict` containing the `ExampleCollection` response.
         :rtype: dict
@@ -831,13 +920,18 @@ class ConversationV1(WatsonService):
         """
         Update user input example.
 
-        Update the text of a user input example.    This operation is limited to 1000
-        requests per 30 minutes. For more information, see **Rate limiting**.
+        Update the text of a user input example.
+        This operation is limited to 1000 requests per 30 minutes. For more information,
+        see **Rate limiting**.
 
         :param str workspace_id: Unique identifier of the workspace.
         :param str intent: The intent name.
         :param str text: The text of the user input example.
-        :param str new_text: The text of the user input example. This string must conform to the following restrictions:  - It cannot contain carriage return, newline, or tab characters.  - It cannot consist of only whitespace characters.  - It must be no longer than 1024 characters.
+        :param str new_text: The text of the user input example. This string must conform
+        to the following restrictions:
+        - It cannot contain carriage return, newline, or tab characters.
+        - It cannot consist of only whitespace characters.
+        - It must be no longer than 1024 characters.
         :param dict headers: A `dict` containing the request headers
         :return: A `dict` containing the `Example` response.
         :rtype: dict
@@ -873,11 +967,16 @@ class ConversationV1(WatsonService):
         Create counterexample.
 
         Add a new counterexample to a workspace. Counterexamples are examples that have
-        been marked as irrelevant input.    This operation is limited to 1000 requests per
-        30 minutes. For more information, see **Rate limiting**.
+        been marked as irrelevant input.
+        This operation is limited to 1000 requests per 30 minutes. For more information,
+        see **Rate limiting**.
 
         :param str workspace_id: Unique identifier of the workspace.
-        :param str text: The text of a user input marked as irrelevant input. This string must conform to the following restrictions:  - It cannot contain carriage return, newline, or tab characters  - It cannot consist of only whitespace characters  - It must be no longer than 1024 characters.
+        :param str text: The text of a user input marked as irrelevant input. This string
+        must conform to the following restrictions:
+        - It cannot contain carriage return, newline, or tab characters
+        - It cannot consist of only whitespace characters
+        - It must be no longer than 1024 characters.
         :param dict headers: A `dict` containing the request headers
         :return: A `dict` containing the `Counterexample` response.
         :rtype: dict
@@ -907,11 +1006,13 @@ class ConversationV1(WatsonService):
         Delete counterexample.
 
         Delete a counterexample from a workspace. Counterexamples are examples that have
-        been marked as irrelevant input.    This operation is limited to 1000 requests per
-        30 minutes. For more information, see **Rate limiting**.
+        been marked as irrelevant input.
+        This operation is limited to 1000 requests per 30 minutes. For more information,
+        see **Rate limiting**.
 
         :param str workspace_id: Unique identifier of the workspace.
-        :param str text: The text of a user input counterexample (for example, `What are you wearing?`).
+        :param str text: The text of a user input counterexample (for example, `What are
+        you wearing?`).
         :param dict headers: A `dict` containing the request headers
         :rtype: None
         """
@@ -942,12 +1043,15 @@ class ConversationV1(WatsonService):
         Get counterexample.
 
         Get information about a counterexample. Counterexamples are examples that have
-        been marked as irrelevant input.    This operation is limited to 6000 requests per
-        5 minutes. For more information, see **Rate limiting**.
+        been marked as irrelevant input.
+        This operation is limited to 6000 requests per 5 minutes. For more information,
+        see **Rate limiting**.
 
         :param str workspace_id: Unique identifier of the workspace.
-        :param str text: The text of a user input counterexample (for example, `What are you wearing?`).
-        :param bool include_audit: Whether to include the audit properties (`created` and `updated` timestamps) in the response.
+        :param str text: The text of a user input counterexample (for example, `What are
+        you wearing?`).
+        :param bool include_audit: Whether to include the audit properties (`created` and
+        `updated` timestamps) in the response.
         :param dict headers: A `dict` containing the request headers
         :return: A `dict` containing the `Counterexample` response.
         :rtype: dict
@@ -982,15 +1086,20 @@ class ConversationV1(WatsonService):
         List counterexamples.
 
         List the counterexamples for a workspace. Counterexamples are examples that have
-        been marked as irrelevant input.    This operation is limited to 2500 requests per
-        30 minutes. For more information, see **Rate limiting**.
+        been marked as irrelevant input.
+        This operation is limited to 2500 requests per 30 minutes. For more information,
+        see **Rate limiting**.
 
         :param str workspace_id: Unique identifier of the workspace.
         :param int page_limit: The number of records to return in each page of results.
-        :param bool include_count: Whether to include information about the number of records returned.
-        :param str sort: The attribute by which returned results will be sorted. To reverse the sort order, prefix the value with a minus sign (`-`). Supported values are `name`, `updated`, and `workspace_id`.
+        :param bool include_count: Whether to include information about the number of
+        records returned.
+        :param str sort: The attribute by which returned results will be sorted. To
+        reverse the sort order, prefix the value with a minus sign (`-`). Supported values
+        are `name`, `updated`, and `workspace_id`.
         :param str cursor: A token identifying the page of results to retrieve.
-        :param bool include_audit: Whether to include the audit properties (`created` and `updated` timestamps) in the response.
+        :param bool include_audit: Whether to include the audit properties (`created` and
+        `updated` timestamps) in the response.
         :param dict headers: A `dict` containing the request headers
         :return: A `dict` containing the `CounterexampleCollection` response.
         :rtype: dict
@@ -1027,11 +1136,13 @@ class ConversationV1(WatsonService):
         Update counterexample.
 
         Update the text of a counterexample. Counterexamples are examples that have been
-        marked as irrelevant input.    This operation is limited to 1000 requests per 30
-        minutes. For more information, see **Rate limiting**.
+        marked as irrelevant input.
+        This operation is limited to 1000 requests per 30 minutes. For more information,
+        see **Rate limiting**.
 
         :param str workspace_id: Unique identifier of the workspace.
-        :param str text: The text of a user input counterexample (for example, `What are you wearing?`).
+        :param str text: The text of a user input counterexample (for example, `What are
+        you wearing?`).
         :param str new_text: The text of a user input counterexample.
         :param dict headers: A `dict` containing the request headers
         :return: A `dict` containing the `Counterexample` response.
@@ -1072,12 +1183,19 @@ class ConversationV1(WatsonService):
         """
         Create entity.
 
-        Create a new entity.    This operation is limited to 1000 requests per 30 minutes.
-        For more information, see **Rate limiting**.
+        Create a new entity.
+        This operation is limited to 1000 requests per 30 minutes. For more information,
+        see **Rate limiting**.
 
         :param str workspace_id: Unique identifier of the workspace.
-        :param str entity: The name of the entity. This string must conform to the following restrictions:  - It can contain only Unicode alphanumeric, underscore, and hyphen characters.  - It cannot begin with the reserved prefix `sys-`.  - It must be no longer than 64 characters.
-        :param str description: The description of the entity. This string cannot contain carriage return, newline, or tab characters, and it must be no longer than 128 characters.
+        :param str entity: The name of the entity. This string must conform to the
+        following restrictions:
+        - It can contain only Unicode alphanumeric, underscore, and hyphen characters.
+        - It cannot begin with the reserved prefix `sys-`.
+        - It must be no longer than 64 characters.
+        :param str description: The description of the entity. This string cannot contain
+        carriage return, newline, or tab characters, and it must be no longer than 128
+        characters.
         :param object metadata: Any metadata related to the value.
         :param list[CreateValue] values: An array of objects describing the entity values.
         :param bool fuzzy_match: Whether to use fuzzy matching for the entity.
@@ -1117,8 +1235,9 @@ class ConversationV1(WatsonService):
         """
         Delete entity.
 
-        Delete an entity from a workspace.    This operation is limited to 1000 requests
-        per 30 minutes. For more information, see **Rate limiting**.
+        Delete an entity from a workspace.
+        This operation is limited to 1000 requests per 30 minutes. For more information,
+        see **Rate limiting**.
 
         :param str workspace_id: Unique identifier of the workspace.
         :param str entity: The name of the entity.
@@ -1152,15 +1271,19 @@ class ConversationV1(WatsonService):
         """
         Get entity.
 
-        Get information about an entity, optionally including all entity content.    With
-        **export**=`false`, this operation is limited to 6000 requests per 5 minutes. With
-        **export**=`true`, the limit is 200 requests per 30 minutes. For more information,
-        see **Rate limiting**.
+        Get information about an entity, optionally including all entity content.
+        With **export**=`false`, this operation is limited to 6000 requests per 5 minutes.
+        With **export**=`true`, the limit is 200 requests per 30 minutes. For more
+        information, see **Rate limiting**.
 
         :param str workspace_id: Unique identifier of the workspace.
         :param str entity: The name of the entity.
-        :param bool export: Whether to include all element content in the returned data. If **export**=`false`, the returned data includes only information about the element itself. If **export**=`true`, all content, including subelements, is included.
-        :param bool include_audit: Whether to include the audit properties (`created` and `updated` timestamps) in the response.
+        :param bool export: Whether to include all element content in the returned data.
+        If **export**=`false`, the returned data includes only information about the
+        element itself. If **export**=`true`, all content, including subelements, is
+        included.
+        :param bool include_audit: Whether to include the audit properties (`created` and
+        `updated` timestamps) in the response.
         :param dict headers: A `dict` containing the request headers
         :return: A `dict` containing the `EntityExport` response.
         :rtype: dict
@@ -1199,17 +1322,25 @@ class ConversationV1(WatsonService):
         """
         List entities.
 
-        List the entities for a workspace.    With **export**=`false`, this operation is
-        limited to 1000 requests per 30 minutes. With **export**=`true`, the limit is 200
-        requests per 30 minutes. For more information, see **Rate limiting**.
+        List the entities for a workspace.
+        With **export**=`false`, this operation is limited to 1000 requests per 30
+        minutes. With **export**=`true`, the limit is 200 requests per 30 minutes. For
+        more information, see **Rate limiting**.
 
         :param str workspace_id: Unique identifier of the workspace.
-        :param bool export: Whether to include all element content in the returned data. If **export**=`false`, the returned data includes only information about the element itself. If **export**=`true`, all content, including subelements, is included.
+        :param bool export: Whether to include all element content in the returned data.
+        If **export**=`false`, the returned data includes only information about the
+        element itself. If **export**=`true`, all content, including subelements, is
+        included.
         :param int page_limit: The number of records to return in each page of results.
-        :param bool include_count: Whether to include information about the number of records returned.
-        :param str sort: The attribute by which returned results will be sorted. To reverse the sort order, prefix the value with a minus sign (`-`). Supported values are `name`, `updated`, and `workspace_id`.
+        :param bool include_count: Whether to include information about the number of
+        records returned.
+        :param str sort: The attribute by which returned results will be sorted. To
+        reverse the sort order, prefix the value with a minus sign (`-`). Supported values
+        are `name`, `updated`, and `workspace_id`.
         :param str cursor: A token identifying the page of results to retrieve.
-        :param bool include_audit: Whether to include the audit properties (`created` and `updated` timestamps) in the response.
+        :param bool include_audit: Whether to include the audit properties (`created` and
+        `updated` timestamps) in the response.
         :param dict headers: A `dict` containing the request headers
         :return: A `dict` containing the `EntityCollection` response.
         :rtype: dict
@@ -1251,13 +1382,20 @@ class ConversationV1(WatsonService):
         Update entity.
 
         Update an existing entity with new or modified data. You must provide component
-        objects defining the content of the updated entity.    This operation is limited
-        to 1000 requests per 30 minutes. For more information, see **Rate limiting**.
+        objects defining the content of the updated entity.
+        This operation is limited to 1000 requests per 30 minutes. For more information,
+        see **Rate limiting**.
 
         :param str workspace_id: Unique identifier of the workspace.
         :param str entity: The name of the entity.
-        :param str new_entity: The name of the entity. This string must conform to the following restrictions:  - It can contain only Unicode alphanumeric, underscore, and hyphen characters.  - It cannot begin with the reserved prefix `sys-`.  - It must be no longer than 64 characters.
-        :param str new_description: The description of the entity. This string cannot contain carriage return, newline, or tab characters, and it must be no longer than 128 characters.
+        :param str new_entity: The name of the entity. This string must conform to the
+        following restrictions:
+        - It can contain only Unicode alphanumeric, underscore, and hyphen characters.
+        - It cannot begin with the reserved prefix `sys-`.
+        - It must be no longer than 64 characters.
+        :param str new_description: The description of the entity. This string cannot
+        contain carriage return, newline, or tab characters, and it must be no longer than
+        128 characters.
         :param object new_metadata: Any metadata related to the entity.
         :param bool new_fuzzy_match: Whether to use fuzzy matching for the entity.
         :param list[CreateValue] new_values: An array of entity values.
@@ -1311,15 +1449,29 @@ class ConversationV1(WatsonService):
         """
         Add entity value.
 
-        Create a new value for an entity.    This operation is limited to 1000 requests
-        per 30 minutes. For more information, see **Rate limiting**.
+        Create a new value for an entity.
+        This operation is limited to 1000 requests per 30 minutes. For more information,
+        see **Rate limiting**.
 
         :param str workspace_id: Unique identifier of the workspace.
         :param str entity: The name of the entity.
-        :param str value: The text of the entity value. This string must conform to the following restrictions:  - It cannot contain carriage return, newline, or tab characters.  - It cannot consist of only whitespace characters.  - It must be no longer than 64 characters.
+        :param str value: The text of the entity value. This string must conform to the
+        following restrictions:
+        - It cannot contain carriage return, newline, or tab characters.
+        - It cannot consist of only whitespace characters.
+        - It must be no longer than 64 characters.
         :param object metadata: Any metadata related to the entity value.
-        :param list[str] synonyms: An array containing any synonyms for the entity value. You can provide either synonyms or patterns (as indicated by **type**), but not both. A synonym must conform to the following restrictions:  - It cannot contain carriage return, newline, or tab characters.  - It cannot consist of only whitespace characters.  - It must be no longer than 64 characters.
-        :param list[str] patterns: An array of patterns for the entity value. You can provide either synonyms or patterns (as indicated by **type**), but not both. A pattern is a regular expression no longer than 128 characters. For more information about how to specify a pattern, see the [documentation](https://console.bluemix.net/docs/services/conversation/entities.html#creating-entities).
+        :param list[str] synonyms: An array containing any synonyms for the entity value.
+        You can provide either synonyms or patterns (as indicated by **type**), but not
+        both. A synonym must conform to the following restrictions:
+        - It cannot contain carriage return, newline, or tab characters.
+        - It cannot consist of only whitespace characters.
+        - It must be no longer than 64 characters.
+        :param list[str] patterns: An array of patterns for the entity value. You can
+        provide either synonyms or patterns (as indicated by **type**), but not both. A
+        pattern is a regular expression no longer than 128 characters. For more
+        information about how to specify a pattern, see the
+        [documentation](https://console.bluemix.net/docs/services/conversation/entities.html#creating-entities).
         :param str value_type: Specifies the type of value.
         :param dict headers: A `dict` containing the request headers
         :return: A `dict` containing the `Value` response.
@@ -1357,8 +1509,9 @@ class ConversationV1(WatsonService):
         """
         Delete entity value.
 
-        Delete a value from an entity.    This operation is limited to 1000 requests per
-        30 minutes. For more information, see **Rate limiting**.
+        Delete a value from an entity.
+        This operation is limited to 1000 requests per 30 minutes. For more information,
+        see **Rate limiting**.
 
         :param str workspace_id: Unique identifier of the workspace.
         :param str entity: The name of the entity.
@@ -1396,14 +1549,19 @@ class ConversationV1(WatsonService):
         """
         Get entity value.
 
-        Get information about an entity value.    This operation is limited to 6000
-        requests per 5 minutes. For more information, see **Rate limiting**.
+        Get information about an entity value.
+        This operation is limited to 6000 requests per 5 minutes. For more information,
+        see **Rate limiting**.
 
         :param str workspace_id: Unique identifier of the workspace.
         :param str entity: The name of the entity.
         :param str value: The text of the entity value.
-        :param bool export: Whether to include all element content in the returned data. If **export**=`false`, the returned data includes only information about the element itself. If **export**=`true`, all content, including subelements, is included.
-        :param bool include_audit: Whether to include the audit properties (`created` and `updated` timestamps) in the response.
+        :param bool export: Whether to include all element content in the returned data.
+        If **export**=`false`, the returned data includes only information about the
+        element itself. If **export**=`true`, all content, including subelements, is
+        included.
+        :param bool include_audit: Whether to include the audit properties (`created` and
+        `updated` timestamps) in the response.
         :param dict headers: A `dict` containing the request headers
         :return: A `dict` containing the `ValueExport` response.
         :rtype: dict
@@ -1445,17 +1603,25 @@ class ConversationV1(WatsonService):
         """
         List entity values.
 
-        List the values for an entity.    This operation is limited to 2500 requests per
-        30 minutes. For more information, see **Rate limiting**.
+        List the values for an entity.
+        This operation is limited to 2500 requests per 30 minutes. For more information,
+        see **Rate limiting**.
 
         :param str workspace_id: Unique identifier of the workspace.
         :param str entity: The name of the entity.
-        :param bool export: Whether to include all element content in the returned data. If **export**=`false`, the returned data includes only information about the element itself. If **export**=`true`, all content, including subelements, is included.
+        :param bool export: Whether to include all element content in the returned data.
+        If **export**=`false`, the returned data includes only information about the
+        element itself. If **export**=`true`, all content, including subelements, is
+        included.
         :param int page_limit: The number of records to return in each page of results.
-        :param bool include_count: Whether to include information about the number of records returned.
-        :param str sort: The attribute by which returned results will be sorted. To reverse the sort order, prefix the value with a minus sign (`-`). Supported values are `name`, `updated`, and `workspace_id`.
+        :param bool include_count: Whether to include information about the number of
+        records returned.
+        :param str sort: The attribute by which returned results will be sorted. To
+        reverse the sort order, prefix the value with a minus sign (`-`). Supported values
+        are `name`, `updated`, and `workspace_id`.
         :param str cursor: A token identifying the page of results to retrieve.
-        :param bool include_audit: Whether to include the audit properties (`created` and `updated` timestamps) in the response.
+        :param bool include_audit: Whether to include the audit properties (`created` and
+        `updated` timestamps) in the response.
         :param dict headers: A `dict` containing the request headers
         :return: A `dict` containing the `ValueCollection` response.
         :rtype: dict
@@ -1500,18 +1666,31 @@ class ConversationV1(WatsonService):
         Update entity value.
 
         Update an existing entity value with new or modified data. You must provide
-        component objects defining the content of the updated entity value.    This
-        operation is limited to 1000 requests per 30 minutes. For more information, see
-        **Rate limiting**.
+        component objects defining the content of the updated entity value.
+        This operation is limited to 1000 requests per 30 minutes. For more information,
+        see **Rate limiting**.
 
         :param str workspace_id: Unique identifier of the workspace.
         :param str entity: The name of the entity.
         :param str value: The text of the entity value.
-        :param str new_value: The text of the entity value. This string must conform to the following restrictions:  - It cannot contain carriage return, newline, or tab characters.  - It cannot consist of only whitespace characters.  - It must be no longer than 64 characters.
+        :param str new_value: The text of the entity value. This string must conform to
+        the following restrictions:
+        - It cannot contain carriage return, newline, or tab characters.
+        - It cannot consist of only whitespace characters.
+        - It must be no longer than 64 characters.
         :param object new_metadata: Any metadata related to the entity value.
         :param str new_type: Specifies the type of value.
-        :param list[str] new_synonyms: An array of synonyms for the entity value. You can provide either synonyms or patterns (as indicated by **type**), but not both. A synonym must conform to the following resrictions:  - It cannot contain carriage return, newline, or tab characters.  - It cannot consist of only whitespace characters.  - It must be no longer than 64 characters.
-        :param list[str] new_patterns: An array of patterns for the entity value. You can provide either synonyms or patterns (as indicated by **type**), but not both. A pattern is a regular expression no longer than 128 characters. For more information about how to specify a pattern, see the [documentation](https://console.bluemix.net/docs/services/conversation/entities.html#creating-entities).
+        :param list[str] new_synonyms: An array of synonyms for the entity value. You can
+        provide either synonyms or patterns (as indicated by **type**), but not both. A
+        synonym must conform to the following resrictions:
+        - It cannot contain carriage return, newline, or tab characters.
+        - It cannot consist of only whitespace characters.
+        - It must be no longer than 64 characters.
+        :param list[str] new_patterns: An array of patterns for the entity value. You can
+        provide either synonyms or patterns (as indicated by **type**), but not both. A
+        pattern is a regular expression no longer than 128 characters. For more
+        information about how to specify a pattern, see the
+        [documentation](https://console.bluemix.net/docs/services/conversation/entities.html#creating-entities).
         :param dict headers: A `dict` containing the request headers
         :return: A `dict` containing the `Value` response.
         :rtype: dict
@@ -1552,13 +1731,18 @@ class ConversationV1(WatsonService):
         """
         Add entity value synonym.
 
-        Add a new synonym to an entity value.    This operation is limited to 1000
-        requests per 30 minutes. For more information, see **Rate limiting**.
+        Add a new synonym to an entity value.
+        This operation is limited to 1000 requests per 30 minutes. For more information,
+        see **Rate limiting**.
 
         :param str workspace_id: Unique identifier of the workspace.
         :param str entity: The name of the entity.
         :param str value: The text of the entity value.
-        :param str synonym: The text of the synonym. This string must conform to the following restrictions:  - It cannot contain carriage return, newline, or tab characters.  - It cannot consist of only whitespace characters.  - It must be no longer than 64 characters.
+        :param str synonym: The text of the synonym. This string must conform to the
+        following restrictions:
+        - It cannot contain carriage return, newline, or tab characters.
+        - It cannot consist of only whitespace characters.
+        - It must be no longer than 64 characters.
         :param dict headers: A `dict` containing the request headers
         :return: A `dict` containing the `Synonym` response.
         :rtype: dict
@@ -1591,8 +1775,9 @@ class ConversationV1(WatsonService):
         """
         Delete entity value synonym.
 
-        Delete a synonym from an entity value.    This operation is limited to 1000
-        requests per 30 minutes. For more information, see **Rate limiting**.
+        Delete a synonym from an entity value.
+        This operation is limited to 1000 requests per 30 minutes. For more information,
+        see **Rate limiting**.
 
         :param str workspace_id: Unique identifier of the workspace.
         :param str entity: The name of the entity.
@@ -1633,14 +1818,16 @@ class ConversationV1(WatsonService):
         """
         Get entity value synonym.
 
-        Get information about a synonym of an entity value.    This operation is limited
-        to 6000 requests per 5 minutes. For more information, see **Rate limiting**.
+        Get information about a synonym of an entity value.
+        This operation is limited to 6000 requests per 5 minutes. For more information,
+        see **Rate limiting**.
 
         :param str workspace_id: Unique identifier of the workspace.
         :param str entity: The name of the entity.
         :param str value: The text of the entity value.
         :param str synonym: The text of the synonym.
-        :param bool include_audit: Whether to include the audit properties (`created` and `updated` timestamps) in the response.
+        :param bool include_audit: Whether to include the audit properties (`created` and
+        `updated` timestamps) in the response.
         :param dict headers: A `dict` containing the request headers
         :return: A `dict` containing the `Synonym` response.
         :rtype: dict
@@ -1680,17 +1867,22 @@ class ConversationV1(WatsonService):
         """
         List entity value synonyms.
 
-        List the synonyms for an entity value.    This operation is limited to 2500
-        requests per 30 minutes. For more information, see **Rate limiting**.
+        List the synonyms for an entity value.
+        This operation is limited to 2500 requests per 30 minutes. For more information,
+        see **Rate limiting**.
 
         :param str workspace_id: Unique identifier of the workspace.
         :param str entity: The name of the entity.
         :param str value: The text of the entity value.
         :param int page_limit: The number of records to return in each page of results.
-        :param bool include_count: Whether to include information about the number of records returned.
-        :param str sort: The attribute by which returned results will be sorted. To reverse the sort order, prefix the value with a minus sign (`-`). Supported values are `name`, `updated`, and `workspace_id`.
+        :param bool include_count: Whether to include information about the number of
+        records returned.
+        :param str sort: The attribute by which returned results will be sorted. To
+        reverse the sort order, prefix the value with a minus sign (`-`). Supported values
+        are `name`, `updated`, and `workspace_id`.
         :param str cursor: A token identifying the page of results to retrieve.
-        :param bool include_audit: Whether to include the audit properties (`created` and `updated` timestamps) in the response.
+        :param bool include_audit: Whether to include the audit properties (`created` and
+        `updated` timestamps) in the response.
         :param dict headers: A `dict` containing the request headers
         :return: A `dict` containing the `SynonymCollection` response.
         :rtype: dict
@@ -1732,15 +1924,19 @@ class ConversationV1(WatsonService):
         """
         Update entity value synonym.
 
-        Update an existing entity value synonym with new text.    This operation is
-        limited to 1000 requests per 30 minutes. For more information, see **Rate
-        limiting**.
+        Update an existing entity value synonym with new text.
+        This operation is limited to 1000 requests per 30 minutes. For more information,
+        see **Rate limiting**.
 
         :param str workspace_id: Unique identifier of the workspace.
         :param str entity: The name of the entity.
         :param str value: The text of the entity value.
         :param str synonym: The text of the synonym.
-        :param str new_synonym: The text of the synonym. This string must conform to the following restrictions:  - It cannot contain carriage return, newline, or tab characters.  - It cannot consist of only whitespace characters.  - It must be no longer than 64 characters.
+        :param str new_synonym: The text of the synonym. This string must conform to the
+        following restrictions:
+        - It cannot contain carriage return, newline, or tab characters.
+        - It cannot consist of only whitespace characters.
+        - It must be no longer than 64 characters.
         :param dict headers: A `dict` containing the request headers
         :return: A `dict` containing the `Synonym` response.
         :rtype: dict
@@ -1796,27 +1992,46 @@ class ConversationV1(WatsonService):
         """
         Create dialog node.
 
-        Create a new dialog node.    This operation is limited to 500 requests per 30
-        minutes. For more information, see **Rate limiting**.
+        Create a new dialog node.
+        This operation is limited to 500 requests per 30 minutes. For more information,
+        see **Rate limiting**.
 
         :param str workspace_id: Unique identifier of the workspace.
-        :param str dialog_node: The dialog node ID. This string must conform to the following restrictions:  - It can contain only Unicode alphanumeric, space, underscore, hyphen, and dot characters.  - It must be no longer than 1024 characters.
-        :param str description: The description of the dialog node. This string cannot contain carriage return, newline, or tab characters, and it must be no longer than 128 characters.
-        :param str conditions: The condition that will trigger the dialog node. This string cannot contain carriage return, newline, or tab characters, and it must be no longer than 2048 characters.
+        :param str dialog_node: The dialog node ID. This string must conform to the
+        following restrictions:
+        - It can contain only Unicode alphanumeric, space, underscore, hyphen, and dot
+        characters.
+        - It must be no longer than 1024 characters.
+        :param str description: The description of the dialog node. This string cannot
+        contain carriage return, newline, or tab characters, and it must be no longer than
+        128 characters.
+        :param str conditions: The condition that will trigger the dialog node. This
+        string cannot contain carriage return, newline, or tab characters, and it must be
+        no longer than 2048 characters.
         :param str parent: The ID of the parent dialog node.
         :param str previous_sibling: The ID of the previous dialog node.
-        :param object output: The output of the dialog node. For more information about how to specify dialog node output, see the [documentation](https://console.bluemix.net/docs/services/conversation/dialog-overview.html#complex).
+        :param object output: The output of the dialog node. For more information about
+        how to specify dialog node output, see the
+        [documentation](https://console.bluemix.net/docs/services/conversation/dialog-overview.html#complex).
         :param object context: The context for the dialog node.
         :param object metadata: The metadata for the dialog node.
-        :param DialogNodeNextStep next_step: The next step to be executed in dialog processing.
-        :param list[DialogNodeAction] actions: An array of objects describing any actions to be invoked by the dialog node.
-        :param str title: The alias used to identify the dialog node. This string must conform to the following restrictions:  - It can contain only Unicode alphanumeric, space, underscore, hyphen, and dot characters.  - It must be no longer than 64 characters.
+        :param DialogNodeNextStep next_step: The next step to be executed in dialog
+        processing.
+        :param list[DialogNodeAction] actions: An array of objects describing any actions
+        to be invoked by the dialog node.
+        :param str title: The alias used to identify the dialog node. This string must
+        conform to the following restrictions:
+        - It can contain only Unicode alphanumeric, space, underscore, hyphen, and dot
+        characters.
+        - It must be no longer than 64 characters.
         :param str node_type: How the dialog node is processed.
         :param str event_name: How an `event_handler` node is processed.
         :param str variable: The location in the dialog context where output is stored.
         :param str digress_in: Whether this top-level dialog node can be digressed into.
-        :param str digress_out: Whether this dialog node can be returned to after a digression.
-        :param str digress_out_slots: Whether the user can digress to top-level nodes while filling out slots.
+        :param str digress_out: Whether this dialog node can be returned to after a
+        digression.
+        :param str digress_out_slots: Whether the user can digress to top-level nodes
+        while filling out slots.
         :param dict headers: A `dict` containing the request headers
         :return: A `dict` containing the `DialogNode` response.
         :rtype: dict
@@ -1869,8 +2084,9 @@ class ConversationV1(WatsonService):
         """
         Delete dialog node.
 
-        Delete a dialog node from a workspace.    This operation is limited to 500
-        requests per 30 minutes. For more information, see **Rate limiting**.
+        Delete a dialog node from a workspace.
+        This operation is limited to 500 requests per 30 minutes. For more information,
+        see **Rate limiting**.
 
         :param str workspace_id: Unique identifier of the workspace.
         :param str dialog_node: The dialog node ID (for example, `get_order`).
@@ -1903,12 +2119,14 @@ class ConversationV1(WatsonService):
         """
         Get dialog node.
 
-        Get information about a dialog node.    This operation is limited to 6000 requests
-        per 5 minutes. For more information, see **Rate limiting**.
+        Get information about a dialog node.
+        This operation is limited to 6000 requests per 5 minutes. For more information,
+        see **Rate limiting**.
 
         :param str workspace_id: Unique identifier of the workspace.
         :param str dialog_node: The dialog node ID (for example, `get_order`).
-        :param bool include_audit: Whether to include the audit properties (`created` and `updated` timestamps) in the response.
+        :param bool include_audit: Whether to include the audit properties (`created` and
+        `updated` timestamps) in the response.
         :param dict headers: A `dict` containing the request headers
         :return: A `dict` containing the `DialogNode` response.
         :rtype: dict
@@ -1942,15 +2160,20 @@ class ConversationV1(WatsonService):
         """
         List dialog nodes.
 
-        List the dialog nodes for a workspace.    This operation is limited to 2500
-        requests per 30 minutes. For more information, see **Rate limiting**.
+        List the dialog nodes for a workspace.
+        This operation is limited to 2500 requests per 30 minutes. For more information,
+        see **Rate limiting**.
 
         :param str workspace_id: Unique identifier of the workspace.
         :param int page_limit: The number of records to return in each page of results.
-        :param bool include_count: Whether to include information about the number of records returned.
-        :param str sort: The attribute by which returned results will be sorted. To reverse the sort order, prefix the value with a minus sign (`-`). Supported values are `name`, `updated`, and `workspace_id`.
+        :param bool include_count: Whether to include information about the number of
+        records returned.
+        :param str sort: The attribute by which returned results will be sorted. To
+        reverse the sort order, prefix the value with a minus sign (`-`). Supported values
+        are `name`, `updated`, and `workspace_id`.
         :param str cursor: A token identifying the page of results to retrieve.
-        :param bool include_audit: Whether to include the audit properties (`created` and `updated` timestamps) in the response.
+        :param bool include_audit: Whether to include the audit properties (`created` and
+        `updated` timestamps) in the response.
         :param dict headers: A `dict` containing the request headers
         :return: A `dict` containing the `DialogNodeCollection` response.
         :rtype: dict
@@ -2002,29 +2225,49 @@ class ConversationV1(WatsonService):
         """
         Update dialog node.
 
-        Update an existing dialog node with new or modified data.    This operation is
-        limited to 500 requests per 30 minutes. For more information, see **Rate
-        limiting**.
+        Update an existing dialog node with new or modified data.
+        This operation is limited to 500 requests per 30 minutes. For more information,
+        see **Rate limiting**.
 
         :param str workspace_id: Unique identifier of the workspace.
         :param str dialog_node: The dialog node ID (for example, `get_order`).
-        :param str new_dialog_node: The dialog node ID. This string must conform to the following restrictions:  - It can contain only Unicode alphanumeric, space, underscore, hyphen, and dot characters.  - It must be no longer than 1024 characters.
-        :param str new_description: The description of the dialog node. This string cannot contain carriage return, newline, or tab characters, and it must be no longer than 128 characters.
-        :param str new_conditions: The condition that will trigger the dialog node. This string cannot contain carriage return, newline, or tab characters, and it must be no longer than 2048 characters.
+        :param str new_dialog_node: The dialog node ID. This string must conform to the
+        following restrictions:
+        - It can contain only Unicode alphanumeric, space, underscore, hyphen, and dot
+        characters.
+        - It must be no longer than 1024 characters.
+        :param str new_description: The description of the dialog node. This string cannot
+        contain carriage return, newline, or tab characters, and it must be no longer than
+        128 characters.
+        :param str new_conditions: The condition that will trigger the dialog node. This
+        string cannot contain carriage return, newline, or tab characters, and it must be
+        no longer than 2048 characters.
         :param str new_parent: The ID of the parent dialog node.
         :param str new_previous_sibling: The ID of the previous sibling dialog node.
-        :param object new_output: The output of the dialog node. For more information about how to specify dialog node output, see the [documentation](https://console.bluemix.net/docs/services/conversation/dialog-overview.html#complex).
+        :param object new_output: The output of the dialog node. For more information
+        about how to specify dialog node output, see the
+        [documentation](https://console.bluemix.net/docs/services/conversation/dialog-overview.html#complex).
         :param object new_context: The context for the dialog node.
         :param object new_metadata: The metadata for the dialog node.
-        :param DialogNodeNextStep new_next_step: The next step to be executed in dialog processing.
-        :param str new_title: The alias used to identify the dialog node. This string must conform to the following restrictions:  - It can contain only Unicode alphanumeric, space, underscore, hyphen, and dot characters.  - It must be no longer than 64 characters.
+        :param DialogNodeNextStep new_next_step: The next step to be executed in dialog
+        processing.
+        :param str new_title: The alias used to identify the dialog node. This string must
+        conform to the following restrictions:
+        - It can contain only Unicode alphanumeric, space, underscore, hyphen, and dot
+        characters.
+        - It must be no longer than 64 characters.
         :param str new_type: How the dialog node is processed.
         :param str new_event_name: How an `event_handler` node is processed.
-        :param str new_variable: The location in the dialog context where output is stored.
-        :param list[DialogNodeAction] new_actions: An array of objects describing any actions to be invoked by the dialog node.
-        :param str new_digress_in: Whether this top-level dialog node can be digressed into.
-        :param str new_digress_out: Whether this dialog node can be returned to after a digression.
-        :param str new_digress_out_slots: Whether the user can digress to top-level nodes while filling out slots.
+        :param str new_variable: The location in the dialog context where output is
+        stored.
+        :param list[DialogNodeAction] new_actions: An array of objects describing any
+        actions to be invoked by the dialog node.
+        :param str new_digress_in: Whether this top-level dialog node can be digressed
+        into.
+        :param str new_digress_out: Whether this dialog node can be returned to after a
+        digression.
+        :param str new_digress_out_slots: Whether the user can digress to top-level nodes
+        while filling out slots.
         :param dict headers: A `dict` containing the request headers
         :return: A `dict` containing the `DialogNode` response.
         :rtype: dict
@@ -2087,13 +2330,19 @@ class ConversationV1(WatsonService):
         """
         List log events in all workspaces.
 
-        List the events from the logs of all workspaces in the service instance.    If
-        **cursor** is not specified, this operation is limited to 40 requests per 30
+        List the events from the logs of all workspaces in the service instance.
+        If **cursor** is not specified, this operation is limited to 40 requests per 30
         minutes. If **cursor** is specified, the limit is 120 requests per minute. For
         more information, see **Rate limiting**.
 
-        :param str filter: A cacheable parameter that limits the results to those matching the specified filter. You must specify a filter query that includes a value for `language`, as well as a value for `workspace_id` or `request.context.metadata.deployment`. For more information, see the [documentation](https://console.bluemix.net/docs/services/conversation/filter-reference.html#filter-query-syntax).
-        :param str sort: The attribute by which returned results will be sorted. To reverse the sort order, prefix the value with a minus sign (`-`). Supported values are `name`, `updated`, and `workspace_id`.
+        :param str filter: A cacheable parameter that limits the results to those matching
+        the specified filter. You must specify a filter query that includes a value for
+        `language`, as well as a value for `workspace_id` or
+        `request.context.metadata.deployment`. For more information, see the
+        [documentation](https://console.bluemix.net/docs/services/conversation/filter-reference.html#filter-query-syntax).
+        :param str sort: The attribute by which returned results will be sorted. To
+        reverse the sort order, prefix the value with a minus sign (`-`). Supported values
+        are `name`, `updated`, and `workspace_id`.
         :param int page_limit: The number of records to return in each page of results.
         :param str cursor: A token identifying the page of results to retrieve.
         :param dict headers: A `dict` containing the request headers
@@ -2131,14 +2380,18 @@ class ConversationV1(WatsonService):
         """
         List log events in a workspace.
 
-        List the events from the log of a specific workspace.    If **cursor** is not
-        specified, this operation is limited to 40 requests per 30 minutes. If **cursor**
-        is specified, the limit is 120 requests per minute. For more information, see
-        **Rate limiting**.
+        List the events from the log of a specific workspace.
+        If **cursor** is not specified, this operation is limited to 40 requests per 30
+        minutes. If **cursor** is specified, the limit is 120 requests per minute. For
+        more information, see **Rate limiting**.
 
         :param str workspace_id: Unique identifier of the workspace.
-        :param str sort: The attribute by which returned results will be sorted. To reverse the sort order, prefix the value with a minus sign (`-`). Supported values are `name`, `updated`, and `workspace_id`.
-        :param str filter: A cacheable parameter that limits the results to those matching the specified filter. For more information, see the [documentation](https://console.bluemix.net/docs/services/conversation/filter-reference.html#filter-query-syntax).
+        :param str sort: The attribute by which returned results will be sorted. To
+        reverse the sort order, prefix the value with a minus sign (`-`). Supported values
+        are `name`, `updated`, and `workspace_id`.
+        :param str filter: A cacheable parameter that limits the results to those matching
+        the specified filter. For more information, see the
+        [documentation](https://console.bluemix.net/docs/services/conversation/filter-reference.html#filter-query-syntax).
         :param int page_limit: The number of records to return in each page of results.
         :param str cursor: A token identifying the page of results to retrieve.
         :param dict headers: A `dict` containing the request headers
@@ -2176,9 +2429,10 @@ class ConversationV1(WatsonService):
         Delete labeled data.
 
         Deletes all data associated with a specified customer ID. The method has no effect
-        if no data is associated with the customer ID.   You associate a customer ID with
-        data by passing the `X-Watson-Metadata` header with a request that passes data.
-        For more information about personal data and customer IDs, see [Information
+        if no data is associated with the customer ID.
+        You associate a customer ID with data by passing the `X-Watson-Metadata` header
+        with a request that passes data. For more information about personal data and
+        customer IDs, see [Information
         security](https://console.bluemix.net/docs/services/conversation/information-security.html).
 
         :param str customer_id: The customer ID for which all data is to be deleted.
@@ -2211,7 +2465,8 @@ class CaptureGroup(object):
     CaptureGroup.
 
     :attr str group: A recognized capture group for the entity.
-    :attr list[int] location: (optional) Zero-based character offsets that indicate where the entity value begins and ends in the input text.
+    :attr list[int] location: (optional) Zero-based character offsets that indicate where
+    the entity value begins and ends in the input text.
     """
 
     def __init__(self, group, location=None):
@@ -2219,7 +2474,8 @@ class CaptureGroup(object):
         Initialize a CaptureGroup object.
 
         :param str group: A recognized capture group for the entity.
-        :param list[int] location: (optional) Zero-based character offsets that indicate where the entity value begins and ends in the input text.
+        :param list[int] location: (optional) Zero-based character offsets that indicate
+        where the entity value begins and ends in the input text.
         """
         self.group = group
         self.location = location
@@ -2341,7 +2597,8 @@ class Counterexample(object):
 
     :attr str text: The text of the counterexample.
     :attr datetime created: (optional) The timestamp for creation of the counterexample.
-    :attr datetime updated: (optional) The timestamp for the last update to the counterexample.
+    :attr datetime updated: (optional) The timestamp for the last update to the
+    counterexample.
     """
 
     def __init__(self, text, created=None, updated=None):
@@ -2349,8 +2606,10 @@ class Counterexample(object):
         Initialize a Counterexample object.
 
         :param str text: The text of the counterexample.
-        :param datetime created: (optional) The timestamp for creation of the counterexample.
-        :param datetime updated: (optional) The timestamp for the last update to the counterexample.
+        :param datetime created: (optional) The timestamp for creation of the
+        counterexample.
+        :param datetime updated: (optional) The timestamp for the last update to the
+        counterexample.
         """
         self.text = text
         self.created = created
@@ -2402,7 +2661,8 @@ class CounterexampleCollection(object):
     """
     CounterexampleCollection.
 
-    :attr list[Counterexample] counterexamples: An array of objects describing the examples marked as irrelevant input.
+    :attr list[Counterexample] counterexamples: An array of objects describing the
+    examples marked as irrelevant input.
     :attr Pagination pagination: The pagination data for the returned objects.
     """
 
@@ -2410,7 +2670,8 @@ class CounterexampleCollection(object):
         """
         Initialize a CounterexampleCollection object.
 
-        :param list[Counterexample] counterexamples: An array of objects describing the examples marked as irrelevant input.
+        :param list[Counterexample] counterexamples: An array of objects describing the
+        examples marked as irrelevant input.
         :param Pagination pagination: The pagination data for the returned objects.
         """
         self.counterexamples = counterexamples
@@ -2468,14 +2729,22 @@ class CreateCounterexample(object):
     """
     CreateCounterexample.
 
-    :attr str text: The text of a user input marked as irrelevant input. This string must conform to the following restrictions:  - It cannot contain carriage return, newline, or tab characters  - It cannot consist of only whitespace characters  - It must be no longer than 1024 characters.
+    :attr str text: The text of a user input marked as irrelevant input. This string must
+    conform to the following restrictions:
+    - It cannot contain carriage return, newline, or tab characters
+    - It cannot consist of only whitespace characters
+    - It must be no longer than 1024 characters.
     """
 
     def __init__(self, text):
         """
         Initialize a CreateCounterexample object.
 
-        :param str text: The text of a user input marked as irrelevant input. This string must conform to the following restrictions:  - It cannot contain carriage return, newline, or tab characters  - It cannot consist of only whitespace characters  - It must be no longer than 1024 characters.
+        :param str text: The text of a user input marked as irrelevant input. This string
+        must conform to the following restrictions:
+        - It cannot contain carriage return, newline, or tab characters
+        - It cannot consist of only whitespace characters
+        - It must be no longer than 1024 characters.
         """
         self.text = text
 
@@ -2517,23 +2786,43 @@ class CreateDialogNode(object):
     """
     CreateDialogNode.
 
-    :attr str dialog_node: The dialog node ID. This string must conform to the following restrictions:  - It can contain only Unicode alphanumeric, space, underscore, hyphen, and dot characters.  - It must be no longer than 1024 characters.
-    :attr str description: (optional) The description of the dialog node. This string cannot contain carriage return, newline, or tab characters, and it must be no longer than 128 characters.
-    :attr str conditions: (optional) The condition that will trigger the dialog node. This string cannot contain carriage return, newline, or tab characters, and it must be no longer than 2048 characters.
+    :attr str dialog_node: The dialog node ID. This string must conform to the following
+    restrictions:
+    - It can contain only Unicode alphanumeric, space, underscore, hyphen, and dot
+    characters.
+    - It must be no longer than 1024 characters.
+    :attr str description: (optional) The description of the dialog node. This string
+    cannot contain carriage return, newline, or tab characters, and it must be no longer
+    than 128 characters.
+    :attr str conditions: (optional) The condition that will trigger the dialog node. This
+    string cannot contain carriage return, newline, or tab characters, and it must be no
+    longer than 2048 characters.
     :attr str parent: (optional) The ID of the parent dialog node.
     :attr str previous_sibling: (optional) The ID of the previous dialog node.
-    :attr object output: (optional) The output of the dialog node. For more information about how to specify dialog node output, see the [documentation](https://console.bluemix.net/docs/services/conversation/dialog-overview.html#complex).
+    :attr object output: (optional) The output of the dialog node. For more information
+    about how to specify dialog node output, see the
+    [documentation](https://console.bluemix.net/docs/services/conversation/dialog-overview.html#complex).
     :attr object context: (optional) The context for the dialog node.
     :attr object metadata: (optional) The metadata for the dialog node.
-    :attr DialogNodeNextStep next_step: (optional) The next step to be executed in dialog processing.
-    :attr list[DialogNodeAction] actions: (optional) An array of objects describing any actions to be invoked by the dialog node.
-    :attr str title: (optional) The alias used to identify the dialog node. This string must conform to the following restrictions:  - It can contain only Unicode alphanumeric, space, underscore, hyphen, and dot characters.  - It must be no longer than 64 characters.
+    :attr DialogNodeNextStep next_step: (optional) The next step to be executed in dialog
+    processing.
+    :attr list[DialogNodeAction] actions: (optional) An array of objects describing any
+    actions to be invoked by the dialog node.
+    :attr str title: (optional) The alias used to identify the dialog node. This string
+    must conform to the following restrictions:
+    - It can contain only Unicode alphanumeric, space, underscore, hyphen, and dot
+    characters.
+    - It must be no longer than 64 characters.
     :attr str node_type: (optional) How the dialog node is processed.
     :attr str event_name: (optional) How an `event_handler` node is processed.
-    :attr str variable: (optional) The location in the dialog context where output is stored.
-    :attr str digress_in: (optional) Whether this top-level dialog node can be digressed into.
-    :attr str digress_out: (optional) Whether this dialog node can be returned to after a digression.
-    :attr str digress_out_slots: (optional) Whether the user can digress to top-level nodes while filling out slots.
+    :attr str variable: (optional) The location in the dialog context where output is
+    stored.
+    :attr str digress_in: (optional) Whether this top-level dialog node can be digressed
+    into.
+    :attr str digress_out: (optional) Whether this dialog node can be returned to after a
+    digression.
+    :attr str digress_out_slots: (optional) Whether the user can digress to top-level
+    nodes while filling out slots.
     """
 
     def __init__(self,
@@ -2557,23 +2846,43 @@ class CreateDialogNode(object):
         """
         Initialize a CreateDialogNode object.
 
-        :param str dialog_node: The dialog node ID. This string must conform to the following restrictions:  - It can contain only Unicode alphanumeric, space, underscore, hyphen, and dot characters.  - It must be no longer than 1024 characters.
-        :param str description: (optional) The description of the dialog node. This string cannot contain carriage return, newline, or tab characters, and it must be no longer than 128 characters.
-        :param str conditions: (optional) The condition that will trigger the dialog node. This string cannot contain carriage return, newline, or tab characters, and it must be no longer than 2048 characters.
+        :param str dialog_node: The dialog node ID. This string must conform to the
+        following restrictions:
+        - It can contain only Unicode alphanumeric, space, underscore, hyphen, and dot
+        characters.
+        - It must be no longer than 1024 characters.
+        :param str description: (optional) The description of the dialog node. This string
+        cannot contain carriage return, newline, or tab characters, and it must be no
+        longer than 128 characters.
+        :param str conditions: (optional) The condition that will trigger the dialog node.
+        This string cannot contain carriage return, newline, or tab characters, and it
+        must be no longer than 2048 characters.
         :param str parent: (optional) The ID of the parent dialog node.
         :param str previous_sibling: (optional) The ID of the previous dialog node.
-        :param object output: (optional) The output of the dialog node. For more information about how to specify dialog node output, see the [documentation](https://console.bluemix.net/docs/services/conversation/dialog-overview.html#complex).
+        :param object output: (optional) The output of the dialog node. For more
+        information about how to specify dialog node output, see the
+        [documentation](https://console.bluemix.net/docs/services/conversation/dialog-overview.html#complex).
         :param object context: (optional) The context for the dialog node.
         :param object metadata: (optional) The metadata for the dialog node.
-        :param DialogNodeNextStep next_step: (optional) The next step to be executed in dialog processing.
-        :param list[DialogNodeAction] actions: (optional) An array of objects describing any actions to be invoked by the dialog node.
-        :param str title: (optional) The alias used to identify the dialog node. This string must conform to the following restrictions:  - It can contain only Unicode alphanumeric, space, underscore, hyphen, and dot characters.  - It must be no longer than 64 characters.
+        :param DialogNodeNextStep next_step: (optional) The next step to be executed in
+        dialog processing.
+        :param list[DialogNodeAction] actions: (optional) An array of objects describing
+        any actions to be invoked by the dialog node.
+        :param str title: (optional) The alias used to identify the dialog node. This
+        string must conform to the following restrictions:
+        - It can contain only Unicode alphanumeric, space, underscore, hyphen, and dot
+        characters.
+        - It must be no longer than 64 characters.
         :param str node_type: (optional) How the dialog node is processed.
         :param str event_name: (optional) How an `event_handler` node is processed.
-        :param str variable: (optional) The location in the dialog context where output is stored.
-        :param str digress_in: (optional) Whether this top-level dialog node can be digressed into.
-        :param str digress_out: (optional) Whether this dialog node can be returned to after a digression.
-        :param str digress_out_slots: (optional) Whether the user can digress to top-level nodes while filling out slots.
+        :param str variable: (optional) The location in the dialog context where output is
+        stored.
+        :param str digress_in: (optional) Whether this top-level dialog node can be
+        digressed into.
+        :param str digress_out: (optional) Whether this dialog node can be returned to
+        after a digression.
+        :param str digress_out_slots: (optional) Whether the user can digress to top-level
+        nodes while filling out slots.
         """
         self.dialog_node = dialog_node
         self.description = description
@@ -2700,10 +3009,17 @@ class CreateEntity(object):
     """
     CreateEntity.
 
-    :attr str entity: The name of the entity. This string must conform to the following restrictions:  - It can contain only Unicode alphanumeric, underscore, and hyphen characters.  - It cannot begin with the reserved prefix `sys-`.  - It must be no longer than 64 characters.
-    :attr str description: (optional) The description of the entity. This string cannot contain carriage return, newline, or tab characters, and it must be no longer than 128 characters.
+    :attr str entity: The name of the entity. This string must conform to the following
+    restrictions:
+    - It can contain only Unicode alphanumeric, underscore, and hyphen characters.
+    - It cannot begin with the reserved prefix `sys-`.
+    - It must be no longer than 64 characters.
+    :attr str description: (optional) The description of the entity. This string cannot
+    contain carriage return, newline, or tab characters, and it must be no longer than 128
+    characters.
     :attr object metadata: (optional) Any metadata related to the value.
-    :attr list[CreateValue] values: (optional) An array of objects describing the entity values.
+    :attr list[CreateValue] values: (optional) An array of objects describing the entity
+    values.
     :attr bool fuzzy_match: (optional) Whether to use fuzzy matching for the entity.
     """
 
@@ -2716,10 +3032,17 @@ class CreateEntity(object):
         """
         Initialize a CreateEntity object.
 
-        :param str entity: The name of the entity. This string must conform to the following restrictions:  - It can contain only Unicode alphanumeric, underscore, and hyphen characters.  - It cannot begin with the reserved prefix `sys-`.  - It must be no longer than 64 characters.
-        :param str description: (optional) The description of the entity. This string cannot contain carriage return, newline, or tab characters, and it must be no longer than 128 characters.
+        :param str entity: The name of the entity. This string must conform to the
+        following restrictions:
+        - It can contain only Unicode alphanumeric, underscore, and hyphen characters.
+        - It cannot begin with the reserved prefix `sys-`.
+        - It must be no longer than 64 characters.
+        :param str description: (optional) The description of the entity. This string
+        cannot contain carriage return, newline, or tab characters, and it must be no
+        longer than 128 characters.
         :param object metadata: (optional) Any metadata related to the value.
-        :param list[CreateValue] values: (optional) An array of objects describing the entity values.
+        :param list[CreateValue] values: (optional) An array of objects describing the
+        entity values.
         :param bool fuzzy_match: (optional) Whether to use fuzzy matching for the entity.
         """
         self.entity = entity
@@ -2784,14 +3107,22 @@ class CreateExample(object):
     """
     CreateExample.
 
-    :attr str text: The text of a user input example. This string must conform to the following restrictions:  - It cannot contain carriage return, newline, or tab characters.  - It cannot consist of only whitespace characters.  - It must be no longer than 1024 characters.
+    :attr str text: The text of a user input example. This string must conform to the
+    following restrictions:
+    - It cannot contain carriage return, newline, or tab characters.
+    - It cannot consist of only whitespace characters.
+    - It must be no longer than 1024 characters.
     """
 
     def __init__(self, text):
         """
         Initialize a CreateExample object.
 
-        :param str text: The text of a user input example. This string must conform to the following restrictions:  - It cannot contain carriage return, newline, or tab characters.  - It cannot consist of only whitespace characters.  - It must be no longer than 1024 characters.
+        :param str text: The text of a user input example. This string must conform to the
+        following restrictions:
+        - It cannot contain carriage return, newline, or tab characters.
+        - It cannot consist of only whitespace characters.
+        - It must be no longer than 1024 characters.
         """
         self.text = text
 
@@ -2832,18 +3163,33 @@ class CreateIntent(object):
     """
     CreateIntent.
 
-    :attr str intent: The name of the intent. This string must conform to the following restrictions:  - It can contain only Unicode alphanumeric, underscore, hyphen, and dot characters.  - It cannot begin with the reserved prefix `sys-`.  - It must be no longer than 128 characters.
-    :attr str description: (optional) The description of the intent. This string cannot contain carriage return, newline, or tab characters, and it must be no longer than 128 characters.
-    :attr list[CreateExample] examples: (optional) An array of user input examples for the intent.
+    :attr str intent: The name of the intent. This string must conform to the following
+    restrictions:
+    - It can contain only Unicode alphanumeric, underscore, hyphen, and dot characters.
+    - It cannot begin with the reserved prefix `sys-`.
+    - It must be no longer than 128 characters.
+    :attr str description: (optional) The description of the intent. This string cannot
+    contain carriage return, newline, or tab characters, and it must be no longer than 128
+    characters.
+    :attr list[CreateExample] examples: (optional) An array of user input examples for the
+    intent.
     """
 
     def __init__(self, intent, description=None, examples=None):
         """
         Initialize a CreateIntent object.
 
-        :param str intent: The name of the intent. This string must conform to the following restrictions:  - It can contain only Unicode alphanumeric, underscore, hyphen, and dot characters.  - It cannot begin with the reserved prefix `sys-`.  - It must be no longer than 128 characters.
-        :param str description: (optional) The description of the intent. This string cannot contain carriage return, newline, or tab characters, and it must be no longer than 128 characters.
-        :param list[CreateExample] examples: (optional) An array of user input examples for the intent.
+        :param str intent: The name of the intent. This string must conform to the
+        following restrictions:
+        - It can contain only Unicode alphanumeric, underscore, hyphen, and dot
+        characters.
+        - It cannot begin with the reserved prefix `sys-`.
+        - It must be no longer than 128 characters.
+        :param str description: (optional) The description of the intent. This string
+        cannot contain carriage return, newline, or tab characters, and it must be no
+        longer than 128 characters.
+        :param list[CreateExample] examples: (optional) An array of user input examples
+        for the intent.
         """
         self.intent = intent
         self.description = description
@@ -2897,10 +3243,23 @@ class CreateValue(object):
     """
     CreateValue.
 
-    :attr str value: The text of the entity value. This string must conform to the following restrictions:  - It cannot contain carriage return, newline, or tab characters.  - It cannot consist of only whitespace characters.  - It must be no longer than 64 characters.
+    :attr str value: The text of the entity value. This string must conform to the
+    following restrictions:
+    - It cannot contain carriage return, newline, or tab characters.
+    - It cannot consist of only whitespace characters.
+    - It must be no longer than 64 characters.
     :attr object metadata: (optional) Any metadata related to the entity value.
-    :attr list[str] synonyms: (optional) An array containing any synonyms for the entity value. You can provide either synonyms or patterns (as indicated by **type**), but not both. A synonym must conform to the following restrictions:  - It cannot contain carriage return, newline, or tab characters.  - It cannot consist of only whitespace characters.  - It must be no longer than 64 characters.
-    :attr list[str] patterns: (optional) An array of patterns for the entity value. You can provide either synonyms or patterns (as indicated by **type**), but not both. A pattern is a regular expression no longer than 128 characters. For more information about how to specify a pattern, see the [documentation](https://console.bluemix.net/docs/services/conversation/entities.html#creating-entities).
+    :attr list[str] synonyms: (optional) An array containing any synonyms for the entity
+    value. You can provide either synonyms or patterns (as indicated by **type**), but not
+    both. A synonym must conform to the following restrictions:
+    - It cannot contain carriage return, newline, or tab characters.
+    - It cannot consist of only whitespace characters.
+    - It must be no longer than 64 characters.
+    :attr list[str] patterns: (optional) An array of patterns for the entity value. You
+    can provide either synonyms or patterns (as indicated by **type**), but not both. A
+    pattern is a regular expression no longer than 128 characters. For more information
+    about how to specify a pattern, see the
+    [documentation](https://console.bluemix.net/docs/services/conversation/entities.html#creating-entities).
     :attr str value_type: (optional) Specifies the type of value.
     """
 
@@ -2913,10 +3272,23 @@ class CreateValue(object):
         """
         Initialize a CreateValue object.
 
-        :param str value: The text of the entity value. This string must conform to the following restrictions:  - It cannot contain carriage return, newline, or tab characters.  - It cannot consist of only whitespace characters.  - It must be no longer than 64 characters.
+        :param str value: The text of the entity value. This string must conform to the
+        following restrictions:
+        - It cannot contain carriage return, newline, or tab characters.
+        - It cannot consist of only whitespace characters.
+        - It must be no longer than 64 characters.
         :param object metadata: (optional) Any metadata related to the entity value.
-        :param list[str] synonyms: (optional) An array containing any synonyms for the entity value. You can provide either synonyms or patterns (as indicated by **type**), but not both. A synonym must conform to the following restrictions:  - It cannot contain carriage return, newline, or tab characters.  - It cannot consist of only whitespace characters.  - It must be no longer than 64 characters.
-        :param list[str] patterns: (optional) An array of patterns for the entity value. You can provide either synonyms or patterns (as indicated by **type**), but not both. A pattern is a regular expression no longer than 128 characters. For more information about how to specify a pattern, see the [documentation](https://console.bluemix.net/docs/services/conversation/entities.html#creating-entities).
+        :param list[str] synonyms: (optional) An array containing any synonyms for the
+        entity value. You can provide either synonyms or patterns (as indicated by
+        **type**), but not both. A synonym must conform to the following restrictions:
+        - It cannot contain carriage return, newline, or tab characters.
+        - It cannot consist of only whitespace characters.
+        - It must be no longer than 64 characters.
+        :param list[str] patterns: (optional) An array of patterns for the entity value.
+        You can provide either synonyms or patterns (as indicated by **type**), but not
+        both. A pattern is a regular expression no longer than 128 characters. For more
+        information about how to specify a pattern, see the
+        [documentation](https://console.bluemix.net/docs/services/conversation/entities.html#creating-entities).
         :param str value_type: (optional) Specifies the type of value.
         """
         self.value = value
@@ -2981,22 +3353,30 @@ class DialogNode(object):
     :attr str dialog_node_id: The dialog node ID.
     :attr str description: (optional) The description of the dialog node.
     :attr str conditions: (optional) The condition that triggers the dialog node.
-    :attr str parent: (optional) The ID of the parent dialog node. This property is not returned if the dialog node has no parent.
-    :attr str previous_sibling: (optional) The ID of the previous sibling dialog node. This property is not returned if the dialog node has no previous sibling.
+    :attr str parent: (optional) The ID of the parent dialog node. This property is not
+    returned if the dialog node has no parent.
+    :attr str previous_sibling: (optional) The ID of the previous sibling dialog node.
+    This property is not returned if the dialog node has no previous sibling.
     :attr object output: (optional) The output of the dialog node.
     :attr object context: (optional) The context (if defined) for the dialog node.
     :attr object metadata: (optional) Any metadata for the dialog node.
-    :attr DialogNodeNextStep next_step: (optional) The next step to execute following this dialog node.
+    :attr DialogNodeNextStep next_step: (optional) The next step to execute following this
+    dialog node.
     :attr datetime created: (optional) The timestamp for creation of the dialog node.
-    :attr datetime updated: (optional) The timestamp for the most recent update to the dialog node.
+    :attr datetime updated: (optional) The timestamp for the most recent update to the
+    dialog node.
     :attr list[DialogNodeAction] actions: (optional) The actions for the dialog node.
     :attr str title: (optional) The alias used to identify the dialog node.
     :attr str node_type: (optional) How the dialog node is processed.
     :attr str event_name: (optional) How an `event_handler` node is processed.
-    :attr str variable: (optional) The location in the dialog context where output is stored.
-    :attr str digress_in: (optional) Whether this top-level dialog node can be digressed into.
-    :attr str digress_out: (optional) Whether this dialog node can be returned to after a digression.
-    :attr str digress_out_slots: (optional) Whether the user can digress to top-level nodes while filling out slots.
+    :attr str variable: (optional) The location in the dialog context where output is
+    stored.
+    :attr str digress_in: (optional) Whether this top-level dialog node can be digressed
+    into.
+    :attr str digress_out: (optional) Whether this dialog node can be returned to after a
+    digression.
+    :attr str digress_out_slots: (optional) Whether the user can digress to top-level
+    nodes while filling out slots.
     """
 
     def __init__(self,
@@ -3025,22 +3405,30 @@ class DialogNode(object):
         :param str dialog_node_id: The dialog node ID.
         :param str description: (optional) The description of the dialog node.
         :param str conditions: (optional) The condition that triggers the dialog node.
-        :param str parent: (optional) The ID of the parent dialog node. This property is not returned if the dialog node has no parent.
-        :param str previous_sibling: (optional) The ID of the previous sibling dialog node. This property is not returned if the dialog node has no previous sibling.
+        :param str parent: (optional) The ID of the parent dialog node. This property is
+        not returned if the dialog node has no parent.
+        :param str previous_sibling: (optional) The ID of the previous sibling dialog
+        node. This property is not returned if the dialog node has no previous sibling.
         :param object output: (optional) The output of the dialog node.
         :param object context: (optional) The context (if defined) for the dialog node.
         :param object metadata: (optional) Any metadata for the dialog node.
-        :param DialogNodeNextStep next_step: (optional) The next step to execute following this dialog node.
+        :param DialogNodeNextStep next_step: (optional) The next step to execute following
+        this dialog node.
         :param datetime created: (optional) The timestamp for creation of the dialog node.
-        :param datetime updated: (optional) The timestamp for the most recent update to the dialog node.
+        :param datetime updated: (optional) The timestamp for the most recent update to
+        the dialog node.
         :param list[DialogNodeAction] actions: (optional) The actions for the dialog node.
         :param str title: (optional) The alias used to identify the dialog node.
         :param str node_type: (optional) How the dialog node is processed.
         :param str event_name: (optional) How an `event_handler` node is processed.
-        :param str variable: (optional) The location in the dialog context where output is stored.
-        :param str digress_in: (optional) Whether this top-level dialog node can be digressed into.
-        :param str digress_out: (optional) Whether this dialog node can be returned to after a digression.
-        :param str digress_out_slots: (optional) Whether the user can digress to top-level nodes while filling out slots.
+        :param str variable: (optional) The location in the dialog context where output is
+        stored.
+        :param str digress_in: (optional) Whether this top-level dialog node can be
+        digressed into.
+        :param str digress_out: (optional) Whether this dialog node can be returned to
+        after a digression.
+        :param str digress_out_slots: (optional) Whether the user can digress to top-level
+        nodes while filling out slots.
         """
         self.dialog_node_id = dialog_node_id
         self.description = description
@@ -3180,9 +3568,12 @@ class DialogNodeAction(object):
 
     :attr str name: The name of the action.
     :attr str action_type: (optional) The type of action to invoke.
-    :attr object parameters: (optional) A map of key/value pairs to be provided to the action.
-    :attr str result_variable: The location in the dialog context where the result of the action is stored.
-    :attr str credentials: (optional) The name of the context variable that the client application will use to pass in credentials for the action.
+    :attr object parameters: (optional) A map of key/value pairs to be provided to the
+    action.
+    :attr str result_variable: The location in the dialog context where the result of the
+    action is stored.
+    :attr str credentials: (optional) The name of the context variable that the client
+    application will use to pass in credentials for the action.
     """
 
     def __init__(self,
@@ -3195,10 +3586,13 @@ class DialogNodeAction(object):
         Initialize a DialogNodeAction object.
 
         :param str name: The name of the action.
-        :param str result_variable: The location in the dialog context where the result of the action is stored.
+        :param str result_variable: The location in the dialog context where the result of
+        the action is stored.
         :param str action_type: (optional) The type of action to invoke.
-        :param object parameters: (optional) A map of key/value pairs to be provided to the action.
-        :param str credentials: (optional) The name of the context variable that the client application will use to pass in credentials for the action.
+        :param object parameters: (optional) A map of key/value pairs to be provided to
+        the action.
+        :param str credentials: (optional) The name of the context variable that the
+        client application will use to pass in credentials for the action.
         """
         self.name = name
         self.action_type = action_type
@@ -3265,7 +3659,8 @@ class DialogNodeCollection(object):
     """
     An array of dialog nodes.
 
-    :attr list[DialogNode] dialog_nodes: An array of objects describing the dialog nodes defined for the workspace.
+    :attr list[DialogNode] dialog_nodes: An array of objects describing the dialog nodes
+    defined for the workspace.
     :attr Pagination pagination: The pagination data for the returned objects.
     """
 
@@ -3273,7 +3668,8 @@ class DialogNodeCollection(object):
         """
         Initialize a DialogNodeCollection object.
 
-        :param list[DialogNode] dialog_nodes: An array of objects describing the dialog nodes defined for the workspace.
+        :param list[DialogNode] dialog_nodes: An array of objects describing the dialog
+        nodes defined for the workspace.
         :param Pagination pagination: The pagination data for the returned objects.
         """
         self.dialog_nodes = dialog_nodes
@@ -3327,8 +3723,29 @@ class DialogNodeNextStep(object):
     """
     The next step to execute following this dialog node.
 
-    :attr str behavior: What happens after the dialog node completes. The valid values depend on the node type:  - The following values are valid for any node:    - `get_user_input`    - `skip_user_input`    - `jump_to`  - If the node is of type `event_handler` and its parent node is of type `slot` or `frame`, additional values are also valid:    - if **event_name**=`filled` and the type of the parent node is `slot`:      - `reprompt`      - `skip_all_slots`  - if **event_name**=`nomatch` and the type of the parent node is `slot`:      - `reprompt`      - `skip_slot`      - `skip_all_slots`  - if **event_name**=`generic` and the type of the parent node is `frame`:      - `reprompt`      - `skip_slot`      - `skip_all_slots`        If you specify `jump_to`, then you must also specify a value for the `dialog_node` property.
-    :attr str dialog_node: (optional) The ID of the dialog node to process next. This parameter is required if **behavior**=`jump_to`.
+    :attr str behavior: What happens after the dialog node completes. The valid values
+    depend on the node type:
+    - The following values are valid for any node:
+      - `get_user_input`
+      - `skip_user_input`
+      - `jump_to`
+    - If the node is of type `event_handler` and its parent node is of type `slot` or
+    `frame`, additional values are also valid:
+      - if **event_name**=`filled` and the type of the parent node is `slot`:
+        - `reprompt`
+        - `skip_all_slots`
+    - if **event_name**=`nomatch` and the type of the parent node is `slot`:
+        - `reprompt`
+        - `skip_slot`
+        - `skip_all_slots`
+    - if **event_name**=`generic` and the type of the parent node is `frame`:
+        - `reprompt`
+        - `skip_slot`
+        - `skip_all_slots`
+    If you specify `jump_to`, then you must also specify a value for the `dialog_node`
+    property.
+    :attr str dialog_node: (optional) The ID of the dialog node to process next. This
+    parameter is required if **behavior**=`jump_to`.
     :attr str selector: (optional) Which part of the dialog node to process next.
     """
 
@@ -3336,8 +3753,29 @@ class DialogNodeNextStep(object):
         """
         Initialize a DialogNodeNextStep object.
 
-        :param str behavior: What happens after the dialog node completes. The valid values depend on the node type:  - The following values are valid for any node:    - `get_user_input`    - `skip_user_input`    - `jump_to`  - If the node is of type `event_handler` and its parent node is of type `slot` or `frame`, additional values are also valid:    - if **event_name**=`filled` and the type of the parent node is `slot`:      - `reprompt`      - `skip_all_slots`  - if **event_name**=`nomatch` and the type of the parent node is `slot`:      - `reprompt`      - `skip_slot`      - `skip_all_slots`  - if **event_name**=`generic` and the type of the parent node is `frame`:      - `reprompt`      - `skip_slot`      - `skip_all_slots`        If you specify `jump_to`, then you must also specify a value for the `dialog_node` property.
-        :param str dialog_node: (optional) The ID of the dialog node to process next. This parameter is required if **behavior**=`jump_to`.
+        :param str behavior: What happens after the dialog node completes. The valid
+        values depend on the node type:
+        - The following values are valid for any node:
+          - `get_user_input`
+          - `skip_user_input`
+          - `jump_to`
+        - If the node is of type `event_handler` and its parent node is of type `slot` or
+        `frame`, additional values are also valid:
+          - if **event_name**=`filled` and the type of the parent node is `slot`:
+            - `reprompt`
+            - `skip_all_slots`
+        - if **event_name**=`nomatch` and the type of the parent node is `slot`:
+            - `reprompt`
+            - `skip_slot`
+            - `skip_all_slots`
+        - if **event_name**=`generic` and the type of the parent node is `frame`:
+            - `reprompt`
+            - `skip_slot`
+            - `skip_all_slots`
+        If you specify `jump_to`, then you must also specify a value for the `dialog_node`
+        property.
+        :param str dialog_node: (optional) The ID of the dialog node to process next. This
+        parameter is required if **behavior**=`jump_to`.
         :param str selector: (optional) Which part of the dialog node to process next.
         """
         self.behavior = behavior
@@ -3390,7 +3828,8 @@ class DialogNodeVisitedDetails(object):
     """
     DialogNodeVisitedDetails.
 
-    :attr str dialog_node: (optional) A dialog node that was triggered during processing of the input message.
+    :attr str dialog_node: (optional) A dialog node that was triggered during processing
+    of the input message.
     :attr str title: (optional) The title of the dialog node.
     :attr str conditions: (optional) The conditions that trigger the dialog node.
     """
@@ -3399,7 +3838,8 @@ class DialogNodeVisitedDetails(object):
         """
         Initialize a DialogNodeVisitedDetails object.
 
-        :param str dialog_node: (optional) A dialog node that was triggered during processing of the input message.
+        :param str dialog_node: (optional) A dialog node that was triggered during
+        processing of the input message.
         :param str title: (optional) The title of the dialog node.
         :param str conditions: (optional) The conditions that trigger the dialog node.
         """
@@ -3469,7 +3909,8 @@ class Entity(object):
 
         :param str entity_name: The name of the entity.
         :param datetime created: (optional) The timestamp for creation of the entity.
-        :param datetime updated: (optional) The timestamp for the last update to the entity.
+        :param datetime updated: (optional) The timestamp for the last update to the
+        entity.
         :param str description: (optional) The description of the entity.
         :param object metadata: (optional) Any metadata related to the entity.
         :param bool fuzzy_match: (optional) Whether fuzzy matching is used for the entity.
@@ -3539,7 +3980,8 @@ class EntityCollection(object):
     """
     An array of entities.
 
-    :attr list[EntityExport] entities: An array of objects describing the entities defined for the workspace.
+    :attr list[EntityExport] entities: An array of objects describing the entities defined
+    for the workspace.
     :attr Pagination pagination: The pagination data for the returned objects.
     """
 
@@ -3547,7 +3989,8 @@ class EntityCollection(object):
         """
         Initialize a EntityCollection object.
 
-        :param list[EntityExport] entities: An array of objects describing the entities defined for the workspace.
+        :param list[EntityExport] entities: An array of objects describing the entities
+        defined for the workspace.
         :param Pagination pagination: The pagination data for the returned objects.
         """
         self.entities = entities
@@ -3607,7 +4050,8 @@ class EntityExport(object):
     :attr str description: (optional) The description of the entity.
     :attr object metadata: (optional) Any metadata related to the entity.
     :attr bool fuzzy_match: (optional) Whether fuzzy matching is used for the entity.
-    :attr list[ValueExport] values: (optional) An array objects describing the entity values.
+    :attr list[ValueExport] values: (optional) An array objects describing the entity
+    values.
     """
 
     def __init__(self,
@@ -3623,11 +4067,13 @@ class EntityExport(object):
 
         :param str entity_name: The name of the entity.
         :param datetime created: (optional) The timestamp for creation of the entity.
-        :param datetime updated: (optional) The timestamp for the last update to the entity.
+        :param datetime updated: (optional) The timestamp for the last update to the
+        entity.
         :param str description: (optional) The description of the entity.
         :param object metadata: (optional) Any metadata related to the entity.
         :param bool fuzzy_match: (optional) Whether fuzzy matching is used for the entity.
-        :param list[ValueExport] values: (optional) An array objects describing the entity values.
+        :param list[ValueExport] values: (optional) An array objects describing the entity
+        values.
         """
         self.entity_name = entity_name
         self.created = created
@@ -3713,7 +4159,8 @@ class Example(object):
 
         :param str example_text: The text of the user input example.
         :param datetime created: (optional) The timestamp for creation of the example.
-        :param datetime updated: (optional) The timestamp for the last update to the example.
+        :param datetime updated: (optional) The timestamp for the last update to the
+        example.
         """
         self.example_text = example_text
         self.created = created
@@ -3765,7 +4212,8 @@ class ExampleCollection(object):
     """
     ExampleCollection.
 
-    :attr list[Example] examples: An array of objects describing the examples defined for the intent.
+    :attr list[Example] examples: An array of objects describing the examples defined for
+    the intent.
     :attr Pagination pagination: The pagination data for the returned objects.
     """
 
@@ -3773,7 +4221,8 @@ class ExampleCollection(object):
         """
         Initialize a ExampleCollection object.
 
-        :param list[Example] examples: An array of objects describing the examples defined for the intent.
+        :param list[Example] examples: An array of objects describing the examples defined
+        for the intent.
         :param Pagination pagination: The pagination data for the returned objects.
         """
         self.examples = examples
@@ -3827,14 +4276,16 @@ class InputData(object):
     """
     The user input.
 
-    :attr str text: The text of the user input. This string cannot contain carriage return, newline, or tab characters, and it must be no longer than 2048 characters.
+    :attr str text: The text of the user input. This string cannot contain carriage
+    return, newline, or tab characters, and it must be no longer than 2048 characters.
     """
 
     def __init__(self, text):
         """
         Initialize a InputData object.
 
-        :param str text: The text of the user input. This string cannot contain carriage return, newline, or tab characters, and it must be no longer than 2048 characters.
+        :param str text: The text of the user input. This string cannot contain carriage
+        return, newline, or tab characters, and it must be no longer than 2048 characters.
         """
         self.text = text
 
@@ -3891,7 +4342,8 @@ class Intent(object):
 
         :param str intent_name: The name of the intent.
         :param datetime created: (optional) The timestamp for creation of the intent.
-        :param datetime updated: (optional) The timestamp for the last update to the intent.
+        :param datetime updated: (optional) The timestamp for the last update to the
+        intent.
         :param str description: (optional) The description of the intent.
         """
         self.intent_name = intent_name
@@ -3949,7 +4401,8 @@ class IntentCollection(object):
     """
     IntentCollection.
 
-    :attr list[IntentExport] intents: An array of objects describing the intents defined for the workspace.
+    :attr list[IntentExport] intents: An array of objects describing the intents defined
+    for the workspace.
     :attr Pagination pagination: The pagination data for the returned objects.
     """
 
@@ -3957,7 +4410,8 @@ class IntentCollection(object):
         """
         Initialize a IntentCollection object.
 
-        :param list[IntentExport] intents: An array of objects describing the intents defined for the workspace.
+        :param list[IntentExport] intents: An array of objects describing the intents
+        defined for the workspace.
         :param Pagination pagination: The pagination data for the returned objects.
         """
         self.intents = intents
@@ -4015,7 +4469,8 @@ class IntentExport(object):
     :attr datetime created: (optional) The timestamp for creation of the intent.
     :attr datetime updated: (optional) The timestamp for the last update to the intent.
     :attr str description: (optional) The description of the intent.
-    :attr list[Example] examples: (optional) An array of objects describing the user input examples for the intent.
+    :attr list[Example] examples: (optional) An array of objects describing the user input
+    examples for the intent.
     """
 
     def __init__(self,
@@ -4029,9 +4484,11 @@ class IntentExport(object):
 
         :param str intent_name: The name of the intent.
         :param datetime created: (optional) The timestamp for creation of the intent.
-        :param datetime updated: (optional) The timestamp for the last update to the intent.
+        :param datetime updated: (optional) The timestamp for the last update to the
+        intent.
         :param str description: (optional) The description of the intent.
-        :param list[Example] examples: (optional) An array of objects describing the user input examples for the intent.
+        :param list[Example] examples: (optional) An array of objects describing the user
+        input examples for the intent.
         """
         self.intent_name = intent_name
         self.created = created
@@ -4158,12 +4615,15 @@ class LogExport(object):
     """
     LogExport.
 
-    :attr MessageRequest request: A request received by the workspace, including the user input and context.
-    :attr MessageResponse response: The response sent by the workspace, including the output text, detected intents and entities, and context.
+    :attr MessageRequest request: A request received by the workspace, including the user
+    input and context.
+    :attr MessageResponse response: The response sent by the workspace, including the
+    output text, detected intents and entities, and context.
     :attr str log_id: A unique identifier for the logged event.
     :attr str request_timestamp: The timestamp for receipt of the message.
     :attr str response_timestamp: The timestamp for the system response to the message.
-    :attr str workspace_id: The unique identifier of the workspace where the request was made.
+    :attr str workspace_id: The unique identifier of the workspace where the request was
+    made.
     :attr str language: The language of the workspace where the message request was made.
     """
 
@@ -4172,13 +4632,18 @@ class LogExport(object):
         """
         Initialize a LogExport object.
 
-        :param MessageRequest request: A request received by the workspace, including the user input and context.
-        :param MessageResponse response: The response sent by the workspace, including the output text, detected intents and entities, and context.
+        :param MessageRequest request: A request received by the workspace, including the
+        user input and context.
+        :param MessageResponse response: The response sent by the workspace, including the
+        output text, detected intents and entities, and context.
         :param str log_id: A unique identifier for the logged event.
         :param str request_timestamp: The timestamp for receipt of the message.
-        :param str response_timestamp: The timestamp for the system response to the message.
-        :param str workspace_id: The unique identifier of the workspace where the request was made.
-        :param str language: The language of the workspace where the message request was made.
+        :param str response_timestamp: The timestamp for the system response to the
+        message.
+        :param str workspace_id: The unique identifier of the workspace where the request
+        was made.
+        :param str language: The language of the workspace where the message request was
+        made.
         """
         self.request = request
         self.response = response
@@ -4352,7 +4817,8 @@ class LogPagination(object):
     """
     The pagination data for the returned objects.
 
-    :attr str next_url: (optional) The URL that will return the next page of results, if any.
+    :attr str next_url: (optional) The URL that will return the next page of results, if
+    any.
     :attr int matched: (optional) Reserved for future use.
     :attr str next_cursor: (optional) A token identifying the next page of results.
     """
@@ -4361,7 +4827,8 @@ class LogPagination(object):
         """
         Initialize a LogPagination object.
 
-        :param str next_url: (optional) The URL that will return the next page of results, if any.
+        :param str next_url: (optional) The URL that will return the next page of results,
+        if any.
         :param int matched: (optional) Reserved for future use.
         :param str next_cursor: (optional) A token identifying the next page of results.
         """
@@ -4457,11 +4924,18 @@ class MessageRequest(object):
     A request formatted for the Conversation service.
 
     :attr InputData input: (optional) An input object that includes the input text.
-    :attr bool alternate_intents: (optional) Whether to return more than one intent. Set to `true` to return all matching intents.
-    :attr Context context: (optional) State information for the conversation. Continue a conversation by including the context object from the previous response.
-    :attr list[RuntimeEntity] entities: (optional) Entities to use when evaluating the message. Include entities from the previous response to continue using those entities rather than detecting entities in the new input.
-    :attr list[RuntimeIntent] intents: (optional) Intents to use when evaluating the user input. Include intents from the previous response to continue using those intents rather than trying to recognize intents in the new input.
-    :attr OutputData output: (optional) System output. Include the output from the previous response to maintain intermediate information over multiple requests.
+    :attr bool alternate_intents: (optional) Whether to return more than one intent. Set
+    to `true` to return all matching intents.
+    :attr Context context: (optional) State information for the conversation. Continue a
+    conversation by including the context object from the previous response.
+    :attr list[RuntimeEntity] entities: (optional) Entities to use when evaluating the
+    message. Include entities from the previous response to continue using those entities
+    rather than detecting entities in the new input.
+    :attr list[RuntimeIntent] intents: (optional) Intents to use when evaluating the user
+    input. Include intents from the previous response to continue using those intents
+    rather than trying to recognize intents in the new input.
+    :attr OutputData output: (optional) System output. Include the output from the
+    previous response to maintain intermediate information over multiple requests.
     """
 
     def __init__(self,
@@ -4475,11 +4949,19 @@ class MessageRequest(object):
         Initialize a MessageRequest object.
 
         :param InputData input: (optional) An input object that includes the input text.
-        :param bool alternate_intents: (optional) Whether to return more than one intent. Set to `true` to return all matching intents.
-        :param Context context: (optional) State information for the conversation. Continue a conversation by including the context object from the previous response.
-        :param list[RuntimeEntity] entities: (optional) Entities to use when evaluating the message. Include entities from the previous response to continue using those entities rather than detecting entities in the new input.
-        :param list[RuntimeIntent] intents: (optional) Intents to use when evaluating the user input. Include intents from the previous response to continue using those intents rather than trying to recognize intents in the new input.
-        :param OutputData output: (optional) System output. Include the output from the previous response to maintain intermediate information over multiple requests.
+        :param bool alternate_intents: (optional) Whether to return more than one intent.
+        Set to `true` to return all matching intents.
+        :param Context context: (optional) State information for the conversation.
+        Continue a conversation by including the context object from the previous
+        response.
+        :param list[RuntimeEntity] entities: (optional) Entities to use when evaluating
+        the message. Include entities from the previous response to continue using those
+        entities rather than detecting entities in the new input.
+        :param list[RuntimeIntent] intents: (optional) Intents to use when evaluating the
+        user input. Include intents from the previous response to continue using those
+        intents rather than trying to recognize intents in the new input.
+        :param OutputData output: (optional) System output. Include the output from the
+        previous response to maintain intermediate information over multiple requests.
         """
         self.input = input
         self.alternate_intents = alternate_intents
@@ -4548,11 +5030,14 @@ class MessageResponse(object):
     A response from the Conversation service.
 
     :attr MessageInput input: (optional) The user input from the request.
-    :attr list[RuntimeIntent] intents: An array of intents recognized in the user input, sorted in descending order of confidence.
+    :attr list[RuntimeIntent] intents: An array of intents recognized in the user input,
+    sorted in descending order of confidence.
     :attr list[RuntimeEntity] entities: An array of entities identified in the user input.
-    :attr bool alternate_intents: (optional) Whether to return more than one intent. A value of `true` indicates that all matching intents are returned.
+    :attr bool alternate_intents: (optional) Whether to return more than one intent. A
+    value of `true` indicates that all matching intents are returned.
     :attr Context context: State information for the conversation.
-    :attr OutputData output: Output from the dialog, including the response to the user, the nodes that were triggered, and log messages.
+    :attr OutputData output: Output from the dialog, including the response to the user,
+    the nodes that were triggered, and log messages.
     """
 
     def __init__(self,
@@ -4566,12 +5051,16 @@ class MessageResponse(object):
         """
         Initialize a MessageResponse object.
 
-        :param list[RuntimeIntent] intents: An array of intents recognized in the user input, sorted in descending order of confidence.
-        :param list[RuntimeEntity] entities: An array of entities identified in the user input.
+        :param list[RuntimeIntent] intents: An array of intents recognized in the user
+        input, sorted in descending order of confidence.
+        :param list[RuntimeEntity] entities: An array of entities identified in the user
+        input.
         :param Context context: State information for the conversation.
-        :param OutputData output: Output from the dialog, including the response to the user, the nodes that were triggered, and log messages.
+        :param OutputData output: Output from the dialog, including the response to the
+        user, the nodes that were triggered, and log messages.
         :param MessageInput input: (optional) The user input from the request.
-        :param bool alternate_intents: (optional) Whether to return more than one intent. A value of `true` indicates that all matching intents are returned.
+        :param bool alternate_intents: (optional) Whether to return more than one intent.
+        A value of `true` indicates that all matching intents are returned.
         :param **kwargs: (optional) Any additional properties.
         """
         self.input = input
@@ -4684,10 +5173,16 @@ class OutputData(object):
     An output object that includes the response to the user, the nodes that were hit, and
     messages from the log.
 
-    :attr list[LogMessage] log_messages: An array of up to 50 messages logged with the request.
+    :attr list[LogMessage] log_messages: An array of up to 50 messages logged with the
+    request.
     :attr list[str] text: An array of responses to the user.
-    :attr list[str] nodes_visited: (optional) An array of the nodes that were triggered to create the response, in the order in which they were visited. This information is useful for debugging and for tracing the path taken through the node tree.
-    :attr list[DialogNodeVisitedDetails] nodes_visited_details: (optional) An array of objects containing detailed diagnostic information about the nodes that were triggered during processing of the input message. Included only if **nodes_visited_details** is set to `true` in the message request.
+    :attr list[str] nodes_visited: (optional) An array of the nodes that were triggered to
+    create the response, in the order in which they were visited. This information is
+    useful for debugging and for tracing the path taken through the node tree.
+    :attr list[DialogNodeVisitedDetails] nodes_visited_details: (optional) An array of
+    objects containing detailed diagnostic information about the nodes that were triggered
+    during processing of the input message. Included only if **nodes_visited_details** is
+    set to `true` in the message request.
     """
 
     def __init__(self,
@@ -4699,10 +5194,17 @@ class OutputData(object):
         """
         Initialize a OutputData object.
 
-        :param list[LogMessage] log_messages: An array of up to 50 messages logged with the request.
+        :param list[LogMessage] log_messages: An array of up to 50 messages logged with
+        the request.
         :param list[str] text: An array of responses to the user.
-        :param list[str] nodes_visited: (optional) An array of the nodes that were triggered to create the response, in the order in which they were visited. This information is useful for debugging and for tracing the path taken through the node tree.
-        :param list[DialogNodeVisitedDetails] nodes_visited_details: (optional) An array of objects containing detailed diagnostic information about the nodes that were triggered during processing of the input message. Included only if **nodes_visited_details** is set to `true` in the message request.
+        :param list[str] nodes_visited: (optional) An array of the nodes that were
+        triggered to create the response, in the order in which they were visited. This
+        information is useful for debugging and for tracing the path taken through the
+        node tree.
+        :param list[DialogNodeVisitedDetails] nodes_visited_details: (optional) An array
+        of objects containing detailed diagnostic information about the nodes that were
+        triggered during processing of the input message. Included only if
+        **nodes_visited_details** is set to `true` in the message request.
         :param **kwargs: (optional) Any additional properties.
         """
         self.log_messages = log_messages
@@ -4754,7 +5256,7 @@ class OutputData(object):
         if hasattr(self, 'nodes_visited') and self.nodes_visited is not None:
             _dict['nodes_visited'] = self.nodes_visited
         if hasattr(self, 'nodes_visited_details'
-                  ) and self.nodes_visited_details is not None:
+                   ) and self.nodes_visited_details is not None:
             _dict['nodes_visited_details'] = [
                 x._to_dict() for x in self.nodes_visited_details
             ]
@@ -4816,7 +5318,8 @@ class Pagination(object):
         :param str next_url: (optional) The URL that will return the next page of results.
         :param int total: (optional) Reserved for future use.
         :param int matched: (optional) Reserved for future use.
-        :param str refresh_cursor: (optional) A token identifying the current page of results.
+        :param str refresh_cursor: (optional) A token identifying the current page of
+        results.
         :param str next_cursor: (optional) A token identifying the next page of results.
         """
         self.refresh_url = refresh_url
@@ -4885,11 +5388,14 @@ class RuntimeEntity(object):
     A term from the request that was identified as an entity.
 
     :attr str entity: An entity detected in the input.
-    :attr list[int] location: An array of zero-based character offsets that indicate where the detected entity values begin and end in the input text.
+    :attr list[int] location: An array of zero-based character offsets that indicate where
+    the detected entity values begin and end in the input text.
     :attr str value: The term in the input text that was recognized as an entity value.
-    :attr float confidence: (optional) A decimal percentage that represents Watson's confidence in the entity.
+    :attr float confidence: (optional) A decimal percentage that represents Watson's
+    confidence in the entity.
     :attr object metadata: (optional) Any metadata for the entity.
-    :attr list[CaptureGroup] groups: (optional) The recognized capture groups for the entity, as defined by the entity pattern.
+    :attr list[CaptureGroup] groups: (optional) The recognized capture groups for the
+    entity, as defined by the entity pattern.
     """
 
     def __init__(self,
@@ -4904,11 +5410,15 @@ class RuntimeEntity(object):
         Initialize a RuntimeEntity object.
 
         :param str entity: An entity detected in the input.
-        :param list[int] location: An array of zero-based character offsets that indicate where the detected entity values begin and end in the input text.
-        :param str value: The term in the input text that was recognized as an entity value.
-        :param float confidence: (optional) A decimal percentage that represents Watson's confidence in the entity.
+        :param list[int] location: An array of zero-based character offsets that indicate
+        where the detected entity values begin and end in the input text.
+        :param str value: The term in the input text that was recognized as an entity
+        value.
+        :param float confidence: (optional) A decimal percentage that represents Watson's
+        confidence in the entity.
         :param object metadata: (optional) Any metadata for the entity.
-        :param list[CaptureGroup] groups: (optional) The recognized capture groups for the entity, as defined by the entity pattern.
+        :param list[CaptureGroup] groups: (optional) The recognized capture groups for the
+        entity, as defined by the entity pattern.
         :param **kwargs: (optional) Any additional properties.
         """
         self.entity = entity
@@ -5013,7 +5523,8 @@ class RuntimeIntent(object):
     An intent identified in the user input.
 
     :attr str intent: The name of the recognized intent.
-    :attr float confidence: A decimal percentage that represents Watson's confidence in the intent.
+    :attr float confidence: A decimal percentage that represents Watson's confidence in
+    the intent.
     """
 
     def __init__(self, intent, confidence, **kwargs):
@@ -5021,7 +5532,8 @@ class RuntimeIntent(object):
         Initialize a RuntimeIntent object.
 
         :param str intent: The name of the recognized intent.
-        :param float confidence: A decimal percentage that represents Watson's confidence in the intent.
+        :param float confidence: A decimal percentage that represents Watson's confidence
+        in the intent.
         :param **kwargs: (optional) Any additional properties.
         """
         self.intent = intent
@@ -5095,7 +5607,8 @@ class Synonym(object):
 
     :attr str synonym_text: The text of the synonym.
     :attr datetime created: (optional) The timestamp for creation of the synonym.
-    :attr datetime updated: (optional) The timestamp for the most recent update to the synonym.
+    :attr datetime updated: (optional) The timestamp for the most recent update to the
+    synonym.
     """
 
     def __init__(self, synonym_text, created=None, updated=None):
@@ -5104,7 +5617,8 @@ class Synonym(object):
 
         :param str synonym_text: The text of the synonym.
         :param datetime created: (optional) The timestamp for creation of the synonym.
-        :param datetime updated: (optional) The timestamp for the most recent update to the synonym.
+        :param datetime updated: (optional) The timestamp for the most recent update to
+        the synonym.
         """
         self.synonym_text = synonym_text
         self.created = created
@@ -5278,9 +5792,12 @@ class Value(object):
     :attr str value_text: The text of the entity value.
     :attr object metadata: (optional) Any metadata related to the entity value.
     :attr datetime created: (optional) The timestamp for creation of the entity value.
-    :attr datetime updated: (optional) The timestamp for the last update to the entity value.
-    :attr list[str] synonyms: (optional) An array containing any synonyms for the entity value.
-    :attr list[str] patterns: (optional) An array containing any patterns for the entity value.
+    :attr datetime updated: (optional) The timestamp for the last update to the entity
+    value.
+    :attr list[str] synonyms: (optional) An array containing any synonyms for the entity
+    value.
+    :attr list[str] patterns: (optional) An array containing any patterns for the entity
+    value.
     :attr str value_type: Specifies the type of value.
     """
 
@@ -5298,10 +5815,14 @@ class Value(object):
         :param str value_text: The text of the entity value.
         :param str value_type: Specifies the type of value.
         :param object metadata: (optional) Any metadata related to the entity value.
-        :param datetime created: (optional) The timestamp for creation of the entity value.
-        :param datetime updated: (optional) The timestamp for the last update to the entity value.
-        :param list[str] synonyms: (optional) An array containing any synonyms for the entity value.
-        :param list[str] patterns: (optional) An array containing any patterns for the entity value.
+        :param datetime created: (optional) The timestamp for creation of the entity
+        value.
+        :param datetime updated: (optional) The timestamp for the last update to the
+        entity value.
+        :param list[str] synonyms: (optional) An array containing any synonyms for the
+        entity value.
+        :param list[str] patterns: (optional) An array containing any patterns for the
+        entity value.
         """
         self.value_text = value_text
         self.metadata = metadata
@@ -5376,7 +5897,8 @@ class ValueCollection(object):
     ValueCollection.
 
     :attr list[ValueExport] values: An array of entity values.
-    :attr Pagination pagination: An object defining the pagination data for the returned objects.
+    :attr Pagination pagination: An object defining the pagination data for the returned
+    objects.
     """
 
     def __init__(self, values, pagination):
@@ -5384,7 +5906,8 @@ class ValueCollection(object):
         Initialize a ValueCollection object.
 
         :param list[ValueExport] values: An array of entity values.
-        :param Pagination pagination: An object defining the pagination data for the returned objects.
+        :param Pagination pagination: An object defining the pagination data for the
+        returned objects.
         """
         self.values = values
         self.pagination = pagination
@@ -5440,9 +5963,12 @@ class ValueExport(object):
     :attr str value_text: The text of the entity value.
     :attr object metadata: (optional) Any metadata related to the entity value.
     :attr datetime created: (optional) The timestamp for creation of the entity value.
-    :attr datetime updated: (optional) The timestamp for the last update to the entity value.
-    :attr list[str] synonyms: (optional) An array containing any synonyms for the entity value.
-    :attr list[str] patterns: (optional) An array containing any patterns for the entity value.
+    :attr datetime updated: (optional) The timestamp for the last update to the entity
+    value.
+    :attr list[str] synonyms: (optional) An array containing any synonyms for the entity
+    value.
+    :attr list[str] patterns: (optional) An array containing any patterns for the entity
+    value.
     :attr str value_type: Specifies the type of value.
     """
 
@@ -5460,10 +5986,14 @@ class ValueExport(object):
         :param str value_text: The text of the entity value.
         :param str value_type: Specifies the type of value.
         :param object metadata: (optional) Any metadata related to the entity value.
-        :param datetime created: (optional) The timestamp for creation of the entity value.
-        :param datetime updated: (optional) The timestamp for the last update to the entity value.
-        :param list[str] synonyms: (optional) An array containing any synonyms for the entity value.
-        :param list[str] patterns: (optional) An array containing any patterns for the entity value.
+        :param datetime created: (optional) The timestamp for creation of the entity
+        value.
+        :param datetime updated: (optional) The timestamp for the last update to the
+        entity value.
+        :param list[str] synonyms: (optional) An array containing any synonyms for the
+        entity value.
+        :param list[str] patterns: (optional) An array containing any patterns for the
+        entity value.
         """
         self.value_text = value_text
         self.metadata = metadata
@@ -5544,7 +6074,9 @@ class Workspace(object):
     :attr str workspace_id: The workspace ID.
     :attr str description: (optional) The description of the workspace.
     :attr object metadata: (optional) Any metadata related to the workspace.
-    :attr bool learning_opt_out: (optional) Whether training data from the workspace (including artifacts such as intents and entities) can be used by IBM for general service improvements. `true` indicates that workspace training data is not to be used.
+    :attr bool learning_opt_out: (optional) Whether training data from the workspace
+    (including artifacts such as intents and entities) can be used by IBM for general
+    service improvements. `true` indicates that workspace training data is not to be used.
     """
 
     def __init__(self,
@@ -5563,10 +6095,14 @@ class Workspace(object):
         :param str language: The language of the workspace.
         :param str workspace_id: The workspace ID.
         :param datetime created: (optional) The timestamp for creation of the workspace.
-        :param datetime updated: (optional) The timestamp for the last update to the workspace.
+        :param datetime updated: (optional) The timestamp for the last update to the
+        workspace.
         :param str description: (optional) The description of the workspace.
         :param object metadata: (optional) Any metadata related to the workspace.
-        :param bool learning_opt_out: (optional) Whether training data from the workspace (including artifacts such as intents and entities) can be used by IBM for general service improvements. `true` indicates that workspace training data is not to be used.
+        :param bool learning_opt_out: (optional) Whether training data from the workspace
+        (including artifacts such as intents and entities) can be used by IBM for general
+        service improvements. `true` indicates that workspace training data is not to be
+        used.
         """
         self.name = name
         self.language = language
@@ -5650,16 +6186,20 @@ class WorkspaceCollection(object):
     """
     WorkspaceCollection.
 
-    :attr list[Workspace] workspaces: An array of objects describing the workspaces associated with the service instance.
-    :attr Pagination pagination: An object defining the pagination data for the returned objects.
+    :attr list[Workspace] workspaces: An array of objects describing the workspaces
+    associated with the service instance.
+    :attr Pagination pagination: An object defining the pagination data for the returned
+    objects.
     """
 
     def __init__(self, workspaces, pagination):
         """
         Initialize a WorkspaceCollection object.
 
-        :param list[Workspace] workspaces: An array of objects describing the workspaces associated with the service instance.
-        :param Pagination pagination: An object defining the pagination data for the returned objects.
+        :param list[Workspace] workspaces: An array of objects describing the workspaces
+        associated with the service instance.
+        :param Pagination pagination: An object defining the pagination data for the
+        returned objects.
         """
         self.workspaces = workspaces
         self.pagination = pagination
@@ -5720,11 +6260,14 @@ class WorkspaceExport(object):
     :attr datetime updated: (optional) The timestamp for the last update to the workspace.
     :attr str workspace_id: The workspace ID.
     :attr str status: The current status of the workspace.
-    :attr bool learning_opt_out: Whether training data from the workspace can be used by IBM for general service improvements. `true` indicates that workspace training data is not to be used.
+    :attr bool learning_opt_out: Whether training data from the workspace can be used by
+    IBM for general service improvements. `true` indicates that workspace training data is
+    not to be used.
     :attr list[IntentExport] intents: (optional) An array of intents.
     :attr list[EntityExport] entities: (optional) An array of entities.
     :attr list[Counterexample] counterexamples: (optional) An array of counterexamples.
-    :attr list[DialogNode] dialog_nodes: (optional) An array of objects describing the dialog nodes in the workspace.
+    :attr list[DialogNode] dialog_nodes: (optional) An array of objects describing the
+    dialog nodes in the workspace.
     """
 
     def __init__(self,
@@ -5750,13 +6293,18 @@ class WorkspaceExport(object):
         :param object metadata: Any metadata that is required by the workspace.
         :param str workspace_id: The workspace ID.
         :param str status: The current status of the workspace.
-        :param bool learning_opt_out: Whether training data from the workspace can be used by IBM for general service improvements. `true` indicates that workspace training data is not to be used.
+        :param bool learning_opt_out: Whether training data from the workspace can be used
+        by IBM for general service improvements. `true` indicates that workspace training
+        data is not to be used.
         :param datetime created: (optional) The timestamp for creation of the workspace.
-        :param datetime updated: (optional) The timestamp for the last update to the workspace.
+        :param datetime updated: (optional) The timestamp for the last update to the
+        workspace.
         :param list[IntentExport] intents: (optional) An array of intents.
         :param list[EntityExport] entities: (optional) An array of entities.
-        :param list[Counterexample] counterexamples: (optional) An array of counterexamples.
-        :param list[DialogNode] dialog_nodes: (optional) An array of objects describing the dialog nodes in the workspace.
+        :param list[Counterexample] counterexamples: (optional) An array of
+        counterexamples.
+        :param list[DialogNode] dialog_nodes: (optional) An array of objects describing
+        the dialog nodes in the workspace.
         """
         self.name = name
         self.description = description

--- a/watson_developer_cloud/discovery_v1.py
+++ b/watson_developer_cloud/discovery_v1.py
@@ -2732,7 +2732,7 @@ class Conversions(object):
         if hasattr(self, 'segment') and self.segment is not None:
             _dict['segment'] = self.segment._to_dict()
         if hasattr(self, 'json_normalizations'
-                   ) and self.json_normalizations is not None:
+                  ) and self.json_normalizations is not None:
             _dict['json_normalizations'] = [
                 x._to_dict() for x in self.json_normalizations
             ]
@@ -3075,7 +3075,7 @@ class DiskUsage(object):
         if hasattr(self, 'used_bytes') and self.used_bytes is not None:
             _dict['used_bytes'] = self.used_bytes
         if hasattr(self, 'maximum_allowed_bytes'
-                   ) and self.maximum_allowed_bytes is not None:
+                  ) and self.maximum_allowed_bytes is not None:
             _dict['maximum_allowed_bytes'] = self.maximum_allowed_bytes
         if hasattr(self, 'total_bytes') and self.total_bytes is not None:
             _dict['total_bytes'] = self.total_bytes
@@ -3551,7 +3551,7 @@ class Enrichment(object):
                    'enrichment_name') and self.enrichment_name is not None:
             _dict['enrichment'] = self.enrichment_name
         if hasattr(self, 'ignore_downstream_errors'
-                   ) and self.ignore_downstream_errors is not None:
+                  ) and self.ignore_downstream_errors is not None:
             _dict['ignore_downstream_errors'] = self.ignore_downstream_errors
         if hasattr(self, 'options') and self.options is not None:
             _dict['options'] = self.options._to_dict()
@@ -4138,10 +4138,10 @@ class HtmlSettings(object):
         """Return a json dictionary representing this model."""
         _dict = {}
         if hasattr(self, 'exclude_tags_completely'
-                   ) and self.exclude_tags_completely is not None:
+                  ) and self.exclude_tags_completely is not None:
             _dict['exclude_tags_completely'] = self.exclude_tags_completely
         if hasattr(self, 'exclude_tags_keep_content'
-                   ) and self.exclude_tags_keep_content is not None:
+                  ) and self.exclude_tags_keep_content is not None:
             _dict['exclude_tags_keep_content'] = self.exclude_tags_keep_content
         if hasattr(self, 'keep_content') and self.keep_content is not None:
             _dict['keep_content'] = self.keep_content._to_dict()
@@ -4149,10 +4149,10 @@ class HtmlSettings(object):
                    'exclude_content') and self.exclude_content is not None:
             _dict['exclude_content'] = self.exclude_content._to_dict()
         if hasattr(self, 'keep_tag_attributes'
-                   ) and self.keep_tag_attributes is not None:
+                  ) and self.keep_tag_attributes is not None:
             _dict['keep_tag_attributes'] = self.keep_tag_attributes
         if hasattr(self, 'exclude_tag_attributes'
-                   ) and self.exclude_tag_attributes is not None:
+                  ) and self.exclude_tag_attributes is not None:
             _dict['exclude_tag_attributes'] = self.exclude_tag_attributes
         return _dict
 
@@ -6983,10 +6983,10 @@ class TestDocument(object):
         if hasattr(self, 'status') and self.status is not None:
             _dict['status'] = self.status
         if hasattr(self, 'enriched_field_units'
-                   ) and self.enriched_field_units is not None:
+                  ) and self.enriched_field_units is not None:
             _dict['enriched_field_units'] = self.enriched_field_units
         if hasattr(self, 'original_media_type'
-                   ) and self.original_media_type is not None:
+                  ) and self.original_media_type is not None:
             _dict['original_media_type'] = self.original_media_type
         if hasattr(self, 'snapshots') and self.snapshots is not None:
             _dict['snapshots'] = [x._to_dict() for x in self.snapshots]
@@ -7283,7 +7283,7 @@ class TrainingQuery(object):
         if hasattr(self, 'query_id') and self.query_id is not None:
             _dict['query_id'] = self.query_id
         if hasattr(self, 'natural_language_query'
-                   ) and self.natural_language_query is not None:
+                  ) and self.natural_language_query is not None:
             _dict['natural_language_query'] = self.natural_language_query
         if hasattr(self, 'filter') and self.filter is not None:
             _dict['filter'] = self.filter
@@ -7392,19 +7392,19 @@ class TrainingStatus(object):
         if hasattr(self, 'processing') and self.processing is not None:
             _dict['processing'] = self.processing
         if hasattr(self, 'minimum_queries_added'
-                   ) and self.minimum_queries_added is not None:
+                  ) and self.minimum_queries_added is not None:
             _dict['minimum_queries_added'] = self.minimum_queries_added
         if hasattr(self, 'minimum_examples_added'
-                   ) and self.minimum_examples_added is not None:
+                  ) and self.minimum_examples_added is not None:
             _dict['minimum_examples_added'] = self.minimum_examples_added
         if hasattr(self, 'sufficient_label_diversity'
-                   ) and self.sufficient_label_diversity is not None:
+                  ) and self.sufficient_label_diversity is not None:
             _dict[
                 'sufficient_label_diversity'] = self.sufficient_label_diversity
         if hasattr(self, 'notices') and self.notices is not None:
             _dict['notices'] = self.notices
         if hasattr(self, 'successfully_trained'
-                   ) and self.successfully_trained is not None:
+                  ) and self.successfully_trained is not None:
             _dict['successfully_trained'] = datetime_to_string(
                 self.successfully_trained)
         if hasattr(self, 'data_updated') and self.data_updated is not None:

--- a/watson_developer_cloud/discovery_v1.py
+++ b/watson_developer_cloud/discovery_v1.py
@@ -14,11 +14,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """
-The IBM Watson Discovery Service is a cognitive search and content analytics engine that
-you can add to applications to identify patterns, trends and actionable insights to drive
-better decision-making. Securely unify structured and unstructured data with pre-enriched
-content, and use a simplified query language to eliminate the need for manual filtering of
-results.
+The IBM Watson&trade; Discovery Service is a cognitive search and content analytics engine
+that you can add to applications to identify patterns, trends and actionable insights to
+drive better decision-making. Securely unify structured and unstructured data with
+pre-enriched content, and use a simplified query language to eliminate the need for manual
+filtering of results.
 """
 
 from __future__ import absolute_import
@@ -111,9 +111,9 @@ class DiscoveryV1(WatsonService):
         Create an environment.
 
         Creates a new environment for private data. An environment must be created before
-        collections can be created.   **Note**: You can create only one environment for
-        private data per service instance. An attempt to create another environment
-        results in an error.
+        collections can be created.
+        **Note**: You can create only one environment for private data per service
+        instance. An attempt to create another environment results in an error.
 
         :param str name: Name that identifies the environment.
         :param str description: Description of the environment.
@@ -221,7 +221,8 @@ class DiscoveryV1(WatsonService):
         specified collections.
 
         :param str environment_id: The ID of the environment.
-        :param list[str] collection_ids: A comma-separated list of collection IDs to be queried against.
+        :param list[str] collection_ids: A comma-separated list of collection IDs to be
+        queried against.
         :param dict headers: A `dict` containing the request headers
         :return: A `dict` containing the `ListCollectionFieldsResponse` response.
         :rtype: dict
@@ -298,21 +299,27 @@ class DiscoveryV1(WatsonService):
         """
         Add configuration.
 
-        Creates a new configuration.  If the input configuration contains the
-        `configuration_id`, `created`, or `updated` properties, then they are ignored and
-        overridden by the system, and an error is not returned so that the overridden
-        fields do not need to be removed when copying a configuration.  The configuration
-        can contain unrecognized JSON fields. Any such fields are ignored and do not
-        generate an error. This makes it easier to use newer configuration files with
-        older versions of the API and the service. It also makes it possible for the
-        tooling to add additional metadata and information to the configuration.
+        Creates a new configuration.
+        If the input configuration contains the `configuration_id`, `created`, or
+        `updated` properties, then they are ignored and overridden by the system, and an
+        error is not returned so that the overridden fields do not need to be removed when
+        copying a configuration.
+        The configuration can contain unrecognized JSON fields. Any such fields are
+        ignored and do not generate an error. This makes it easier to use newer
+        configuration files with older versions of the API and the service. It also makes
+        it possible for the tooling to add additional metadata and information to the
+        configuration.
 
         :param str environment_id: The ID of the environment.
         :param str name: The name of the configuration.
         :param str description: The description of the configuration, if available.
-        :param Conversions conversions: The document conversion settings for the configuration.
-        :param list[Enrichment] enrichments: An array of document enrichment settings for the configuration.
-        :param list[NormalizationOperation] normalizations: Defines operations that can be used to transform the final output JSON into a normalized form. Operations are executed in the order that they appear in the array.
+        :param Conversions conversions: The document conversion settings for the
+        configuration.
+        :param list[Enrichment] enrichments: An array of document enrichment settings for
+        the configuration.
+        :param list[NormalizationOperation] normalizations: Defines operations that can be
+        used to transform the final output JSON into a normalized form. Operations are
+        executed in the order that they appear in the array.
         :param dict headers: A `dict` containing the request headers
         :return: A `dict` containing the `Configuration` response.
         :rtype: dict
@@ -457,21 +464,27 @@ class DiscoveryV1(WatsonService):
         """
         Update a configuration.
 
-        Replaces an existing configuration.   * Completely replaces the original
-        configuration.   * The `configuration_id`, `updated`, and `created` fields are
-        accepted in the request, but they are ignored, and an error is not generated. It
-        is also acceptable for users to submit an updated configuration with none of the
-        three properties.   * Documents are processed with a snapshot of the configuration
-        as it was at the time the document was submitted to be ingested. This means that
-        already submitted documents will not see any updates made to the configuration.
+        Replaces an existing configuration.
+          * Completely replaces the original configuration.
+          * The `configuration_id`, `updated`, and `created` fields are accepted in the
+        request, but they are ignored, and an error is not generated. It is also
+        acceptable for users to submit an updated configuration with none of the three
+        properties.
+          * Documents are processed with a snapshot of the configuration as it was at the
+        time the document was submitted to be ingested. This means that already submitted
+        documents will not see any updates made to the configuration.
 
         :param str environment_id: The ID of the environment.
         :param str configuration_id: The ID of the configuration.
         :param str name: The name of the configuration.
         :param str description: The description of the configuration, if available.
-        :param Conversions conversions: The document conversion settings for the configuration.
-        :param list[Enrichment] enrichments: An array of document enrichment settings for the configuration.
-        :param list[NormalizationOperation] normalizations: Defines operations that can be used to transform the final output JSON into a normalized form. Operations are executed in the order that they appear in the array.
+        :param Conversions conversions: The document conversion settings for the
+        configuration.
+        :param list[Enrichment] enrichments: An array of document enrichment settings for
+        the configuration.
+        :param list[NormalizationOperation] normalizations: Defines operations that can be
+        used to transform the final output JSON into a normalized form. Operations are
+        executed in the order that they appear in the array.
         :param dict headers: A `dict` containing the request headers
         :return: A `dict` containing the `Configuration` response.
         :rtype: dict
@@ -537,11 +550,29 @@ class DiscoveryV1(WatsonService):
         processed. The document is not added to the index.
 
         :param str environment_id: The ID of the environment.
-        :param str configuration: The configuration to use to process the document. If this part is provided, then the provided configuration is used to process the document. If the `configuration_id` is also provided (both are present at the same time), then request is rejected. The maximum supported configuration size is 1 MB. Configuration parts larger than 1 MB are rejected. See the `GET /configurations/{configuration_id}` operation for an example configuration.
-        :param str step: Specify to only run the input document through the given step instead of running the input document through the entire ingestion workflow. Valid values are `convert`, `enrich`, and `normalize`.
-        :param str configuration_id: The ID of the configuration to use to process the document. If the `configuration` form part is also provided (both are present at the same time), then request will be rejected.
-        :param file file: The content of the document to ingest. The maximum supported file size is 50 megabytes. Files larger than 50 megabytes is rejected.
-        :param str metadata: If you're using the Data Crawler to upload your documents, you can test a document against the type of metadata that the Data Crawler might send. The maximum supported metadata file size is 1 MB. Metadata parts larger than 1 MB are rejected. Example:  ``` {   \"Creator\": \"Johnny Appleseed\",   \"Subject\": \"Apples\" } ```.
+        :param str configuration: The configuration to use to process the document. If
+        this part is provided, then the provided configuration is used to process the
+        document. If the `configuration_id` is also provided (both are present at the same
+        time), then request is rejected. The maximum supported configuration size is 1 MB.
+        Configuration parts larger than 1 MB are rejected.
+        See the `GET /configurations/{configuration_id}` operation for an example
+        configuration.
+        :param str step: Specify to only run the input document through the given step
+        instead of running the input document through the entire ingestion workflow. Valid
+        values are `convert`, `enrich`, and `normalize`.
+        :param str configuration_id: The ID of the configuration to use to process the
+        document. If the `configuration` form part is also provided (both are present at
+        the same time), then request will be rejected.
+        :param file file: The content of the document to ingest. The maximum supported
+        file size is 50 megabytes. Files larger than 50 megabytes is rejected.
+        :param str metadata: If you're using the Data Crawler to upload your documents,
+        you can test a document against the type of metadata that the Data Crawler might
+        send. The maximum supported metadata file size is 1 MB. Metadata parts larger than
+        1 MB are rejected.
+        Example:  ``` {
+          \"Creator\": \"Johnny Appleseed\",
+          \"Subject\": \"Apples\"
+        } ```.
         :param str file_content_type: The content type of file.
         :param str filename: The filename for file.
         :param dict headers: A `dict` containing the request headers
@@ -604,8 +635,10 @@ class DiscoveryV1(WatsonService):
         :param str environment_id: The ID of the environment.
         :param str name: The name of the collection to be created.
         :param str description: A description of the collection.
-        :param str configuration_id: The ID of the configuration in which the collection is to be created.
-        :param str language: The language of the documents stored in the collection, in the form of an ISO 639-1 language code.
+        :param str configuration_id: The ID of the configuration in which the collection
+        is to be created.
+        :param str language: The language of the documents stored in the collection, in
+        the form of an ISO 639-1 language code.
         :param dict headers: A `dict` containing the request headers
         :return: A `dict` containing the `Collection` response.
         :rtype: dict
@@ -763,7 +796,8 @@ class DiscoveryV1(WatsonService):
         :param str collection_id: The ID of the collection.
         :param str name: The name of the collection.
         :param str description: A description of the collection.
-        :param str configuration_id: The ID of the configuration in which the collection is to be updated.
+        :param str configuration_id: The ID of the configuration in which the collection
+        is to be updated.
         :param dict headers: A `dict` containing the request headers
         :return: A `dict` containing the `Collection` response.
         :rtype: dict
@@ -802,12 +836,22 @@ class DiscoveryV1(WatsonService):
         Create or update expansion list.
 
         Create or replace the Expansion list for this collection. The maximum number of
-        expanded terms per collection is `500`. The current expansion list is replaced
-        with the uploaded content.
+        expanded terms per collection is `500`.
+        The current expansion list is replaced with the uploaded content.
 
         :param str environment_id: The ID of the environment.
         :param str collection_id: The ID of the collection.
-        :param list[Expansion] expansions: An array of query expansion definitions.    Each object in the `expansions` array represents a term or set of terms that will be expanded into other terms. Each expansion object can be configured so that all terms are expanded to all other terms in the object - bi-directional, or a set list of terms can be expanded into a second list of terms - uni-directional.   To create a bi-directional expansion specify an `expanded_terms` array. When found in a query, all items in the `expanded_terms` array are then expanded to the other items in the same array.   To create a uni-directional expansion, specify both an array of `input_terms` and an array of `expanded_terms`. When items in the `input_terms` array are present in a query, they are expanded using the items listed in the `expanded_terms` array.
+        :param list[Expansion] expansions: An array of query expansion definitions.
+         Each object in the `expansions` array represents a term or set of terms that will
+        be expanded into other terms. Each expansion object can be configured so that all
+        terms are expanded to all other terms in the object - bi-directional, or a set
+        list of terms can be expanded into a second list of terms - uni-directional.
+         To create a bi-directional expansion specify an `expanded_terms` array. When
+        found in a query, all items in the `expanded_terms` array are then expanded to the
+        other items in the same array.
+         To create a uni-directional expansion, specify both an array of `input_terms` and
+        an array of `expanded_terms`. When items in the `input_terms` array are present in
+        a query, they are expanded using the items listed in the `expanded_terms` array.
         :param dict headers: A `dict` containing the request headers
         :return: A `dict` containing the `Expansions` response.
         :rtype: dict
@@ -911,25 +955,35 @@ class DiscoveryV1(WatsonService):
         """
         Add a document.
 
-        Add a document to a collection with optional metadata.    * The `version` query
-        parameter is still required.    * Returns immediately after the system has
-        accepted the document for processing.    * The user must provide document content,
-        metadata, or both. If the request is missing both document content and metadata,
-        it is rejected.    * The user can set the `Content-Type` parameter on the `file`
-        part to indicate the media type of the document. If the `Content-Type` parameter
-        is missing or is one of the generic media types (for example,
-        `application/octet-stream`), then the service attempts to automatically detect the
-        document's media type.    * The following field names are reserved and will be
-        filtered out if present after normalization: `id`, `score`, `highlight`, and any
-        field with the prefix of: `_`, `+`, or `-`    * Fields with empty name values
-        after normalization are filtered out before indexing.    * Fields containing the
-        following characters after normalization are filtered out before indexing: `#` and
-        `,`.
+        Add a document to a collection with optional metadata.
+          * The `version` query parameter is still required.
+          * Returns immediately after the system has accepted the document for processing.
+          * The user must provide document content, metadata, or both. If the request is
+        missing both document content and metadata, it is rejected.
+          * The user can set the `Content-Type` parameter on the `file` part to indicate
+        the media type of the document. If the `Content-Type` parameter is missing or is
+        one of the generic media types (for example, `application/octet-stream`), then the
+        service attempts to automatically detect the document's media type.
+          * The following field names are reserved and will be filtered out if present
+        after normalization: `id`, `score`, `highlight`, and any field with the prefix of:
+        `_`, `+`, or `-`
+          * Fields with empty name values after normalization are filtered out before
+        indexing.
+          * Fields containing the following characters after normalization are filtered
+        out before indexing: `#` and `,`.
 
         :param str environment_id: The ID of the environment.
         :param str collection_id: The ID of the collection.
-        :param file file: The content of the document to ingest. The maximum supported file size is 50 megabytes. Files larger than 50 megabytes is rejected.
-        :param str metadata: If you're using the Data Crawler to upload your documents, you can test a document against the type of metadata that the Data Crawler might send. The maximum supported metadata file size is 1 MB. Metadata parts larger than 1 MB are rejected. Example:  ``` {   \"Creator\": \"Johnny Appleseed\",   \"Subject\": \"Apples\" } ```.
+        :param file file: The content of the document to ingest. The maximum supported
+        file size is 50 megabytes. Files larger than 50 megabytes is rejected.
+        :param str metadata: If you're using the Data Crawler to upload your documents,
+        you can test a document against the type of metadata that the Data Crawler might
+        send. The maximum supported metadata file size is 1 MB. Metadata parts larger than
+        1 MB are rejected.
+        Example:  ``` {
+          \"Creator\": \"Johnny Appleseed\",
+          \"Subject\": \"Apples\"
+        } ```.
         :param str file_content_type: The content type of file.
         :param str filename: The filename for file.
         :param dict headers: A `dict` containing the request headers
@@ -1059,8 +1113,16 @@ class DiscoveryV1(WatsonService):
         :param str environment_id: The ID of the environment.
         :param str collection_id: The ID of the collection.
         :param str document_id: The ID of the document.
-        :param file file: The content of the document to ingest. The maximum supported file size is 50 megabytes. Files larger than 50 megabytes is rejected.
-        :param str metadata: If you're using the Data Crawler to upload your documents, you can test a document against the type of metadata that the Data Crawler might send. The maximum supported metadata file size is 1 MB. Metadata parts larger than 1 MB are rejected. Example:  ``` {   \"Creator\": \"Johnny Appleseed\",   \"Subject\": \"Apples\" } ```.
+        :param file file: The content of the document to ingest. The maximum supported
+        file size is 50 megabytes. Files larger than 50 megabytes is rejected.
+        :param str metadata: If you're using the Data Crawler to upload your documents,
+        you can test a document against the type of metadata that the Data Crawler might
+        send. The maximum supported metadata file size is 1 MB. Metadata parts larger than
+        1 MB are rejected.
+        Example:  ``` {
+          \"Creator\": \"Johnny Appleseed\",
+          \"Subject\": \"Apples\"
+        } ```.
         :param str file_content_type: The content type of file.
         :param str filename: The filename for file.
         :param dict headers: A `dict` containing the request headers
@@ -1131,21 +1193,57 @@ class DiscoveryV1(WatsonService):
         more details.
 
         :param str environment_id: The ID of the environment.
-        :param list[str] collection_ids: A comma-separated list of collection IDs to be queried against.
-        :param str filter: A cacheable query that limits the documents returned to exclude any documents that don't mention the query content. Filter searches are better for metadata type searches and when you are trying to get a sense of concepts in the data set.
-        :param str query: A query search returns all documents in your data set with full enrichments and full text, but with the most relevant documents listed first. Use a query search when you want to find the most relevant search results. You cannot use `natural_language_query` and `query` at the same time.
-        :param str natural_language_query: A natural language query that returns relevant documents by utilizing training data and natural language understanding. You cannot use `natural_language_query` and `query` at the same time.
-        :param str aggregation: An aggregation search uses combinations of filters and query search to return an exact answer. Aggregations are useful for building applications, because you can use them to build lists, tables, and time series. For a full list of possible aggregrations, see the Query reference.
+        :param list[str] collection_ids: A comma-separated list of collection IDs to be
+        queried against.
+        :param str filter: A cacheable query that limits the documents returned to exclude
+        any documents that don't mention the query content. Filter searches are better for
+        metadata type searches and when you are trying to get a sense of concepts in the
+        data set.
+        :param str query: A query search returns all documents in your data set with full
+        enrichments and full text, but with the most relevant documents listed first. Use
+        a query search when you want to find the most relevant search results. You cannot
+        use `natural_language_query` and `query` at the same time.
+        :param str natural_language_query: A natural language query that returns relevant
+        documents by utilizing training data and natural language understanding. You
+        cannot use `natural_language_query` and `query` at the same time.
+        :param str aggregation: An aggregation search uses combinations of filters and
+        query search to return an exact answer. Aggregations are useful for building
+        applications, because you can use them to build lists, tables, and time series.
+        For a full list of possible aggregrations, see the Query reference.
         :param int count: Number of documents to return.
-        :param list[str] return_fields: A comma separated list of the portion of the document hierarchy to return.
-        :param int offset: The number of query results to skip at the beginning. For example, if the total number of results that are returned is 10, and the offset is 8, it returns the last two results.
-        :param list[str] sort: A comma separated list of fields in the document to sort on. You can optionally specify a sort direction by prefixing the field with `-` for descending or `+` for ascending. Ascending is the default sort direction if no prefix is specified.
-        :param bool highlight: When true a highlight field is returned for each result which contains the fields that match the query with `<em></em>` tags around the matching query terms. Defaults to false.
-        :param bool deduplicate: When `true` and used with a Watson Discovery News collection, duplicate results (based on the contents of the `title` field) are removed. Duplicate comparison is limited to the current query only, `offset` is not considered. Defaults to `false`. This parameter is currently Beta functionality.
-        :param str deduplicate_field: When specified, duplicate results based on the field specified are removed from the returned results. Duplicate comparison is limited to the current query only, `offset` is not considered. This parameter is currently Beta functionality.
-        :param bool similar: When `true`, results are returned based on their similarity to the document IDs specified in the `similar.document_ids` parameter. The default is `false`.
-        :param list[str] similar_document_ids: A comma-separated list of document IDs that will be used to find similar documents.   **Note:** If the `natural_language_query` parameter is also specified, it will be used to expand the scope of the document similarity search to include the natural language query. Other query parameters, such as `filter` and `query` are subsequently applied and reduce the query scope.
-        :param list[str] similar_fields: A comma-separated list of field names that will be used as a basis for comparison to identify similar documents. If not specified, the entire document is used for comparison.
+        :param list[str] return_fields: A comma separated list of the portion of the
+        document hierarchy to return.
+        :param int offset: The number of query results to skip at the beginning. For
+        example, if the total number of results that are returned is 10, and the offset is
+        8, it returns the last two results.
+        :param list[str] sort: A comma separated list of fields in the document to sort
+        on. You can optionally specify a sort direction by prefixing the field with `-`
+        for descending or `+` for ascending. Ascending is the default sort direction if no
+        prefix is specified.
+        :param bool highlight: When true a highlight field is returned for each result
+        which contains the fields that match the query with `<em></em>` tags around the
+        matching query terms. Defaults to false.
+        :param bool deduplicate: When `true` and used with a Watson Discovery News
+        collection, duplicate results (based on the contents of the `title` field) are
+        removed. Duplicate comparison is limited to the current query only, `offset` is
+        not considered. Defaults to `false`. This parameter is currently Beta
+        functionality.
+        :param str deduplicate_field: When specified, duplicate results based on the field
+        specified are removed from the returned results. Duplicate comparison is limited
+        to the current query only, `offset` is not considered. This parameter is currently
+        Beta functionality.
+        :param bool similar: When `true`, results are returned based on their similarity
+        to the document IDs specified in the `similar.document_ids` parameter. The default
+        is `false`.
+        :param list[str] similar_document_ids: A comma-separated list of document IDs that
+        will be used to find similar documents.
+        **Note:** If the `natural_language_query` parameter is also specified, it will be
+        used to expand the scope of the document similarity search to include the natural
+        language query. Other query parameters, such as `filter` and `query` are
+        subsequently applied and reduce the query scope.
+        :param list[str] similar_fields: A comma-separated list of field names that will
+        be used as a basis for comparison to identify similar documents. If not specified,
+        the entire document is used for comparison.
         :param dict headers: A `dict` containing the request headers
         :return: A `dict` containing the `QueryResponse` response.
         :rtype: dict
@@ -1212,20 +1310,52 @@ class DiscoveryV1(WatsonService):
         more details on the query language.
 
         :param str environment_id: The ID of the environment.
-        :param list[str] collection_ids: A comma-separated list of collection IDs to be queried against.
-        :param str filter: A cacheable query that limits the documents returned to exclude any documents that don't mention the query content. Filter searches are better for metadata type searches and when you are trying to get a sense of concepts in the data set.
-        :param str query: A query search returns all documents in your data set with full enrichments and full text, but with the most relevant documents listed first. Use a query search when you want to find the most relevant search results. You cannot use `natural_language_query` and `query` at the same time.
-        :param str natural_language_query: A natural language query that returns relevant documents by utilizing training data and natural language understanding. You cannot use `natural_language_query` and `query` at the same time.
-        :param str aggregation: An aggregation search uses combinations of filters and query search to return an exact answer. Aggregations are useful for building applications, because you can use them to build lists, tables, and time series. For a full list of possible aggregrations, see the Query reference.
+        :param list[str] collection_ids: A comma-separated list of collection IDs to be
+        queried against.
+        :param str filter: A cacheable query that limits the documents returned to exclude
+        any documents that don't mention the query content. Filter searches are better for
+        metadata type searches and when you are trying to get a sense of concepts in the
+        data set.
+        :param str query: A query search returns all documents in your data set with full
+        enrichments and full text, but with the most relevant documents listed first. Use
+        a query search when you want to find the most relevant search results. You cannot
+        use `natural_language_query` and `query` at the same time.
+        :param str natural_language_query: A natural language query that returns relevant
+        documents by utilizing training data and natural language understanding. You
+        cannot use `natural_language_query` and `query` at the same time.
+        :param str aggregation: An aggregation search uses combinations of filters and
+        query search to return an exact answer. Aggregations are useful for building
+        applications, because you can use them to build lists, tables, and time series.
+        For a full list of possible aggregrations, see the Query reference.
         :param int count: Number of documents to return.
-        :param list[str] return_fields: A comma separated list of the portion of the document hierarchy to return.
-        :param int offset: The number of query results to skip at the beginning. For example, if the total number of results that are returned is 10, and the offset is 8, it returns the last two results.
-        :param list[str] sort: A comma separated list of fields in the document to sort on. You can optionally specify a sort direction by prefixing the field with `-` for descending or `+` for ascending. Ascending is the default sort direction if no prefix is specified.
-        :param bool highlight: When true a highlight field is returned for each result which contains the fields that match the query with `<em></em>` tags around the matching query terms. Defaults to false.
-        :param str deduplicate_field: When specified, duplicate results based on the field specified are removed from the returned results. Duplicate comparison is limited to the current query only, `offset` is not considered. This parameter is currently Beta functionality.
-        :param bool similar: When `true`, results are returned based on their similarity to the document IDs specified in the `similar.document_ids` parameter. The default is `false`.
-        :param list[str] similar_document_ids: A comma-separated list of document IDs that will be used to find similar documents.   **Note:** If the `natural_language_query` parameter is also specified, it will be used to expand the scope of the document similarity search to include the natural language query. Other query parameters, such as `filter` and `query` are subsequently applied and reduce the query scope.
-        :param list[str] similar_fields: A comma-separated list of field names that will be used as a basis for comparison to identify similar documents. If not specified, the entire document is used for comparison.
+        :param list[str] return_fields: A comma separated list of the portion of the
+        document hierarchy to return.
+        :param int offset: The number of query results to skip at the beginning. For
+        example, if the total number of results that are returned is 10, and the offset is
+        8, it returns the last two results.
+        :param list[str] sort: A comma separated list of fields in the document to sort
+        on. You can optionally specify a sort direction by prefixing the field with `-`
+        for descending or `+` for ascending. Ascending is the default sort direction if no
+        prefix is specified.
+        :param bool highlight: When true a highlight field is returned for each result
+        which contains the fields that match the query with `<em></em>` tags around the
+        matching query terms. Defaults to false.
+        :param str deduplicate_field: When specified, duplicate results based on the field
+        specified are removed from the returned results. Duplicate comparison is limited
+        to the current query only, `offset` is not considered. This parameter is currently
+        Beta functionality.
+        :param bool similar: When `true`, results are returned based on their similarity
+        to the document IDs specified in the `similar.document_ids` parameter. The default
+        is `false`.
+        :param list[str] similar_document_ids: A comma-separated list of document IDs that
+        will be used to find similar documents.
+        **Note:** If the `natural_language_query` parameter is also specified, it will be
+        used to expand the scope of the document similarity search to include the natural
+        language query. Other query parameters, such as `filter` and `query` are
+        subsequently applied and reduce the query scope.
+        :param list[str] similar_fields: A comma-separated list of field names that will
+        be used as a basis for comparison to identify similar documents. If not specified,
+        the entire document is used for comparison.
         :param dict headers: A `dict` containing the request headers
         :return: A `dict` containing the `QueryNoticesResponse` response.
         :rtype: dict
@@ -1295,24 +1425,66 @@ class DiscoveryV1(WatsonService):
 
         :param str environment_id: The ID of the environment.
         :param str collection_id: The ID of the collection.
-        :param str filter: A cacheable query that limits the documents returned to exclude any documents that don't mention the query content. Filter searches are better for metadata type searches and when you are trying to get a sense of concepts in the data set.
-        :param str query: A query search returns all documents in your data set with full enrichments and full text, but with the most relevant documents listed first. Use a query search when you want to find the most relevant search results. You cannot use `natural_language_query` and `query` at the same time.
-        :param str natural_language_query: A natural language query that returns relevant documents by utilizing training data and natural language understanding. You cannot use `natural_language_query` and `query` at the same time.
-        :param bool passages: A passages query that returns the most relevant passages from the results.
-        :param str aggregation: An aggregation search uses combinations of filters and query search to return an exact answer. Aggregations are useful for building applications, because you can use them to build lists, tables, and time series. For a full list of possible aggregrations, see the Query reference.
+        :param str filter: A cacheable query that limits the documents returned to exclude
+        any documents that don't mention the query content. Filter searches are better for
+        metadata type searches and when you are trying to get a sense of concepts in the
+        data set.
+        :param str query: A query search returns all documents in your data set with full
+        enrichments and full text, but with the most relevant documents listed first. Use
+        a query search when you want to find the most relevant search results. You cannot
+        use `natural_language_query` and `query` at the same time.
+        :param str natural_language_query: A natural language query that returns relevant
+        documents by utilizing training data and natural language understanding. You
+        cannot use `natural_language_query` and `query` at the same time.
+        :param bool passages: A passages query that returns the most relevant passages
+        from the results.
+        :param str aggregation: An aggregation search uses combinations of filters and
+        query search to return an exact answer. Aggregations are useful for building
+        applications, because you can use them to build lists, tables, and time series.
+        For a full list of possible aggregrations, see the Query reference.
         :param int count: Number of documents to return.
-        :param list[str] return_fields: A comma separated list of the portion of the document hierarchy to return.
-        :param int offset: The number of query results to skip at the beginning. For example, if the total number of results that are returned is 10, and the offset is 8, it returns the last two results.
-        :param list[str] sort: A comma separated list of fields in the document to sort on. You can optionally specify a sort direction by prefixing the field with `-` for descending or `+` for ascending. Ascending is the default sort direction if no prefix is specified.
-        :param bool highlight: When true a highlight field is returned for each result which contains the fields that match the query with `<em></em>` tags around the matching query terms. Defaults to false.
-        :param list[str] passages_fields: A comma-separated list of fields that passages are drawn from. If this parameter not specified, then all top-level fields are included.
-        :param int passages_count: The maximum number of passages to return. The search returns fewer passages if the requested total is not found. The default is `10`. The maximum is `100`.
-        :param int passages_characters: The approximate number of characters that any one passage will have. The default is `400`. The minimum is `50`. The maximum is `2000`.
-        :param bool deduplicate: When `true` and used with a Watson Discovery News collection, duplicate results (based on the contents of the `title` field) are removed. Duplicate comparison is limited to the current query only, `offset` is not considered. Defaults to `false`. This parameter is currently Beta functionality.
-        :param str deduplicate_field: When specified, duplicate results based on the field specified are removed from the returned results. Duplicate comparison is limited to the current query only, `offset` is not considered. This parameter is currently Beta functionality.
-        :param bool similar: When `true`, results are returned based on their similarity to the document IDs specified in the `similar.document_ids` parameter. The default is `false`.
-        :param list[str] similar_document_ids: A comma-separated list of document IDs that will be used to find similar documents.   **Note:** If the `natural_language_query` parameter is also specified, it will be used to expand the scope of the document similarity search to include the natural language query. Other query parameters, such as `filter` and `query` are subsequently applied and reduce the query scope.
-        :param list[str] similar_fields: A comma-separated list of field names that will be used as a basis for comparison to identify similar documents. If not specified, the entire document is used for comparison.
+        :param list[str] return_fields: A comma separated list of the portion of the
+        document hierarchy to return.
+        :param int offset: The number of query results to skip at the beginning. For
+        example, if the total number of results that are returned is 10, and the offset is
+        8, it returns the last two results.
+        :param list[str] sort: A comma separated list of fields in the document to sort
+        on. You can optionally specify a sort direction by prefixing the field with `-`
+        for descending or `+` for ascending. Ascending is the default sort direction if no
+        prefix is specified.
+        :param bool highlight: When true a highlight field is returned for each result
+        which contains the fields that match the query with `<em></em>` tags around the
+        matching query terms. Defaults to false.
+        :param list[str] passages_fields: A comma-separated list of fields that passages
+        are drawn from. If this parameter not specified, then all top-level fields are
+        included.
+        :param int passages_count: The maximum number of passages to return. The search
+        returns fewer passages if the requested total is not found. The default is `10`.
+        The maximum is `100`.
+        :param int passages_characters: The approximate number of characters that any one
+        passage will have. The default is `400`. The minimum is `50`. The maximum is
+        `2000`.
+        :param bool deduplicate: When `true` and used with a Watson Discovery News
+        collection, duplicate results (based on the contents of the `title` field) are
+        removed. Duplicate comparison is limited to the current query only, `offset` is
+        not considered. Defaults to `false`. This parameter is currently Beta
+        functionality.
+        :param str deduplicate_field: When specified, duplicate results based on the field
+        specified are removed from the returned results. Duplicate comparison is limited
+        to the current query only, `offset` is not considered. This parameter is currently
+        Beta functionality.
+        :param bool similar: When `true`, results are returned based on their similarity
+        to the document IDs specified in the `similar.document_ids` parameter. The default
+        is `false`.
+        :param list[str] similar_document_ids: A comma-separated list of document IDs that
+        will be used to find similar documents.
+        **Note:** If the `natural_language_query` parameter is also specified, it will be
+        used to expand the scope of the document similarity search to include the natural
+        language query. Other query parameters, such as `filter` and `query` are
+        subsequently applied and reduce the query scope.
+        :param list[str] similar_fields: A comma-separated list of field names that will
+        be used as a basis for comparison to identify similar documents. If not specified,
+        the entire document is used for comparison.
         :param dict headers: A `dict` containing the request headers
         :return: A `dict` containing the `QueryResponse` response.
         :rtype: dict
@@ -1373,11 +1545,18 @@ class DiscoveryV1(WatsonService):
 
         :param str environment_id: The ID of the environment.
         :param str collection_id: The ID of the collection.
-        :param str feature: The entity query feature to perform. Supported features are `disambiguate` and `similar_entities`.
-        :param QueryEntitiesEntity entity: A text string that appears within the entity text field.
-        :param QueryEntitiesContext context: Entity text to provide context for the queried entity and rank based on that association. For example, if you wanted to query the city of London in England your query would look for `London` with the context of `England`.
-        :param int count: The number of results to return. The default is `10`. The maximum is `1000`.
-        :param int evidence_count: The number of evidence items to return for each result. The default is `0`. The maximum number of evidence items per query is 10,000.
+        :param str feature: The entity query feature to perform. Supported features are
+        `disambiguate` and `similar_entities`.
+        :param QueryEntitiesEntity entity: A text string that appears within the entity
+        text field.
+        :param QueryEntitiesContext context: Entity text to provide context for the
+        queried entity and rank based on that association. For example, if you wanted to
+        query the city of London in England your query would look for `London` with the
+        context of `England`.
+        :param int count: The number of results to return. The default is `10`. The
+        maximum is `1000`.
+        :param int evidence_count: The number of evidence items to return for each result.
+        The default is `0`. The maximum number of evidence items per query is 10,000.
         :param dict headers: A `dict` containing the request headers
         :return: A `dict` containing the `QueryEntitiesResponse` response.
         :rtype: dict
@@ -1444,23 +1623,61 @@ class DiscoveryV1(WatsonService):
 
         :param str environment_id: The ID of the environment.
         :param str collection_id: The ID of the collection.
-        :param str filter: A cacheable query that limits the documents returned to exclude any documents that don't mention the query content. Filter searches are better for metadata type searches and when you are trying to get a sense of concepts in the data set.
-        :param str query: A query search returns all documents in your data set with full enrichments and full text, but with the most relevant documents listed first. Use a query search when you want to find the most relevant search results. You cannot use `natural_language_query` and `query` at the same time.
-        :param str natural_language_query: A natural language query that returns relevant documents by utilizing training data and natural language understanding. You cannot use `natural_language_query` and `query` at the same time.
-        :param bool passages: A passages query that returns the most relevant passages from the results.
-        :param str aggregation: An aggregation search uses combinations of filters and query search to return an exact answer. Aggregations are useful for building applications, because you can use them to build lists, tables, and time series. For a full list of possible aggregrations, see the Query reference.
+        :param str filter: A cacheable query that limits the documents returned to exclude
+        any documents that don't mention the query content. Filter searches are better for
+        metadata type searches and when you are trying to get a sense of concepts in the
+        data set.
+        :param str query: A query search returns all documents in your data set with full
+        enrichments and full text, but with the most relevant documents listed first. Use
+        a query search when you want to find the most relevant search results. You cannot
+        use `natural_language_query` and `query` at the same time.
+        :param str natural_language_query: A natural language query that returns relevant
+        documents by utilizing training data and natural language understanding. You
+        cannot use `natural_language_query` and `query` at the same time.
+        :param bool passages: A passages query that returns the most relevant passages
+        from the results.
+        :param str aggregation: An aggregation search uses combinations of filters and
+        query search to return an exact answer. Aggregations are useful for building
+        applications, because you can use them to build lists, tables, and time series.
+        For a full list of possible aggregrations, see the Query reference.
         :param int count: Number of documents to return.
-        :param list[str] return_fields: A comma separated list of the portion of the document hierarchy to return.
-        :param int offset: The number of query results to skip at the beginning. For example, if the total number of results that are returned is 10, and the offset is 8, it returns the last two results.
-        :param list[str] sort: A comma separated list of fields in the document to sort on. You can optionally specify a sort direction by prefixing the field with `-` for descending or `+` for ascending. Ascending is the default sort direction if no prefix is specified.
-        :param bool highlight: When true a highlight field is returned for each result which contains the fields that match the query with `<em></em>` tags around the matching query terms. Defaults to false.
-        :param list[str] passages_fields: A comma-separated list of fields that passages are drawn from. If this parameter not specified, then all top-level fields are included.
-        :param int passages_count: The maximum number of passages to return. The search returns fewer passages if the requested total is not found. The default is `10`. The maximum is `100`.
-        :param int passages_characters: The approximate number of characters that any one passage will have. The default is `400`. The minimum is `50`. The maximum is `2000`.
-        :param str deduplicate_field: When specified, duplicate results based on the field specified are removed from the returned results. Duplicate comparison is limited to the current query only, `offset` is not considered. This parameter is currently Beta functionality.
-        :param bool similar: When `true`, results are returned based on their similarity to the document IDs specified in the `similar.document_ids` parameter. The default is `false`.
-        :param list[str] similar_document_ids: A comma-separated list of document IDs that will be used to find similar documents.   **Note:** If the `natural_language_query` parameter is also specified, it will be used to expand the scope of the document similarity search to include the natural language query. Other query parameters, such as `filter` and `query` are subsequently applied and reduce the query scope.
-        :param list[str] similar_fields: A comma-separated list of field names that will be used as a basis for comparison to identify similar documents. If not specified, the entire document is used for comparison.
+        :param list[str] return_fields: A comma separated list of the portion of the
+        document hierarchy to return.
+        :param int offset: The number of query results to skip at the beginning. For
+        example, if the total number of results that are returned is 10, and the offset is
+        8, it returns the last two results.
+        :param list[str] sort: A comma separated list of fields in the document to sort
+        on. You can optionally specify a sort direction by prefixing the field with `-`
+        for descending or `+` for ascending. Ascending is the default sort direction if no
+        prefix is specified.
+        :param bool highlight: When true a highlight field is returned for each result
+        which contains the fields that match the query with `<em></em>` tags around the
+        matching query terms. Defaults to false.
+        :param list[str] passages_fields: A comma-separated list of fields that passages
+        are drawn from. If this parameter not specified, then all top-level fields are
+        included.
+        :param int passages_count: The maximum number of passages to return. The search
+        returns fewer passages if the requested total is not found. The default is `10`.
+        The maximum is `100`.
+        :param int passages_characters: The approximate number of characters that any one
+        passage will have. The default is `400`. The minimum is `50`. The maximum is
+        `2000`.
+        :param str deduplicate_field: When specified, duplicate results based on the field
+        specified are removed from the returned results. Duplicate comparison is limited
+        to the current query only, `offset` is not considered. This parameter is currently
+        Beta functionality.
+        :param bool similar: When `true`, results are returned based on their similarity
+        to the document IDs specified in the `similar.document_ids` parameter. The default
+        is `false`.
+        :param list[str] similar_document_ids: A comma-separated list of document IDs that
+        will be used to find similar documents.
+        **Note:** If the `natural_language_query` parameter is also specified, it will be
+        used to expand the scope of the document similarity search to include the natural
+        language query. Other query parameters, such as `filter` and `query` are
+        subsequently applied and reduce the query scope.
+        :param list[str] similar_fields: A comma-separated list of field names that will
+        be used as a basis for comparison to identify similar documents. If not specified,
+        the entire document is used for comparison.
         :param dict headers: A `dict` containing the request headers
         :return: A `dict` containing the `QueryNoticesResponse` response.
         :rtype: dict
@@ -1521,12 +1738,20 @@ class DiscoveryV1(WatsonService):
 
         :param str environment_id: The ID of the environment.
         :param str collection_id: The ID of the collection.
-        :param list[QueryRelationsEntity] entities: An array of entities to find relationships for.
-        :param QueryEntitiesContext context: Entity text to provide context for the queried entity and rank based on that association. For example, if you wanted to query the city of London in England your query would look for `London` with the context of `England`.
-        :param str sort: The sorting method for the relationships, can be `score` or `frequency`. `frequency` is the number of unique times each entity is identified. The default is `score`.
+        :param list[QueryRelationsEntity] entities: An array of entities to find
+        relationships for.
+        :param QueryEntitiesContext context: Entity text to provide context for the
+        queried entity and rank based on that association. For example, if you wanted to
+        query the city of London in England your query would look for `London` with the
+        context of `England`.
+        :param str sort: The sorting method for the relationships, can be `score` or
+        `frequency`. `frequency` is the number of unique times each entity is identified.
+        The default is `score`.
         :param QueryRelationsFilter filter: Filters to apply to the relationship query.
-        :param int count: The number of results to return. The default is `10`. The maximum is `1000`.
-        :param int evidence_count: The number of evidence items to return for each result. The default is `0`. The maximum number of evidence items per query is 10,000.
+        :param int count: The number of results to return. The default is `10`. The
+        maximum is `1000`.
+        :param int evidence_count: The number of evidence items to return for each result.
+        The default is `0`. The maximum number of evidence items per query is 10,000.
         :param dict headers: A `dict` containing the request headers
         :return: A `dict` containing the `QueryRelationsResponse` response.
         :rtype: dict
@@ -1964,9 +2189,10 @@ class DiscoveryV1(WatsonService):
         Delete labeled data.
 
         Deletes all data associated with a specified customer ID. The method has no effect
-        if no data is associated with the customer ID.   You associate a customer ID with
-        data by passing the **X-Watson-Metadata** header with a request that passes data.
-        For more information about personal data and customer IDs, see [Information
+        if no data is associated with the customer ID.
+        You associate a customer ID with data by passing the **X-Watson-Metadata** header
+        with a request that passes data. For more information about personal data and
+        customer IDs, see [Information
         security](https://console.bluemix.net/docs/services/discovery/information-security.html).
 
         :param str customer_id: The customer ID for which all data is to be deleted.
@@ -2000,7 +2226,8 @@ class AggregationResult(object):
 
     :attr str key: (optional) Key that matched the aggregation type.
     :attr int matching_results: (optional) Number of matching results.
-    :attr list[QueryAggregation] aggregations: (optional) Aggregations returned in the case of chained aggregations.
+    :attr list[QueryAggregation] aggregations: (optional) Aggregations returned in the
+    case of chained aggregations.
     """
 
     def __init__(self, key=None, matching_results=None, aggregations=None):
@@ -2009,7 +2236,8 @@ class AggregationResult(object):
 
         :param str key: (optional) Key that matched the aggregation type.
         :param int matching_results: (optional) Number of matching results.
-        :param list[QueryAggregation] aggregations: (optional) Aggregations returned in the case of chained aggregations.
+        :param list[QueryAggregation] aggregations: (optional) Aggregations returned in
+        the case of chained aggregations.
         """
         self.key = key
         self.matching_results = matching_results
@@ -2064,14 +2292,23 @@ class Collection(object):
     :attr str collection_id: (optional) The unique identifier of the collection.
     :attr str name: (optional) The name of the collection.
     :attr str description: (optional) The description of the collection.
-    :attr datetime created: (optional) The creation date of the collection in the format yyyy-MM-dd'T'HH:mmcon:ss.SSS'Z'.
-    :attr datetime updated: (optional) The timestamp of when the collection was last updated in the format yyyy-MM-dd'T'HH:mm:ss.SSS'Z'.
+    :attr datetime created: (optional) The creation date of the collection in the format
+    yyyy-MM-dd'T'HH:mmcon:ss.SSS'Z'.
+    :attr datetime updated: (optional) The timestamp of when the collection was last
+    updated in the format yyyy-MM-dd'T'HH:mm:ss.SSS'Z'.
     :attr str status: (optional) The status of the collection.
-    :attr str configuration_id: (optional) The unique identifier of the collection's configuration.
-    :attr str language: (optional) The language of the documents stored in the collection. Permitted values include `en` (English), `de` (German), and `es` (Spanish).
-    :attr DocumentCounts document_counts: (optional) The object providing information about the documents in the collection. Present only when retrieving details of a collection.
-    :attr CollectionDiskUsage disk_usage: (optional) The object providing information about the disk usage of the collection. Present only when retrieving details of a collection.
-    :attr TrainingStatus training_status: (optional) Provides information about the status of relevance training for collection.
+    :attr str configuration_id: (optional) The unique identifier of the collection's
+    configuration.
+    :attr str language: (optional) The language of the documents stored in the collection.
+    Permitted values include `en` (English), `de` (German), and `es` (Spanish).
+    :attr DocumentCounts document_counts: (optional) The object providing information
+    about the documents in the collection. Present only when retrieving details of a
+    collection.
+    :attr CollectionDiskUsage disk_usage: (optional) The object providing information
+    about the disk usage of the collection. Present only when retrieving details of a
+    collection.
+    :attr TrainingStatus training_status: (optional) Provides information about the status
+    of relevance training for collection.
     """
 
     def __init__(self,
@@ -2092,14 +2329,24 @@ class Collection(object):
         :param str collection_id: (optional) The unique identifier of the collection.
         :param str name: (optional) The name of the collection.
         :param str description: (optional) The description of the collection.
-        :param datetime created: (optional) The creation date of the collection in the format yyyy-MM-dd'T'HH:mmcon:ss.SSS'Z'.
-        :param datetime updated: (optional) The timestamp of when the collection was last updated in the format yyyy-MM-dd'T'HH:mm:ss.SSS'Z'.
+        :param datetime created: (optional) The creation date of the collection in the
+        format yyyy-MM-dd'T'HH:mmcon:ss.SSS'Z'.
+        :param datetime updated: (optional) The timestamp of when the collection was last
+        updated in the format yyyy-MM-dd'T'HH:mm:ss.SSS'Z'.
         :param str status: (optional) The status of the collection.
-        :param str configuration_id: (optional) The unique identifier of the collection's configuration.
-        :param str language: (optional) The language of the documents stored in the collection. Permitted values include `en` (English), `de` (German), and `es` (Spanish).
-        :param DocumentCounts document_counts: (optional) The object providing information about the documents in the collection. Present only when retrieving details of a collection.
-        :param CollectionDiskUsage disk_usage: (optional) The object providing information about the disk usage of the collection. Present only when retrieving details of a collection.
-        :param TrainingStatus training_status: (optional) Provides information about the status of relevance training for collection.
+        :param str configuration_id: (optional) The unique identifier of the collection's
+        configuration.
+        :param str language: (optional) The language of the documents stored in the
+        collection. Permitted values include `en` (English), `de` (German), and `es`
+        (Spanish).
+        :param DocumentCounts document_counts: (optional) The object providing information
+        about the documents in the collection. Present only when retrieving details of a
+        collection.
+        :param CollectionDiskUsage disk_usage: (optional) The object providing information
+        about the disk usage of the collection. Present only when retrieving details of a
+        collection.
+        :param TrainingStatus training_status: (optional) Provides information about the
+        status of relevance training for collection.
         """
         self.collection_id = collection_id
         self.name = name
@@ -2239,7 +2486,8 @@ class CollectionUsage(object):
     Summary of the collection usage in the environment.
 
     :attr int available: (optional) Number of active collections in the environment.
-    :attr int maximum_allowed: (optional) Total number of collections allowed in the environment.
+    :attr int maximum_allowed: (optional) Total number of collections allowed in the
+    environment.
     """
 
     def __init__(self, available=None, maximum_allowed=None):
@@ -2247,7 +2495,8 @@ class CollectionUsage(object):
         Initialize a CollectionUsage object.
 
         :param int available: (optional) Number of active collections in the environment.
-        :param int maximum_allowed: (optional) Total number of collections allowed in the environment.
+        :param int maximum_allowed: (optional) Total number of collections allowed in the
+        environment.
         """
         self.available = available
         self.maximum_allowed = maximum_allowed
@@ -2293,12 +2542,18 @@ class Configuration(object):
 
     :attr str configuration_id: (optional) The unique identifier of the configuration.
     :attr str name: The name of the configuration.
-    :attr datetime created: (optional) The creation date of the configuration in the format yyyy-MM-dd'T'HH:mm:ss.SSS'Z'.
-    :attr datetime updated: (optional) The timestamp of when the configuration was last updated in the format yyyy-MM-dd'T'HH:mm:ss.SSS'Z'.
+    :attr datetime created: (optional) The creation date of the configuration in the
+    format yyyy-MM-dd'T'HH:mm:ss.SSS'Z'.
+    :attr datetime updated: (optional) The timestamp of when the configuration was last
+    updated in the format yyyy-MM-dd'T'HH:mm:ss.SSS'Z'.
     :attr str description: (optional) The description of the configuration, if available.
-    :attr Conversions conversions: (optional) The document conversion settings for the configuration.
-    :attr list[Enrichment] enrichments: (optional) An array of document enrichment settings for the configuration.
-    :attr list[NormalizationOperation] normalizations: (optional) Defines operations that can be used to transform the final output JSON into a normalized form. Operations are executed in the order that they appear in the array.
+    :attr Conversions conversions: (optional) The document conversion settings for the
+    configuration.
+    :attr list[Enrichment] enrichments: (optional) An array of document enrichment
+    settings for the configuration.
+    :attr list[NormalizationOperation] normalizations: (optional) Defines operations that
+    can be used to transform the final output JSON into a normalized form. Operations are
+    executed in the order that they appear in the array.
     """
 
     def __init__(self,
@@ -2314,13 +2569,21 @@ class Configuration(object):
         Initialize a Configuration object.
 
         :param str name: The name of the configuration.
-        :param str configuration_id: (optional) The unique identifier of the configuration.
-        :param datetime created: (optional) The creation date of the configuration in the format yyyy-MM-dd'T'HH:mm:ss.SSS'Z'.
-        :param datetime updated: (optional) The timestamp of when the configuration was last updated in the format yyyy-MM-dd'T'HH:mm:ss.SSS'Z'.
-        :param str description: (optional) The description of the configuration, if available.
-        :param Conversions conversions: (optional) The document conversion settings for the configuration.
-        :param list[Enrichment] enrichments: (optional) An array of document enrichment settings for the configuration.
-        :param list[NormalizationOperation] normalizations: (optional) Defines operations that can be used to transform the final output JSON into a normalized form. Operations are executed in the order that they appear in the array.
+        :param str configuration_id: (optional) The unique identifier of the
+        configuration.
+        :param datetime created: (optional) The creation date of the configuration in the
+        format yyyy-MM-dd'T'HH:mm:ss.SSS'Z'.
+        :param datetime updated: (optional) The timestamp of when the configuration was
+        last updated in the format yyyy-MM-dd'T'HH:mm:ss.SSS'Z'.
+        :param str description: (optional) The description of the configuration, if
+        available.
+        :param Conversions conversions: (optional) The document conversion settings for
+        the configuration.
+        :param list[Enrichment] enrichments: (optional) An array of document enrichment
+        settings for the configuration.
+        :param list[NormalizationOperation] normalizations: (optional) Defines operations
+        that can be used to transform the final output JSON into a normalized form.
+        Operations are executed in the order that they appear in the array.
         """
         self.configuration_id = configuration_id
         self.name = name
@@ -2409,7 +2672,9 @@ class Conversions(object):
     :attr WordSettings word: (optional) A list of Word conversion settings.
     :attr HtmlSettings html: (optional) A list of HTML conversion settings.
     :attr SegmentSettings segment: (optional) A list of Document Segmentation settings.
-    :attr list[NormalizationOperation] json_normalizations: (optional) Defines operations that can be used to transform the final output JSON into a normalized form. Operations are executed in the order that they appear in the array.
+    :attr list[NormalizationOperation] json_normalizations: (optional) Defines operations
+    that can be used to transform the final output JSON into a normalized form. Operations
+    are executed in the order that they appear in the array.
     """
 
     def __init__(self,
@@ -2424,8 +2689,11 @@ class Conversions(object):
         :param PdfSettings pdf: (optional) A list of PDF conversion settings.
         :param WordSettings word: (optional) A list of Word conversion settings.
         :param HtmlSettings html: (optional) A list of HTML conversion settings.
-        :param SegmentSettings segment: (optional) A list of Document Segmentation settings.
-        :param list[NormalizationOperation] json_normalizations: (optional) Defines operations that can be used to transform the final output JSON into a normalized form. Operations are executed in the order that they appear in the array.
+        :param SegmentSettings segment: (optional) A list of Document Segmentation
+        settings.
+        :param list[NormalizationOperation] json_normalizations: (optional) Defines
+        operations that can be used to transform the final output JSON into a normalized
+        form. Operations are executed in the order that they appear in the array.
         """
         self.pdf = pdf
         self.word = word
@@ -2464,7 +2732,7 @@ class Conversions(object):
         if hasattr(self, 'segment') and self.segment is not None:
             _dict['segment'] = self.segment._to_dict()
         if hasattr(self, 'json_normalizations'
-                  ) and self.json_normalizations is not None:
+                   ) and self.json_normalizations is not None:
             _dict['json_normalizations'] = [
                 x._to_dict() for x in self.json_normalizations
             ]
@@ -2489,16 +2757,20 @@ class DeleteCollectionResponse(object):
     """
     DeleteCollectionResponse.
 
-    :attr str collection_id: The unique identifier of the collection that is being deleted.
-    :attr str status: The status of the collection. The status of a successful deletion operation is `deleted`.
+    :attr str collection_id: The unique identifier of the collection that is being
+    deleted.
+    :attr str status: The status of the collection. The status of a successful deletion
+    operation is `deleted`.
     """
 
     def __init__(self, collection_id, status):
         """
         Initialize a DeleteCollectionResponse object.
 
-        :param str collection_id: The unique identifier of the collection that is being deleted.
-        :param str status: The status of the collection. The status of a successful deletion operation is `deleted`.
+        :param str collection_id: The unique identifier of the collection that is being
+        deleted.
+        :param str status: The status of the collection. The status of a successful
+        deletion operation is `deleted`.
         """
         self.collection_id = collection_id
         self.status = status
@@ -2550,7 +2822,8 @@ class DeleteConfigurationResponse(object):
     DeleteConfigurationResponse.
 
     :attr str configuration_id: The unique identifier for the configuration.
-    :attr str status: Status of the configuration. A deleted configuration has the status deleted.
+    :attr str status: Status of the configuration. A deleted configuration has the status
+    deleted.
     :attr list[Notice] notices: (optional) An array of notice messages, if any.
     """
 
@@ -2559,7 +2832,8 @@ class DeleteConfigurationResponse(object):
         Initialize a DeleteConfigurationResponse object.
 
         :param str configuration_id: The unique identifier for the configuration.
-        :param str status: Status of the configuration. A deleted configuration has the status deleted.
+        :param str status: Status of the configuration. A deleted configuration has the
+        status deleted.
         :param list[Notice] notices: (optional) An array of notice messages, if any.
         """
         self.configuration_id = configuration_id
@@ -2620,7 +2894,8 @@ class DeleteDocumentResponse(object):
     DeleteDocumentResponse.
 
     :attr str document_id: (optional) The unique identifier of the document.
-    :attr str status: (optional) Status of the document. A deleted document has the status deleted.
+    :attr str status: (optional) Status of the document. A deleted document has the status
+    deleted.
     """
 
     def __init__(self, document_id=None, status=None):
@@ -2628,7 +2903,8 @@ class DeleteDocumentResponse(object):
         Initialize a DeleteDocumentResponse object.
 
         :param str document_id: (optional) The unique identifier of the document.
-        :param str status: (optional) Status of the document. A deleted document has the status deleted.
+        :param str status: (optional) Status of the document. A deleted document has the
+        status deleted.
         """
         self.document_id = document_id
         self.status = status
@@ -2731,12 +3007,18 @@ class DiskUsage(object):
     """
     Summary of the disk usage statistics for the environment.
 
-    :attr int used_bytes: (optional) Number of bytes used on the environment's disk capacity.
-    :attr int maximum_allowed_bytes: (optional) Total number of bytes available in the environment's disk capacity.
-    :attr int total_bytes: (optional) **Deprecated**: Total number of bytes available in the environment's disk capacity.
-    :attr str used: (optional) **Deprecated**: Amount of disk capacity used, in KB or GB format.
-    :attr str total: (optional) **Deprecated**: Total amount of the environment's disk capacity, in KB or GB format.
-    :attr float percent_used: (optional) **Deprecated**: Percentage of the environment's disk capacity that is being used.
+    :attr int used_bytes: (optional) Number of bytes used on the environment's disk
+    capacity.
+    :attr int maximum_allowed_bytes: (optional) Total number of bytes available in the
+    environment's disk capacity.
+    :attr int total_bytes: (optional) **Deprecated**: Total number of bytes available in
+    the environment's disk capacity.
+    :attr str used: (optional) **Deprecated**: Amount of disk capacity used, in KB or GB
+    format.
+    :attr str total: (optional) **Deprecated**: Total amount of the environment's disk
+    capacity, in KB or GB format.
+    :attr float percent_used: (optional) **Deprecated**: Percentage of the environment's
+    disk capacity that is being used.
     """
 
     def __init__(self,
@@ -2749,12 +3031,18 @@ class DiskUsage(object):
         """
         Initialize a DiskUsage object.
 
-        :param int used_bytes: (optional) Number of bytes used on the environment's disk capacity.
-        :param int maximum_allowed_bytes: (optional) Total number of bytes available in the environment's disk capacity.
-        :param int total_bytes: (optional) **Deprecated**: Total number of bytes available in the environment's disk capacity.
-        :param str used: (optional) **Deprecated**: Amount of disk capacity used, in KB or GB format.
-        :param str total: (optional) **Deprecated**: Total amount of the environment's disk capacity, in KB or GB format.
-        :param float percent_used: (optional) **Deprecated**: Percentage of the environment's disk capacity that is being used.
+        :param int used_bytes: (optional) Number of bytes used on the environment's disk
+        capacity.
+        :param int maximum_allowed_bytes: (optional) Total number of bytes available in
+        the environment's disk capacity.
+        :param int total_bytes: (optional) **Deprecated**: Total number of bytes available
+        in the environment's disk capacity.
+        :param str used: (optional) **Deprecated**: Amount of disk capacity used, in KB or
+        GB format.
+        :param str total: (optional) **Deprecated**: Total amount of the environment's
+        disk capacity, in KB or GB format.
+        :param float percent_used: (optional) **Deprecated**: Percentage of the
+        environment's disk capacity that is being used.
         """
         self.used_bytes = used_bytes
         self.maximum_allowed_bytes = maximum_allowed_bytes
@@ -2787,7 +3075,7 @@ class DiskUsage(object):
         if hasattr(self, 'used_bytes') and self.used_bytes is not None:
             _dict['used_bytes'] = self.used_bytes
         if hasattr(self, 'maximum_allowed_bytes'
-                  ) and self.maximum_allowed_bytes is not None:
+                   ) and self.maximum_allowed_bytes is not None:
             _dict['maximum_allowed_bytes'] = self.maximum_allowed_bytes
         if hasattr(self, 'total_bytes') and self.total_bytes is not None:
             _dict['total_bytes'] = self.total_bytes
@@ -2820,7 +3108,8 @@ class DocumentAccepted(object):
 
     :attr str document_id: (optional) The unique identifier of the ingested document.
     :attr str status: (optional) Status of the document in the ingestion process.
-    :attr list[Notice] notices: (optional) Array of notices produced by the document-ingestion process.
+    :attr list[Notice] notices: (optional) Array of notices produced by the
+    document-ingestion process.
     """
 
     def __init__(self, document_id=None, status=None, notices=None):
@@ -2829,7 +3118,8 @@ class DocumentAccepted(object):
 
         :param str document_id: (optional) The unique identifier of the ingested document.
         :param str status: (optional) Status of the document in the ingestion process.
-        :param list[Notice] notices: (optional) Array of notices produced by the document-ingestion process.
+        :param list[Notice] notices: (optional) Array of notices produced by the
+        document-ingestion process.
         """
         self.document_id = document_id
         self.status = status
@@ -2879,18 +3169,24 @@ class DocumentCounts(object):
     """
     DocumentCounts.
 
-    :attr int available: (optional) The total number of available documents in the collection.
-    :attr int processing: (optional) The number of documents in the collection that are currently being processed.
-    :attr int failed: (optional) The number of documents in the collection that failed to be ingested.
+    :attr int available: (optional) The total number of available documents in the
+    collection.
+    :attr int processing: (optional) The number of documents in the collection that are
+    currently being processed.
+    :attr int failed: (optional) The number of documents in the collection that failed to
+    be ingested.
     """
 
     def __init__(self, available=None, processing=None, failed=None):
         """
         Initialize a DocumentCounts object.
 
-        :param int available: (optional) The total number of available documents in the collection.
-        :param int processing: (optional) The number of documents in the collection that are currently being processed.
-        :param int failed: (optional) The number of documents in the collection that failed to be ingested.
+        :param int available: (optional) The total number of available documents in the
+        collection.
+        :param int processing: (optional) The number of documents in the collection that
+        are currently being processed.
+        :param int failed: (optional) The number of documents in the collection that
+        failed to be ingested.
         """
         self.available = available
         self.processing = processing
@@ -2992,14 +3288,18 @@ class DocumentStatus(object):
 
     :attr str document_id: The unique identifier of the document.
     :attr str configuration_id: (optional) The unique identifier for the configuration.
-    :attr datetime created: (optional) The creation date of the document in the format yyyy-MM-dd'T'HH:mm:ss.SSS'Z'.
-    :attr datetime updated: (optional) Date of the most recent document update, in the format yyyy-MM-dd'T'HH:mm:ss.SSS'Z'.
+    :attr datetime created: (optional) The creation date of the document in the format
+    yyyy-MM-dd'T'HH:mm:ss.SSS'Z'.
+    :attr datetime updated: (optional) Date of the most recent document update, in the
+    format yyyy-MM-dd'T'HH:mm:ss.SSS'Z'.
     :attr str status: Status of the document in the ingestion process.
     :attr str status_description: Description of the document status.
     :attr str filename: (optional) Name of the original source file (if available).
     :attr str file_type: (optional) The type of the original source file.
-    :attr str sha1: (optional) The SHA-1 hash of the original source file (formatted as a hexadecimal string).
-    :attr list[Notice] notices: Array of notices produced by the document-ingestion process.
+    :attr str sha1: (optional) The SHA-1 hash of the original source file (formatted as a
+    hexadecimal string).
+    :attr list[Notice] notices: Array of notices produced by the document-ingestion
+    process.
     """
 
     def __init__(self,
@@ -3019,13 +3319,18 @@ class DocumentStatus(object):
         :param str document_id: The unique identifier of the document.
         :param str status: Status of the document in the ingestion process.
         :param str status_description: Description of the document status.
-        :param list[Notice] notices: Array of notices produced by the document-ingestion process.
-        :param str configuration_id: (optional) The unique identifier for the configuration.
-        :param datetime created: (optional) The creation date of the document in the format yyyy-MM-dd'T'HH:mm:ss.SSS'Z'.
-        :param datetime updated: (optional) Date of the most recent document update, in the format yyyy-MM-dd'T'HH:mm:ss.SSS'Z'.
+        :param list[Notice] notices: Array of notices produced by the document-ingestion
+        process.
+        :param str configuration_id: (optional) The unique identifier for the
+        configuration.
+        :param datetime created: (optional) The creation date of the document in the
+        format yyyy-MM-dd'T'HH:mm:ss.SSS'Z'.
+        :param datetime updated: (optional) Date of the most recent document update, in
+        the format yyyy-MM-dd'T'HH:mm:ss.SSS'Z'.
         :param str filename: (optional) Name of the original source file (if available).
         :param str file_type: (optional) The type of the original source file.
-        :param str sha1: (optional) The SHA-1 hash of the original source file (formatted as a hexadecimal string).
+        :param str sha1: (optional) The SHA-1 hash of the original source file (formatted
+        as a hexadecimal string).
         """
         self.document_id = document_id
         self.configuration_id = configuration_id
@@ -3130,12 +3435,27 @@ class Enrichment(object):
     Enrichment.
 
     :attr str description: (optional) Describes what the enrichment step does.
-    :attr str destination_field: Field where enrichments will be stored. This field must already exist or be at most 1 level deeper than an existing field. For example, if `text` is a top-level field with no sub-fields, `text.foo` is a valid destination but `text.foo.bar` is not.
+    :attr str destination_field: Field where enrichments will be stored. This field must
+    already exist or be at most 1 level deeper than an existing field. For example, if
+    `text` is a top-level field with no sub-fields, `text.foo` is a valid destination but
+    `text.foo.bar` is not.
     :attr str source_field: Field to be enriched.
-    :attr bool overwrite: (optional) Indicates that the enrichments will overwrite the destination_field field if it already exists.
-    :attr str enrichment_name: Name of the enrichment service to call. Current options are `natural_language_understanding` and `elements`.   When using `natual_language_understanding`, the `options` object must contain Natural Language Understanding Options.   When using `elements` the `options` object must contain Element Classification options. Additionally, when using the `elements` enrichment the configuration specified and files ingested must meet all the criteria specified in [the documentation](https://console.bluemix.net/docs/services/discovery/element-classification.html)     Previous API versions also supported `alchemy_language`.
-    :attr bool ignore_downstream_errors: (optional) If true, then most errors generated during the enrichment process will be treated as warnings and will not cause the document to fail processing.
-    :attr EnrichmentOptions options: (optional) A list of options specific to the enrichment.
+    :attr bool overwrite: (optional) Indicates that the enrichments will overwrite the
+    destination_field field if it already exists.
+    :attr str enrichment_name: Name of the enrichment service to call. Current options are
+    `natural_language_understanding` and `elements`.
+     When using `natual_language_understanding`, the `options` object must contain Natural
+    Language Understanding Options.
+     When using `elements` the `options` object must contain Element Classification
+    options. Additionally, when using the `elements` enrichment the configuration
+    specified and files ingested must meet all the criteria specified in [the
+    documentation](https://console.bluemix.net/docs/services/discovery/element-classification.html)
+     Previous API versions also supported `alchemy_language`.
+    :attr bool ignore_downstream_errors: (optional) If true, then most errors generated
+    during the enrichment process will be treated as warnings and will not cause the
+    document to fail processing.
+    :attr EnrichmentOptions options: (optional) A list of options specific to the
+    enrichment.
     """
 
     def __init__(self,
@@ -3149,13 +3469,28 @@ class Enrichment(object):
         """
         Initialize a Enrichment object.
 
-        :param str destination_field: Field where enrichments will be stored. This field must already exist or be at most 1 level deeper than an existing field. For example, if `text` is a top-level field with no sub-fields, `text.foo` is a valid destination but `text.foo.bar` is not.
+        :param str destination_field: Field where enrichments will be stored. This field
+        must already exist or be at most 1 level deeper than an existing field. For
+        example, if `text` is a top-level field with no sub-fields, `text.foo` is a valid
+        destination but `text.foo.bar` is not.
         :param str source_field: Field to be enriched.
-        :param str enrichment_name: Name of the enrichment service to call. Current options are `natural_language_understanding` and `elements`.   When using `natual_language_understanding`, the `options` object must contain Natural Language Understanding Options.   When using `elements` the `options` object must contain Element Classification options. Additionally, when using the `elements` enrichment the configuration specified and files ingested must meet all the criteria specified in [the documentation](https://console.bluemix.net/docs/services/discovery/element-classification.html)     Previous API versions also supported `alchemy_language`.
+        :param str enrichment_name: Name of the enrichment service to call. Current
+        options are `natural_language_understanding` and `elements`.
+         When using `natual_language_understanding`, the `options` object must contain
+        Natural Language Understanding Options.
+         When using `elements` the `options` object must contain Element Classification
+        options. Additionally, when using the `elements` enrichment the configuration
+        specified and files ingested must meet all the criteria specified in [the
+        documentation](https://console.bluemix.net/docs/services/discovery/element-classification.html)
+         Previous API versions also supported `alchemy_language`.
         :param str description: (optional) Describes what the enrichment step does.
-        :param bool overwrite: (optional) Indicates that the enrichments will overwrite the destination_field field if it already exists.
-        :param bool ignore_downstream_errors: (optional) If true, then most errors generated during the enrichment process will be treated as warnings and will not cause the document to fail processing.
-        :param EnrichmentOptions options: (optional) A list of options specific to the enrichment.
+        :param bool overwrite: (optional) Indicates that the enrichments will overwrite
+        the destination_field field if it already exists.
+        :param bool ignore_downstream_errors: (optional) If true, then most errors
+        generated during the enrichment process will be treated as warnings and will not
+        cause the document to fail processing.
+        :param EnrichmentOptions options: (optional) A list of options specific to the
+        enrichment.
         """
         self.description = description
         self.destination_field = destination_field
@@ -3216,7 +3551,7 @@ class Enrichment(object):
                    'enrichment_name') and self.enrichment_name is not None:
             _dict['enrichment'] = self.enrichment_name
         if hasattr(self, 'ignore_downstream_errors'
-                  ) and self.ignore_downstream_errors is not None:
+                   ) and self.ignore_downstream_errors is not None:
             _dict['ignore_downstream_errors'] = self.ignore_downstream_errors
         if hasattr(self, 'options') and self.options is not None:
             _dict['options'] = self.options._to_dict()
@@ -3241,16 +3576,20 @@ class EnrichmentOptions(object):
     """
     Options which are specific to a particular enrichment.
 
-    :attr NluEnrichmentFeatures features: (optional) An object representing the enrichment features that will be applied to the specified field.
-    :attr str model: (optional) *For use with `elements` enrichments only.* The element extraction model to use. Models available are: `contract`.
+    :attr NluEnrichmentFeatures features: (optional) An object representing the enrichment
+    features that will be applied to the specified field.
+    :attr str model: (optional) *For use with `elements` enrichments only.* The element
+    extraction model to use. Models available are: `contract`.
     """
 
     def __init__(self, features=None, model=None):
         """
         Initialize a EnrichmentOptions object.
 
-        :param NluEnrichmentFeatures features: (optional) An object representing the enrichment features that will be applied to the specified field.
-        :param str model: (optional) *For use with `elements` enrichments only.* The element extraction model to use. Models available are: `contract`.
+        :param NluEnrichmentFeatures features: (optional) An object representing the
+        enrichment features that will be applied to the specified field.
+        :param str model: (optional) *For use with `elements` enrichments only.* The
+        element extraction model to use. Models available are: `contract`.
         """
         self.features = features
         self.model = model
@@ -3297,12 +3636,16 @@ class Environment(object):
     :attr str environment_id: (optional) Unique identifier for the environment.
     :attr str name: (optional) Name that identifies the environment.
     :attr str description: (optional) Description of the environment.
-    :attr datetime created: (optional) Creation date of the environment, in the format yyyy-MM-dd'T'HH:mm:ss.SSS'Z'.
-    :attr datetime updated: (optional) Date of most recent environment update, in the format yyyy-MM-dd'T'HH:mm:ss.SSS'Z'.
+    :attr datetime created: (optional) Creation date of the environment, in the format
+    yyyy-MM-dd'T'HH:mm:ss.SSS'Z'.
+    :attr datetime updated: (optional) Date of most recent environment update, in the
+    format yyyy-MM-dd'T'HH:mm:ss.SSS'Z'.
     :attr str status: (optional) Status of the environment.
-    :attr bool read_only: (optional) If true, then the environment contains read-only collections which are maintained by IBM.
+    :attr bool read_only: (optional) If true, then the environment contains read-only
+    collections which are maintained by IBM.
     :attr int size: (optional) **Deprecated**: Size of the environment.
-    :attr IndexCapacity index_capacity: (optional) Details about the resource usage and capacity of the environment.
+    :attr IndexCapacity index_capacity: (optional) Details about the resource usage and
+    capacity of the environment.
     """
 
     def __init__(self,
@@ -3321,12 +3664,16 @@ class Environment(object):
         :param str environment_id: (optional) Unique identifier for the environment.
         :param str name: (optional) Name that identifies the environment.
         :param str description: (optional) Description of the environment.
-        :param datetime created: (optional) Creation date of the environment, in the format yyyy-MM-dd'T'HH:mm:ss.SSS'Z'.
-        :param datetime updated: (optional) Date of most recent environment update, in the format yyyy-MM-dd'T'HH:mm:ss.SSS'Z'.
+        :param datetime created: (optional) Creation date of the environment, in the
+        format yyyy-MM-dd'T'HH:mm:ss.SSS'Z'.
+        :param datetime updated: (optional) Date of most recent environment update, in the
+        format yyyy-MM-dd'T'HH:mm:ss.SSS'Z'.
         :param str status: (optional) Status of the environment.
-        :param bool read_only: (optional) If true, then the environment contains read-only collections which are maintained by IBM.
+        :param bool read_only: (optional) If true, then the environment contains read-only
+        collections which are maintained by IBM.
         :param int size: (optional) **Deprecated**: Size of the environment.
-        :param IndexCapacity index_capacity: (optional) Details about the resource usage and capacity of the environment.
+        :param IndexCapacity index_capacity: (optional) Details about the resource usage
+        and capacity of the environment.
         """
         self.environment_id = environment_id
         self.name = name
@@ -3406,7 +3753,8 @@ class EnvironmentDocuments(object):
     Summary of the document usage statistics for the environment.
 
     :attr int indexed: (optional) Number of documents indexed for the environment.
-    :attr int maximum_allowed: (optional) Total number of documents allowed in the environment's capacity.
+    :attr int maximum_allowed: (optional) Total number of documents allowed in the
+    environment's capacity.
     """
 
     def __init__(self, indexed=None, maximum_allowed=None):
@@ -3414,7 +3762,8 @@ class EnvironmentDocuments(object):
         Initialize a EnvironmentDocuments object.
 
         :param int indexed: (optional) Number of documents indexed for the environment.
-        :param int maximum_allowed: (optional) Total number of documents allowed in the environment's capacity.
+        :param int maximum_allowed: (optional) Total number of documents allowed in the
+        environment's capacity.
         """
         self.indexed = indexed
         self.maximum_allowed = maximum_allowed
@@ -3460,16 +3809,21 @@ class Expansion(object):
     example, you could have expansions for the word `hot` in one object, and expansions
     for the word `cold` in another.
 
-    :attr list[str] input_terms: (optional) A list of terms that will be expanded for this expansion. If specified, only the items in this list are expanded.
-    :attr list[str] expanded_terms: A list of terms that this expansion will be expanded to. If specified without `input_terms`, it also functions as the input term list.
+    :attr list[str] input_terms: (optional) A list of terms that will be expanded for this
+    expansion. If specified, only the items in this list are expanded.
+    :attr list[str] expanded_terms: A list of terms that this expansion will be expanded
+    to. If specified without `input_terms`, it also functions as the input term list.
     """
 
     def __init__(self, expanded_terms, input_terms=None):
         """
         Initialize a Expansion object.
 
-        :param list[str] expanded_terms: A list of terms that this expansion will be expanded to. If specified without `input_terms`, it also functions as the input term list.
-        :param list[str] input_terms: (optional) A list of terms that will be expanded for this expansion. If specified, only the items in this list are expanded.
+        :param list[str] expanded_terms: A list of terms that this expansion will be
+        expanded to. If specified without `input_terms`, it also functions as the input
+        term list.
+        :param list[str] input_terms: (optional) A list of terms that will be expanded for
+        this expansion. If specified, only the items in this list are expanded.
         """
         self.input_terms = input_terms
         self.expanded_terms = expanded_terms
@@ -3516,14 +3870,34 @@ class Expansions(object):
     """
     The query expansion definitions for the specified collection.
 
-    :attr list[Expansion] expansions: An array of query expansion definitions.    Each object in the `expansions` array represents a term or set of terms that will be expanded into other terms. Each expansion object can be configured so that all terms are expanded to all other terms in the object - bi-directional, or a set list of terms can be expanded into a second list of terms - uni-directional.   To create a bi-directional expansion specify an `expanded_terms` array. When found in a query, all items in the `expanded_terms` array are then expanded to the other items in the same array.   To create a uni-directional expansion, specify both an array of `input_terms` and an array of `expanded_terms`. When items in the `input_terms` array are present in a query, they are expanded using the items listed in the `expanded_terms` array.
+    :attr list[Expansion] expansions: An array of query expansion definitions.
+     Each object in the `expansions` array represents a term or set of terms that will be
+    expanded into other terms. Each expansion object can be configured so that all terms
+    are expanded to all other terms in the object - bi-directional, or a set list of terms
+    can be expanded into a second list of terms - uni-directional.
+     To create a bi-directional expansion specify an `expanded_terms` array. When found in
+    a query, all items in the `expanded_terms` array are then expanded to the other items
+    in the same array.
+     To create a uni-directional expansion, specify both an array of `input_terms` and an
+    array of `expanded_terms`. When items in the `input_terms` array are present in a
+    query, they are expanded using the items listed in the `expanded_terms` array.
     """
 
     def __init__(self, expansions):
         """
         Initialize a Expansions object.
 
-        :param list[Expansion] expansions: An array of query expansion definitions.    Each object in the `expansions` array represents a term or set of terms that will be expanded into other terms. Each expansion object can be configured so that all terms are expanded to all other terms in the object - bi-directional, or a set list of terms can be expanded into a second list of terms - uni-directional.   To create a bi-directional expansion specify an `expanded_terms` array. When found in a query, all items in the `expanded_terms` array are then expanded to the other items in the same array.   To create a uni-directional expansion, specify both an array of `input_terms` and an array of `expanded_terms`. When items in the `input_terms` array are present in a query, they are expanded using the items listed in the `expanded_terms` array.
+        :param list[Expansion] expansions: An array of query expansion definitions.
+         Each object in the `expansions` array represents a term or set of terms that will
+        be expanded into other terms. Each expansion object can be configured so that all
+        terms are expanded to all other terms in the object - bi-directional, or a set
+        list of terms can be expanded into a second list of terms - uni-directional.
+         To create a bi-directional expansion specify an `expanded_terms` array. When
+        found in a query, all items in the `expanded_terms` array are then expanded to the
+        other items in the same array.
+         To create a uni-directional expansion, specify both an array of `input_terms` and
+        an array of `expanded_terms`. When items in the `input_terms` array are present in
+        a query, they are expanded using the items listed in the `expanded_terms` array.
         """
         self.expansions = expansions
 
@@ -3764,10 +4138,10 @@ class HtmlSettings(object):
         """Return a json dictionary representing this model."""
         _dict = {}
         if hasattr(self, 'exclude_tags_completely'
-                  ) and self.exclude_tags_completely is not None:
+                   ) and self.exclude_tags_completely is not None:
             _dict['exclude_tags_completely'] = self.exclude_tags_completely
         if hasattr(self, 'exclude_tags_keep_content'
-                  ) and self.exclude_tags_keep_content is not None:
+                   ) and self.exclude_tags_keep_content is not None:
             _dict['exclude_tags_keep_content'] = self.exclude_tags_keep_content
         if hasattr(self, 'keep_content') and self.keep_content is not None:
             _dict['keep_content'] = self.keep_content._to_dict()
@@ -3775,10 +4149,10 @@ class HtmlSettings(object):
                    'exclude_content') and self.exclude_content is not None:
             _dict['exclude_content'] = self.exclude_content._to_dict()
         if hasattr(self, 'keep_tag_attributes'
-                  ) and self.keep_tag_attributes is not None:
+                   ) and self.keep_tag_attributes is not None:
             _dict['keep_tag_attributes'] = self.keep_tag_attributes
         if hasattr(self, 'exclude_tag_attributes'
-                  ) and self.exclude_tag_attributes is not None:
+                   ) and self.exclude_tag_attributes is not None:
             _dict['exclude_tag_attributes'] = self.exclude_tag_attributes
         return _dict
 
@@ -3801,10 +4175,13 @@ class IndexCapacity(object):
     """
     Details about the resource usage and capacity of the environment.
 
-    :attr EnvironmentDocuments documents: (optional) Summary of the document usage statistics for the environment.
+    :attr EnvironmentDocuments documents: (optional) Summary of the document usage
+    statistics for the environment.
     :attr DiskUsage disk_usage: (optional) Summary of the disk usage of the environment.
-    :attr CollectionUsage collections: (optional) Summary of the collection usage in the environment.
-    :attr MemoryUsage memory_usage: (optional) **Deprecated**: Summary of the memory usage of the environment.
+    :attr CollectionUsage collections: (optional) Summary of the collection usage in the
+    environment.
+    :attr MemoryUsage memory_usage: (optional) **Deprecated**: Summary of the memory usage
+    of the environment.
     """
 
     def __init__(self,
@@ -3815,10 +4192,14 @@ class IndexCapacity(object):
         """
         Initialize a IndexCapacity object.
 
-        :param EnvironmentDocuments documents: (optional) Summary of the document usage statistics for the environment.
-        :param DiskUsage disk_usage: (optional) Summary of the disk usage of the environment.
-        :param CollectionUsage collections: (optional) Summary of the collection usage in the environment.
-        :param MemoryUsage memory_usage: (optional) **Deprecated**: Summary of the memory usage of the environment.
+        :param EnvironmentDocuments documents: (optional) Summary of the document usage
+        statistics for the environment.
+        :param DiskUsage disk_usage: (optional) Summary of the disk usage of the
+        environment.
+        :param CollectionUsage collections: (optional) Summary of the collection usage in
+        the environment.
+        :param MemoryUsage memory_usage: (optional) **Deprecated**: Summary of the memory
+        usage of the environment.
         """
         self.documents = documents
         self.disk_usage = disk_usage
@@ -3872,23 +4253,27 @@ class IndexCapacity(object):
 
 class ListCollectionFieldsResponse(object):
     """
-    The list of fetched fields.  The fields are returned using a fully qualified name
-    format, however, the format differs slightly from that used by the query operations.
-     * Fields which contain nested JSON objects are assigned a type of "nested".    *
-    Fields which belong to a nested object are prefixed with `.properties` (for example,
-    `warnings.properties.severity` means that the `warnings` object has a property called
-    `severity`).    * Fields returned from the News collection are prefixed with
+    The list of fetched fields.
+    The fields are returned using a fully qualified name format, however, the format
+    differs slightly from that used by the query operations.
+      * Fields which contain nested JSON objects are assigned a type of "nested".
+      * Fields which belong to a nested object are prefixed with `.properties` (for
+    example, `warnings.properties.severity` means that the `warnings` object has a
+    property called `severity`).
+      * Fields returned from the News collection are prefixed with
     `v{N}-fullnews-t3-{YEAR}.mappings` (for example,
     `v5-fullnews-t3-2016.mappings.text.properties.author`).
 
-    :attr list[Field] fields: (optional) An array containing information about each field in the collections.
+    :attr list[Field] fields: (optional) An array containing information about each field
+    in the collections.
     """
 
     def __init__(self, fields=None):
         """
         Initialize a ListCollectionFieldsResponse object.
 
-        :param list[Field] fields: (optional) An array containing information about each field in the collections.
+        :param list[Field] fields: (optional) An array containing information about each
+        field in the collections.
         """
         self.fields = fields
 
@@ -3928,14 +4313,16 @@ class ListCollectionsResponse(object):
     """
     ListCollectionsResponse.
 
-    :attr list[Collection] collections: (optional) An array containing information about each collection in the environment.
+    :attr list[Collection] collections: (optional) An array containing information about
+    each collection in the environment.
     """
 
     def __init__(self, collections=None):
         """
         Initialize a ListCollectionsResponse object.
 
-        :param list[Collection] collections: (optional) An array containing information about each collection in the environment.
+        :param list[Collection] collections: (optional) An array containing information
+        about each collection in the environment.
         """
         self.collections = collections
 
@@ -3975,14 +4362,16 @@ class ListConfigurationsResponse(object):
     """
     ListConfigurationsResponse.
 
-    :attr list[Configuration] configurations: (optional) An array of Configurations that are available for the service instance.
+    :attr list[Configuration] configurations: (optional) An array of Configurations that
+    are available for the service instance.
     """
 
     def __init__(self, configurations=None):
         """
         Initialize a ListConfigurationsResponse object.
 
-        :param list[Configuration] configurations: (optional) An array of Configurations that are available for the service instance.
+        :param list[Configuration] configurations: (optional) An array of Configurations
+        that are available for the service instance.
         """
         self.configurations = configurations
 
@@ -4025,14 +4414,16 @@ class ListEnvironmentsResponse(object):
     """
     ListEnvironmentsResponse.
 
-    :attr list[Environment] environments: (optional) An array of [environments] that are available for the service instance.
+    :attr list[Environment] environments: (optional) An array of [environments] that are
+    available for the service instance.
     """
 
     def __init__(self, environments=None):
         """
         Initialize a ListEnvironmentsResponse object.
 
-        :param list[Environment] environments: (optional) An array of [environments] that are available for the service instance.
+        :param list[Environment] environments: (optional) An array of [environments] that
+        are available for the service instance.
         """
         self.environments = environments
 
@@ -4072,11 +4463,16 @@ class MemoryUsage(object):
     """
     **Deprecated**: Summary of the memory usage statistics for this environment.
 
-    :attr int used_bytes: (optional) **Deprecated**: Number of bytes used in the environment's memory capacity.
-    :attr int total_bytes: (optional) **Deprecated**: Total number of bytes available in the environment's memory capacity.
-    :attr str used: (optional) **Deprecated**: Amount of memory capacity used, in KB or GB format.
-    :attr str total: (optional) **Deprecated**: Total amount of the environment's memory capacity, in KB or GB format.
-    :attr float percent_used: (optional) **Deprecated**: Percentage of the environment's memory capacity that is being used.
+    :attr int used_bytes: (optional) **Deprecated**: Number of bytes used in the
+    environment's memory capacity.
+    :attr int total_bytes: (optional) **Deprecated**: Total number of bytes available in
+    the environment's memory capacity.
+    :attr str used: (optional) **Deprecated**: Amount of memory capacity used, in KB or GB
+    format.
+    :attr str total: (optional) **Deprecated**: Total amount of the environment's memory
+    capacity, in KB or GB format.
+    :attr float percent_used: (optional) **Deprecated**: Percentage of the environment's
+    memory capacity that is being used.
     """
 
     def __init__(self,
@@ -4088,11 +4484,16 @@ class MemoryUsage(object):
         """
         Initialize a MemoryUsage object.
 
-        :param int used_bytes: (optional) **Deprecated**: Number of bytes used in the environment's memory capacity.
-        :param int total_bytes: (optional) **Deprecated**: Total number of bytes available in the environment's memory capacity.
-        :param str used: (optional) **Deprecated**: Amount of memory capacity used, in KB or GB format.
-        :param str total: (optional) **Deprecated**: Total amount of the environment's memory capacity, in KB or GB format.
-        :param float percent_used: (optional) **Deprecated**: Percentage of the environment's memory capacity that is being used.
+        :param int used_bytes: (optional) **Deprecated**: Number of bytes used in the
+        environment's memory capacity.
+        :param int total_bytes: (optional) **Deprecated**: Total number of bytes available
+        in the environment's memory capacity.
+        :param str used: (optional) **Deprecated**: Amount of memory capacity used, in KB
+        or GB format.
+        :param str total: (optional) **Deprecated**: Total amount of the environment's
+        memory capacity, in KB or GB format.
+        :param float percent_used: (optional) **Deprecated**: Percentage of the
+        environment's memory capacity that is being used.
         """
         self.used_bytes = used_bytes
         self.total_bytes = total_bytes
@@ -4208,16 +4609,20 @@ class NluEnrichmentEmotion(object):
     """
     An object specifying the emotion detection enrichment and related parameters.
 
-    :attr bool document: (optional) When `true`, emotion detection is performed on the entire field.
-    :attr list[str] targets: (optional) A comma-separated list of target strings that will have any associated emotions detected.
+    :attr bool document: (optional) When `true`, emotion detection is performed on the
+    entire field.
+    :attr list[str] targets: (optional) A comma-separated list of target strings that will
+    have any associated emotions detected.
     """
 
     def __init__(self, document=None, targets=None):
         """
         Initialize a NluEnrichmentEmotion object.
 
-        :param bool document: (optional) When `true`, emotion detection is performed on the entire field.
-        :param list[str] targets: (optional) A comma-separated list of target strings that will have any associated emotions detected.
+        :param bool document: (optional) When `true`, emotion detection is performed on
+        the entire field.
+        :param list[str] targets: (optional) A comma-separated list of target strings that
+        will have any associated emotions detected.
         """
         self.document = document
         self.targets = targets
@@ -4260,13 +4665,21 @@ class NluEnrichmentEntities(object):
     """
     An object speficying the Entities enrichment and related parameters.
 
-    :attr bool sentiment: (optional) When `true`, sentiment analysis of entities will be performed on the specified field.
-    :attr bool emotion: (optional) When `true`, emotion detection of entities will be performed on the specified field.
-    :attr int limit: (optional) The maximum number of entities to extract for each instance of the specified field.
-    :attr bool mentions: (optional) When `true`, the number of mentions of each identified entity is recorded. The default is `false`.
-    :attr bool mention_types: (optional) When `true`, the types of mentions for each idetifieid entity is recorded. The default is `false`.
-    :attr bool sentence_location: (optional) When `true`, a list of sentence locations for each instance of each identified entity is recorded. The default is `false`.
-    :attr str model: (optional) The enrichement model to use with entity extraction. May be a custom model provided by Watson Knowledge Studio, the public model for use with Knowledge Graph `en-news`, or the default public model `alchemy`.
+    :attr bool sentiment: (optional) When `true`, sentiment analysis of entities will be
+    performed on the specified field.
+    :attr bool emotion: (optional) When `true`, emotion detection of entities will be
+    performed on the specified field.
+    :attr int limit: (optional) The maximum number of entities to extract for each
+    instance of the specified field.
+    :attr bool mentions: (optional) When `true`, the number of mentions of each identified
+    entity is recorded. The default is `false`.
+    :attr bool mention_types: (optional) When `true`, the types of mentions for each
+    idetifieid entity is recorded. The default is `false`.
+    :attr bool sentence_location: (optional) When `true`, a list of sentence locations for
+    each instance of each identified entity is recorded. The default is `false`.
+    :attr str model: (optional) The enrichement model to use with entity extraction. May
+    be a custom model provided by Watson Knowledge Studio, the public model for use with
+    Knowledge Graph `en-news`, or the default public model `alchemy`.
     """
 
     def __init__(self,
@@ -4280,13 +4693,22 @@ class NluEnrichmentEntities(object):
         """
         Initialize a NluEnrichmentEntities object.
 
-        :param bool sentiment: (optional) When `true`, sentiment analysis of entities will be performed on the specified field.
-        :param bool emotion: (optional) When `true`, emotion detection of entities will be performed on the specified field.
-        :param int limit: (optional) The maximum number of entities to extract for each instance of the specified field.
-        :param bool mentions: (optional) When `true`, the number of mentions of each identified entity is recorded. The default is `false`.
-        :param bool mention_types: (optional) When `true`, the types of mentions for each idetifieid entity is recorded. The default is `false`.
-        :param bool sentence_location: (optional) When `true`, a list of sentence locations for each instance of each identified entity is recorded. The default is `false`.
-        :param str model: (optional) The enrichement model to use with entity extraction. May be a custom model provided by Watson Knowledge Studio, the public model for use with Knowledge Graph `en-news`, or the default public model `alchemy`.
+        :param bool sentiment: (optional) When `true`, sentiment analysis of entities will
+        be performed on the specified field.
+        :param bool emotion: (optional) When `true`, emotion detection of entities will be
+        performed on the specified field.
+        :param int limit: (optional) The maximum number of entities to extract for each
+        instance of the specified field.
+        :param bool mentions: (optional) When `true`, the number of mentions of each
+        identified entity is recorded. The default is `false`.
+        :param bool mention_types: (optional) When `true`, the types of mentions for each
+        idetifieid entity is recorded. The default is `false`.
+        :param bool sentence_location: (optional) When `true`, a list of sentence
+        locations for each instance of each identified entity is recorded. The default is
+        `false`.
+        :param str model: (optional) The enrichement model to use with entity extraction.
+        May be a custom model provided by Watson Knowledge Studio, the public model for
+        use with Knowledge Graph `en-news`, or the default public model `alchemy`.
         """
         self.sentiment = sentiment
         self.emotion = emotion
@@ -4355,13 +4777,20 @@ class NluEnrichmentFeatures(object):
     """
     NluEnrichmentFeatures.
 
-    :attr NluEnrichmentKeywords keywords: (optional) An object specifying the Keyword enrichment and related parameters.
-    :attr NluEnrichmentEntities entities: (optional) An object speficying the Entities enrichment and related parameters.
-    :attr NluEnrichmentSentiment sentiment: (optional) An object specifying the sentiment extraction enrichment and related parameters.
-    :attr NluEnrichmentEmotion emotion: (optional) An object specifying the emotion detection enrichment and related parameters.
-    :attr NluEnrichmentCategories categories: (optional) An object specifying the categories enrichment and related parameters.
-    :attr NluEnrichmentSemanticRoles semantic_roles: (optional) An object specifiying the semantic roles enrichment and related parameters.
-    :attr NluEnrichmentRelations relations: (optional) An object specifying the relations enrichment and related parameters.
+    :attr NluEnrichmentKeywords keywords: (optional) An object specifying the Keyword
+    enrichment and related parameters.
+    :attr NluEnrichmentEntities entities: (optional) An object speficying the Entities
+    enrichment and related parameters.
+    :attr NluEnrichmentSentiment sentiment: (optional) An object specifying the sentiment
+    extraction enrichment and related parameters.
+    :attr NluEnrichmentEmotion emotion: (optional) An object specifying the emotion
+    detection enrichment and related parameters.
+    :attr NluEnrichmentCategories categories: (optional) An object specifying the
+    categories enrichment and related parameters.
+    :attr NluEnrichmentSemanticRoles semantic_roles: (optional) An object specifiying the
+    semantic roles enrichment and related parameters.
+    :attr NluEnrichmentRelations relations: (optional) An object specifying the relations
+    enrichment and related parameters.
     """
 
     def __init__(self,
@@ -4375,13 +4804,20 @@ class NluEnrichmentFeatures(object):
         """
         Initialize a NluEnrichmentFeatures object.
 
-        :param NluEnrichmentKeywords keywords: (optional) An object specifying the Keyword enrichment and related parameters.
-        :param NluEnrichmentEntities entities: (optional) An object speficying the Entities enrichment and related parameters.
-        :param NluEnrichmentSentiment sentiment: (optional) An object specifying the sentiment extraction enrichment and related parameters.
-        :param NluEnrichmentEmotion emotion: (optional) An object specifying the emotion detection enrichment and related parameters.
-        :param NluEnrichmentCategories categories: (optional) An object specifying the categories enrichment and related parameters.
-        :param NluEnrichmentSemanticRoles semantic_roles: (optional) An object specifiying the semantic roles enrichment and related parameters.
-        :param NluEnrichmentRelations relations: (optional) An object specifying the relations enrichment and related parameters.
+        :param NluEnrichmentKeywords keywords: (optional) An object specifying the Keyword
+        enrichment and related parameters.
+        :param NluEnrichmentEntities entities: (optional) An object speficying the
+        Entities enrichment and related parameters.
+        :param NluEnrichmentSentiment sentiment: (optional) An object specifying the
+        sentiment extraction enrichment and related parameters.
+        :param NluEnrichmentEmotion emotion: (optional) An object specifying the emotion
+        detection enrichment and related parameters.
+        :param NluEnrichmentCategories categories: (optional) An object specifying the
+        categories enrichment and related parameters.
+        :param NluEnrichmentSemanticRoles semantic_roles: (optional) An object specifiying
+        the semantic roles enrichment and related parameters.
+        :param NluEnrichmentRelations relations: (optional) An object specifying the
+        relations enrichment and related parameters.
         """
         self.keywords = keywords
         self.entities = entities
@@ -4456,18 +4892,24 @@ class NluEnrichmentKeywords(object):
     """
     An object specifying the Keyword enrichment and related parameters.
 
-    :attr bool sentiment: (optional) When `true`, sentiment analysis of keywords will be performed on the specified field.
-    :attr bool emotion: (optional) When `true`, emotion detection of keywords will be performed on the specified field.
-    :attr int limit: (optional) The maximum number of keywords to extract for each instance of the specified field.
+    :attr bool sentiment: (optional) When `true`, sentiment analysis of keywords will be
+    performed on the specified field.
+    :attr bool emotion: (optional) When `true`, emotion detection of keywords will be
+    performed on the specified field.
+    :attr int limit: (optional) The maximum number of keywords to extract for each
+    instance of the specified field.
     """
 
     def __init__(self, sentiment=None, emotion=None, limit=None):
         """
         Initialize a NluEnrichmentKeywords object.
 
-        :param bool sentiment: (optional) When `true`, sentiment analysis of keywords will be performed on the specified field.
-        :param bool emotion: (optional) When `true`, emotion detection of keywords will be performed on the specified field.
-        :param int limit: (optional) The maximum number of keywords to extract for each instance of the specified field.
+        :param bool sentiment: (optional) When `true`, sentiment analysis of keywords will
+        be performed on the specified field.
+        :param bool emotion: (optional) When `true`, emotion detection of keywords will be
+        performed on the specified field.
+        :param int limit: (optional) The maximum number of keywords to extract for each
+        instance of the specified field.
         """
         self.sentiment = sentiment
         self.emotion = emotion
@@ -4515,14 +4957,20 @@ class NluEnrichmentRelations(object):
     """
     An object specifying the relations enrichment and related parameters.
 
-    :attr str model: (optional) *For use with `natural_language_understanding` enrichments only.* The enrichement model to use with relationship extraction. May be a custom model provided by Watson Knowledge Studio, the public model for use with Knowledge Graph `en-news`, the default is`en-news`.
+    :attr str model: (optional) *For use with `natural_language_understanding` enrichments
+    only.* The enrichement model to use with relationship extraction. May be a custom
+    model provided by Watson Knowledge Studio, the public model for use with Knowledge
+    Graph `en-news`, the default is`en-news`.
     """
 
     def __init__(self, model=None):
         """
         Initialize a NluEnrichmentRelations object.
 
-        :param str model: (optional) *For use with `natural_language_understanding` enrichments only.* The enrichement model to use with relationship extraction. May be a custom model provided by Watson Knowledge Studio, the public model for use with Knowledge Graph `en-news`, the default is`en-news`.
+        :param str model: (optional) *For use with `natural_language_understanding`
+        enrichments only.* The enrichement model to use with relationship extraction. May
+        be a custom model provided by Watson Knowledge Studio, the public model for use
+        with Knowledge Graph `en-news`, the default is`en-news`.
         """
         self.model = model
 
@@ -4560,18 +5008,24 @@ class NluEnrichmentSemanticRoles(object):
     """
     An object specifiying the semantic roles enrichment and related parameters.
 
-    :attr bool entities: (optional) When `true` entities are extracted from the identified sentence parts.
-    :attr bool keywords: (optional) When `true`, keywords are extracted from the identified sentence parts.
-    :attr int limit: (optional) The maximum number of semantic roles enrichments to extact from each instance of the specified field.
+    :attr bool entities: (optional) When `true` entities are extracted from the identified
+    sentence parts.
+    :attr bool keywords: (optional) When `true`, keywords are extracted from the
+    identified sentence parts.
+    :attr int limit: (optional) The maximum number of semantic roles enrichments to extact
+    from each instance of the specified field.
     """
 
     def __init__(self, entities=None, keywords=None, limit=None):
         """
         Initialize a NluEnrichmentSemanticRoles object.
 
-        :param bool entities: (optional) When `true` entities are extracted from the identified sentence parts.
-        :param bool keywords: (optional) When `true`, keywords are extracted from the identified sentence parts.
-        :param int limit: (optional) The maximum number of semantic roles enrichments to extact from each instance of the specified field.
+        :param bool entities: (optional) When `true` entities are extracted from the
+        identified sentence parts.
+        :param bool keywords: (optional) When `true`, keywords are extracted from the
+        identified sentence parts.
+        :param int limit: (optional) The maximum number of semantic roles enrichments to
+        extact from each instance of the specified field.
         """
         self.entities = entities
         self.keywords = keywords
@@ -4619,16 +5073,20 @@ class NluEnrichmentSentiment(object):
     """
     An object specifying the sentiment extraction enrichment and related parameters.
 
-    :attr bool document: (optional) When `true`, sentiment analysis is performed on the entire field.
-    :attr list[str] targets: (optional) A comma-separated list of target strings that will have any associated sentiment analyzed.
+    :attr bool document: (optional) When `true`, sentiment analysis is performed on the
+    entire field.
+    :attr list[str] targets: (optional) A comma-separated list of target strings that will
+    have any associated sentiment analyzed.
     """
 
     def __init__(self, document=None, targets=None):
         """
         Initialize a NluEnrichmentSentiment object.
 
-        :param bool document: (optional) When `true`, sentiment analysis is performed on the entire field.
-        :param list[str] targets: (optional) A comma-separated list of target strings that will have any associated sentiment analyzed.
+        :param bool document: (optional) When `true`, sentiment analysis is performed on
+        the entire field.
+        :param list[str] targets: (optional) A comma-separated list of target strings that
+        will have any associated sentiment analyzed.
         """
         self.document = document
         self.targets = targets
@@ -4671,7 +5129,29 @@ class NormalizationOperation(object):
     """
     NormalizationOperation.
 
-    :attr str operation: (optional) Identifies what type of operation to perform.   **copy** - Copies the value of the `source_field` to the `destination_field` field. If the `destination_field` already exists, then the value of the `source_field` overwrites the original value of the `destination_field`.   **move** - Renames (moves) the `source_field` to the `destination_field`. If the `destination_field` already exists, then the value of the `source_field` overwrites the original value of the `destination_field`. Rename is identical to copy, except that the `source_field` is removed after the value has been copied to the `destination_field` (it is the same as a _copy_ followed by a _remove_).   **merge** - Merges the value of the `source_field` with the value of the `destination_field`. The `destination_field` is converted into an array if it is not already an array, and the value of the `source_field` is appended to the array. This operation removes the `source_field` after the merge. If the `source_field` does not exist in the current document, then the `destination_field` is still converted into an array (if it is not an array already). This is ensures the type for `destination_field` is consistent across all documents.   **remove** - Deletes the `source_field` field. The `destination_field` is ignored for this operation.   **remove_nulls** - Removes all nested null (blank) leif values from the JSON tree. `source_field` and `destination_field` are ignored by this operation because _remove_nulls_ operates on the entire JSON tree. Typically, `remove_nulls` is invoked as the last normalization operation (if it is inoked at all, it can be time-expensive).
+    :attr str operation: (optional) Identifies what type of operation to perform.
+    **copy** - Copies the value of the `source_field` to the `destination_field` field. If
+    the `destination_field` already exists, then the value of the `source_field`
+    overwrites the original value of the `destination_field`.
+    **move** - Renames (moves) the `source_field` to the `destination_field`. If the
+    `destination_field` already exists, then the value of the `source_field` overwrites
+    the original value of the `destination_field`. Rename is identical to copy, except
+    that the `source_field` is removed after the value has been copied to the
+    `destination_field` (it is the same as a _copy_ followed by a _remove_).
+    **merge** - Merges the value of the `source_field` with the value of the
+    `destination_field`. The `destination_field` is converted into an array if it is not
+    already an array, and the value of the `source_field` is appended to the array. This
+    operation removes the `source_field` after the merge. If the `source_field` does not
+    exist in the current document, then the `destination_field` is still converted into an
+    array (if it is not an array already). This is ensures the type for
+    `destination_field` is consistent across all documents.
+    **remove** - Deletes the `source_field` field. The `destination_field` is ignored for
+    this operation.
+    **remove_nulls** - Removes all nested null (blank) leif values from the JSON tree.
+    `source_field` and `destination_field` are ignored by this operation because
+    _remove_nulls_ operates on the entire JSON tree. Typically, `remove_nulls` is invoked
+    as the last normalization operation (if it is inoked at all, it can be
+    time-expensive).
     :attr str source_field: (optional) The source field for the operation.
     :attr str destination_field: (optional) The destination field for the operation.
     """
@@ -4683,7 +5163,30 @@ class NormalizationOperation(object):
         """
         Initialize a NormalizationOperation object.
 
-        :param str operation: (optional) Identifies what type of operation to perform.   **copy** - Copies the value of the `source_field` to the `destination_field` field. If the `destination_field` already exists, then the value of the `source_field` overwrites the original value of the `destination_field`.   **move** - Renames (moves) the `source_field` to the `destination_field`. If the `destination_field` already exists, then the value of the `source_field` overwrites the original value of the `destination_field`. Rename is identical to copy, except that the `source_field` is removed after the value has been copied to the `destination_field` (it is the same as a _copy_ followed by a _remove_).   **merge** - Merges the value of the `source_field` with the value of the `destination_field`. The `destination_field` is converted into an array if it is not already an array, and the value of the `source_field` is appended to the array. This operation removes the `source_field` after the merge. If the `source_field` does not exist in the current document, then the `destination_field` is still converted into an array (if it is not an array already). This is ensures the type for `destination_field` is consistent across all documents.   **remove** - Deletes the `source_field` field. The `destination_field` is ignored for this operation.   **remove_nulls** - Removes all nested null (blank) leif values from the JSON tree. `source_field` and `destination_field` are ignored by this operation because _remove_nulls_ operates on the entire JSON tree. Typically, `remove_nulls` is invoked as the last normalization operation (if it is inoked at all, it can be time-expensive).
+        :param str operation: (optional) Identifies what type of operation to perform.
+        **copy** - Copies the value of the `source_field` to the `destination_field`
+        field. If the `destination_field` already exists, then the value of the
+        `source_field` overwrites the original value of the `destination_field`.
+        **move** - Renames (moves) the `source_field` to the `destination_field`. If the
+        `destination_field` already exists, then the value of the `source_field`
+        overwrites the original value of the `destination_field`. Rename is identical to
+        copy, except that the `source_field` is removed after the value has been copied to
+        the `destination_field` (it is the same as a _copy_ followed by a _remove_).
+        **merge** - Merges the value of the `source_field` with the value of the
+        `destination_field`. The `destination_field` is converted into an array if it is
+        not already an array, and the value of the `source_field` is appended to the
+        array. This operation removes the `source_field` after the merge. If the
+        `source_field` does not exist in the current document, then the
+        `destination_field` is still converted into an array (if it is not an array
+        already). This is ensures the type for `destination_field` is consistent across
+        all documents.
+        **remove** - Deletes the `source_field` field. The `destination_field` is ignored
+        for this operation.
+        **remove_nulls** - Removes all nested null (blank) leif values from the JSON tree.
+        `source_field` and `destination_field` are ignored by this operation because
+        _remove_nulls_ operates on the entire JSON tree. Typically, `remove_nulls` is
+        invoked as the last normalization operation (if it is inoked at all, it can be
+        time-expensive).
         :param str source_field: (optional) The source field for the operation.
         :param str destination_field: (optional) The destination field for the operation.
         """
@@ -4734,10 +5237,14 @@ class Notice(object):
     """
     A notice produced for the collection.
 
-    :attr str notice_id: (optional) Identifies the notice. Many notices might have the same ID. This field exists so that user applications can programmatically identify a notice and take automatic corrective action.
-    :attr datetime created: (optional) The creation date of the collection in the format yyyy-MM-dd'T'HH:mm:ss.SSS'Z'.
+    :attr str notice_id: (optional) Identifies the notice. Many notices might have the
+    same ID. This field exists so that user applications can programmatically identify a
+    notice and take automatic corrective action.
+    :attr datetime created: (optional) The creation date of the collection in the format
+    yyyy-MM-dd'T'HH:mm:ss.SSS'Z'.
     :attr str document_id: (optional) Unique identifier of the document.
-    :attr str query_id: (optional) Unique identifier of the query used for relevance training.
+    :attr str query_id: (optional) Unique identifier of the query used for relevance
+    training.
     :attr str severity: (optional) Severity level of the notice.
     :attr str step: (optional) Ingestion or training step in which the notice occurred.
     :attr str description: (optional) The description of the notice.
@@ -4754,12 +5261,17 @@ class Notice(object):
         """
         Initialize a Notice object.
 
-        :param str notice_id: (optional) Identifies the notice. Many notices might have the same ID. This field exists so that user applications can programmatically identify a notice and take automatic corrective action.
-        :param datetime created: (optional) The creation date of the collection in the format yyyy-MM-dd'T'HH:mm:ss.SSS'Z'.
+        :param str notice_id: (optional) Identifies the notice. Many notices might have
+        the same ID. This field exists so that user applications can programmatically
+        identify a notice and take automatic corrective action.
+        :param datetime created: (optional) The creation date of the collection in the
+        format yyyy-MM-dd'T'HH:mm:ss.SSS'Z'.
         :param str document_id: (optional) Unique identifier of the document.
-        :param str query_id: (optional) Unique identifier of the query used for relevance training.
+        :param str query_id: (optional) Unique identifier of the query used for relevance
+        training.
         :param str severity: (optional) Severity level of the notice.
-        :param str step: (optional) Ingestion or training step in which the notice occurred.
+        :param str step: (optional) Ingestion or training step in which the notice
+        occurred.
         :param str description: (optional) The description of the notice.
         """
         self.notice_id = notice_id
@@ -4921,10 +5433,12 @@ class QueryAggregation(object):
     """
     An aggregation produced by the Discovery service to analyze the input provided.
 
-    :attr str type: (optional) The type of aggregation command used. For example: term, filter, max, min, etc.
+    :attr str type: (optional) The type of aggregation command used. For example: term,
+    filter, max, min, etc.
     :attr list[AggregationResult] results: (optional)
     :attr int matching_results: (optional) Number of matching results.
-    :attr list[QueryAggregation] aggregations: (optional) Aggregations returned by the Discovery service.
+    :attr list[QueryAggregation] aggregations: (optional) Aggregations returned by the
+    Discovery service.
     """
 
     def __init__(self,
@@ -4935,10 +5449,12 @@ class QueryAggregation(object):
         """
         Initialize a QueryAggregation object.
 
-        :param str type: (optional) The type of aggregation command used. For example: term, filter, max, min, etc.
+        :param str type: (optional) The type of aggregation command used. For example:
+        term, filter, max, min, etc.
         :param list[AggregationResult] results: (optional)
         :param int matching_results: (optional) Number of matching results.
-        :param list[QueryAggregation] aggregations: (optional) Aggregations returned by the Discovery service.
+        :param list[QueryAggregation] aggregations: (optional) Aggregations returned by
+        the Discovery service.
         """
         self.type = type
         self.results = results
@@ -4999,14 +5515,19 @@ class QueryEntitiesContext(object):
     association. For example, if you wanted to query the city of London in England your
     query would look for `London` with the context of `England`.
 
-    :attr str text: (optional) Entity text to provide context for the queried entity and rank based on that association. For example, if you wanted to query the city of London in England your query would look for `London` with the context of `England`.
+    :attr str text: (optional) Entity text to provide context for the queried entity and
+    rank based on that association. For example, if you wanted to query the city of London
+    in England your query would look for `London` with the context of `England`.
     """
 
     def __init__(self, text=None):
         """
         Initialize a QueryEntitiesContext object.
 
-        :param str text: (optional) Entity text to provide context for the queried entity and rank based on that association. For example, if you wanted to query the city of London in England your query would look for `London` with the context of `England`.
+        :param str text: (optional) Entity text to provide context for the queried entity
+        and rank based on that association. For example, if you wanted to query the city
+        of London in England your query would look for `London` with the context of
+        `England`.
         """
         self.text = text
 
@@ -5146,7 +5667,8 @@ class QueryEntitiesResponseItem(object):
 
     :attr str text: (optional) Entity text content.
     :attr str type: (optional) The type of the result entity.
-    :attr list[QueryEvidence] evidence: (optional) List of different evidentiary items to support the result.
+    :attr list[QueryEvidence] evidence: (optional) List of different evidentiary items to
+    support the result.
     """
 
     def __init__(self, text=None, type=None, evidence=None):
@@ -5155,7 +5677,8 @@ class QueryEntitiesResponseItem(object):
 
         :param str text: (optional) Entity text content.
         :param str type: (optional) The type of the result entity.
-        :param list[QueryEvidence] evidence: (optional) List of different evidentiary items to support the result.
+        :param list[QueryEvidence] evidence: (optional) List of different evidentiary
+        items to support the result.
         """
         self.text = text
         self.type = type
@@ -5205,11 +5728,16 @@ class QueryEvidence(object):
     """
     Description of evidence location supporting Knoweldge Graph query result.
 
-    :attr str document_id: (optional) The docuemnt ID (as indexed in Discovery) of the evidence location.
-    :attr str field: (optional) The field of the document where the supporting evidence was identified.
-    :attr int start_offset: (optional) The start location of the evidence in the identified field. This value is inclusive.
-    :attr int end_offset: (optional) The end location of the evidence in the identified field. This value is inclusive.
-    :attr list[QueryEvidenceEntity] entities: (optional) An array of entity objects that show evidence of the result.
+    :attr str document_id: (optional) The docuemnt ID (as indexed in Discovery) of the
+    evidence location.
+    :attr str field: (optional) The field of the document where the supporting evidence
+    was identified.
+    :attr int start_offset: (optional) The start location of the evidence in the
+    identified field. This value is inclusive.
+    :attr int end_offset: (optional) The end location of the evidence in the identified
+    field. This value is inclusive.
+    :attr list[QueryEvidenceEntity] entities: (optional) An array of entity objects that
+    show evidence of the result.
     """
 
     def __init__(self,
@@ -5221,11 +5749,16 @@ class QueryEvidence(object):
         """
         Initialize a QueryEvidence object.
 
-        :param str document_id: (optional) The docuemnt ID (as indexed in Discovery) of the evidence location.
-        :param str field: (optional) The field of the document where the supporting evidence was identified.
-        :param int start_offset: (optional) The start location of the evidence in the identified field. This value is inclusive.
-        :param int end_offset: (optional) The end location of the evidence in the identified field. This value is inclusive.
-        :param list[QueryEvidenceEntity] entities: (optional) An array of entity objects that show evidence of the result.
+        :param str document_id: (optional) The docuemnt ID (as indexed in Discovery) of
+        the evidence location.
+        :param str field: (optional) The field of the document where the supporting
+        evidence was identified.
+        :param int start_offset: (optional) The start location of the evidence in the
+        identified field. This value is inclusive.
+        :param int end_offset: (optional) The end location of the evidence in the
+        identified field. This value is inclusive.
+        :param list[QueryEvidenceEntity] entities: (optional) An array of entity objects
+        that show evidence of the result.
         """
         self.document_id = document_id
         self.field = field
@@ -5286,10 +5819,14 @@ class QueryEvidenceEntity(object):
     """
     Entity description and location within evidence field.
 
-    :attr str type: (optional) The entity type for this entity. Possible types vary based on model used.
-    :attr str text: (optional) The original text of this entity as found in the evidence field.
-    :attr int start_offset: (optional) The start location of the entity text in the identified field. This value is inclusive.
-    :attr int end_offset: (optional) The end location of the entity text in the identified field. This value is exclusive.
+    :attr str type: (optional) The entity type for this entity. Possible types vary based
+    on model used.
+    :attr str text: (optional) The original text of this entity as found in the evidence
+    field.
+    :attr int start_offset: (optional) The start location of the entity text in the
+    identified field. This value is inclusive.
+    :attr int end_offset: (optional) The end location of the entity text in the identified
+    field. This value is exclusive.
     """
 
     def __init__(self,
@@ -5300,10 +5837,14 @@ class QueryEvidenceEntity(object):
         """
         Initialize a QueryEvidenceEntity object.
 
-        :param str type: (optional) The entity type for this entity. Possible types vary based on model used.
-        :param str text: (optional) The original text of this entity as found in the evidence field.
-        :param int start_offset: (optional) The start location of the entity text in the identified field. This value is inclusive.
-        :param int end_offset: (optional) The end location of the entity text in the identified field. This value is exclusive.
+        :param str type: (optional) The entity type for this entity. Possible types vary
+        based on model used.
+        :param str text: (optional) The original text of this entity as found in the
+        evidence field.
+        :param int start_offset: (optional) The start location of the entity text in the
+        identified field. This value is inclusive.
+        :param int end_offset: (optional) The end location of the entity text in the
+        identified field. This value is exclusive.
         """
         self.type = type
         self.text = text
@@ -5357,7 +5898,8 @@ class QueryFilterType(object):
     QueryFilterType.
 
     :attr list[str] exclude: (optional) A comma-separated list of types to exclude.
-    :attr list[str] include: (optional) A comma-separated list of types to include. All other types are excluded.
+    :attr list[str] include: (optional) A comma-separated list of types to include. All
+    other types are excluded.
     """
 
     def __init__(self, exclude=None, include=None):
@@ -5365,7 +5907,8 @@ class QueryFilterType(object):
         Initialize a QueryFilterType object.
 
         :param list[str] exclude: (optional) A comma-separated list of types to exclude.
-        :param list[str] include: (optional) A comma-separated list of types to include. All other types are excluded.
+        :param list[str] include: (optional) A comma-separated list of types to include.
+        All other types are excluded.
         """
         self.exclude = exclude
         self.include = include
@@ -5498,14 +6041,19 @@ class QueryNoticesResult(object):
     QueryNoticesResult.
 
     :attr str id: (optional) The unique identifier of the document.
-    :attr float score: (optional) *Deprecated* This field is now part of the `result_metadata` object.
+    :attr float score: (optional) *Deprecated* This field is now part of the
+    `result_metadata` object.
     :attr object metadata: (optional) Metadata of the document.
-    :attr str collection_id: (optional) The collection ID of the collection containing the document for this result.
-    :attr QueryResultResultMetadata result_metadata: (optional) Metadata of the query result.
-    :attr int code: (optional) The internal status code returned by the ingestion subsystem indicating the overall result of ingesting the source document.
+    :attr str collection_id: (optional) The collection ID of the collection containing the
+    document for this result.
+    :attr QueryResultResultMetadata result_metadata: (optional) Metadata of the query
+    result.
+    :attr int code: (optional) The internal status code returned by the ingestion
+    subsystem indicating the overall result of ingesting the source document.
     :attr str filename: (optional) Name of the original source file (if available).
     :attr str file_type: (optional) The type of the original source file.
-    :attr str sha1: (optional) The SHA-1 hash of the original source file (formatted as a hexadecimal string).
+    :attr str sha1: (optional) The SHA-1 hash of the original source file (formatted as a
+    hexadecimal string).
     :attr list[Notice] notices: (optional) Array of notices for the document.
     """
 
@@ -5525,14 +6073,19 @@ class QueryNoticesResult(object):
         Initialize a QueryNoticesResult object.
 
         :param str id: (optional) The unique identifier of the document.
-        :param float score: (optional) *Deprecated* This field is now part of the `result_metadata` object.
+        :param float score: (optional) *Deprecated* This field is now part of the
+        `result_metadata` object.
         :param object metadata: (optional) Metadata of the document.
-        :param str collection_id: (optional) The collection ID of the collection containing the document for this result.
-        :param QueryResultResultMetadata result_metadata: (optional) Metadata of the query result.
-        :param int code: (optional) The internal status code returned by the ingestion subsystem indicating the overall result of ingesting the source document.
+        :param str collection_id: (optional) The collection ID of the collection
+        containing the document for this result.
+        :param QueryResultResultMetadata result_metadata: (optional) Metadata of the query
+        result.
+        :param int code: (optional) The internal status code returned by the ingestion
+        subsystem indicating the overall result of ingesting the source document.
         :param str filename: (optional) Name of the original source file (if available).
         :param str file_type: (optional) The type of the original source file.
-        :param str sha1: (optional) The SHA-1 hash of the original source file (formatted as a hexadecimal string).
+        :param str sha1: (optional) The SHA-1 hash of the original source file (formatted
+        as a hexadecimal string).
         :param list[Notice] notices: (optional) Array of notices for the document.
         :param **kwargs: (optional) Any additional properties.
         """
@@ -5652,12 +6205,17 @@ class QueryPassages(object):
     """
     QueryPassages.
 
-    :attr str document_id: (optional) The unique identifier of the document from which the passage has been extracted.
-    :attr float passage_score: (optional) The confidence score of the passages's analysis. A higher score indicates greater confidence.
+    :attr str document_id: (optional) The unique identifier of the document from which the
+    passage has been extracted.
+    :attr float passage_score: (optional) The confidence score of the passages's analysis.
+    A higher score indicates greater confidence.
     :attr str passage_text: (optional) The content of the extracted passage.
-    :attr int start_offset: (optional) The position of the first character of the extracted passage in the originating field.
-    :attr int end_offset: (optional) The position of the last character of the extracted passage in the originating field.
-    :attr str field: (optional) The label of the field from which the passage has been extracted.
+    :attr int start_offset: (optional) The position of the first character of the
+    extracted passage in the originating field.
+    :attr int end_offset: (optional) The position of the last character of the extracted
+    passage in the originating field.
+    :attr str field: (optional) The label of the field from which the passage has been
+    extracted.
     """
 
     def __init__(self,
@@ -5670,12 +6228,17 @@ class QueryPassages(object):
         """
         Initialize a QueryPassages object.
 
-        :param str document_id: (optional) The unique identifier of the document from which the passage has been extracted.
-        :param float passage_score: (optional) The confidence score of the passages's analysis. A higher score indicates greater confidence.
+        :param str document_id: (optional) The unique identifier of the document from
+        which the passage has been extracted.
+        :param float passage_score: (optional) The confidence score of the passages's
+        analysis. A higher score indicates greater confidence.
         :param str passage_text: (optional) The content of the extracted passage.
-        :param int start_offset: (optional) The position of the first character of the extracted passage in the originating field.
-        :param int end_offset: (optional) The position of the last character of the extracted passage in the originating field.
-        :param str field: (optional) The label of the field from which the passage has been extracted.
+        :param int start_offset: (optional) The position of the first character of the
+        extracted passage in the originating field.
+        :param int end_offset: (optional) The position of the last character of the
+        extracted passage in the originating field.
+        :param str field: (optional) The label of the field from which the passage has
+        been extracted.
         """
         self.document_id = document_id
         self.passage_score = passage_score
@@ -5788,7 +6351,8 @@ class QueryRelationsEntity(object):
 
     :attr str text: (optional) Entity text content.
     :attr str type: (optional) The type of the specified entity.
-    :attr bool exact: (optional) If false, implicit querying is performed. The default is `false`.
+    :attr bool exact: (optional) If false, implicit querying is performed. The default is
+    `false`.
     """
 
     def __init__(self, text=None, type=None, exact=None):
@@ -5797,7 +6361,8 @@ class QueryRelationsEntity(object):
 
         :param str text: (optional) Entity text content.
         :param str type: (optional) The type of the specified entity.
-        :param bool exact: (optional) If false, implicit querying is performed. The default is `false`.
+        :param bool exact: (optional) If false, implicit querying is performed. The
+        default is `false`.
         """
         self.text = text
         self.type = type
@@ -5845,9 +6410,12 @@ class QueryRelationsFilter(object):
     """
     QueryRelationsFilter.
 
-    :attr QueryFilterType relation_types: (optional) A list of relation types to include or exclude from the query.
-    :attr QueryFilterType entity_types: (optional) A list of entity types to include or exclude from the query.
-    :attr list[str] document_ids: (optional) A comma-separated list of document IDs to include in the query.
+    :attr QueryFilterType relation_types: (optional) A list of relation types to include
+    or exclude from the query.
+    :attr QueryFilterType entity_types: (optional) A list of entity types to include or
+    exclude from the query.
+    :attr list[str] document_ids: (optional) A comma-separated list of document IDs to
+    include in the query.
     """
 
     def __init__(self,
@@ -5857,9 +6425,12 @@ class QueryRelationsFilter(object):
         """
         Initialize a QueryRelationsFilter object.
 
-        :param QueryFilterType relation_types: (optional) A list of relation types to include or exclude from the query.
-        :param QueryFilterType entity_types: (optional) A list of entity types to include or exclude from the query.
-        :param list[str] document_ids: (optional) A comma-separated list of document IDs to include in the query.
+        :param QueryFilterType relation_types: (optional) A list of relation types to
+        include or exclude from the query.
+        :param QueryFilterType entity_types: (optional) A list of entity types to include
+        or exclude from the query.
+        :param list[str] document_ids: (optional) A comma-separated list of document IDs
+        to include in the query.
         """
         self.relation_types = relation_types
         self.entity_types = entity_types
@@ -5911,8 +6482,10 @@ class QueryRelationsRelationship(object):
 
     :attr str type: (optional) The identified relationship type.
     :attr int frequency: (optional) The number of times the relationship is mentioned.
-    :attr list[QueryRelationsArgument] arguments: (optional) Information about the relationship.
-    :attr list[QueryEvidence] evidence: (optional) List of different evidentiary items to support the result.
+    :attr list[QueryRelationsArgument] arguments: (optional) Information about the
+    relationship.
+    :attr list[QueryEvidence] evidence: (optional) List of different evidentiary items to
+    support the result.
     """
 
     def __init__(self,
@@ -5924,9 +6497,12 @@ class QueryRelationsRelationship(object):
         Initialize a QueryRelationsRelationship object.
 
         :param str type: (optional) The identified relationship type.
-        :param int frequency: (optional) The number of times the relationship is mentioned.
-        :param list[QueryRelationsArgument] arguments: (optional) Information about the relationship.
-        :param list[QueryEvidence] evidence: (optional) List of different evidentiary items to support the result.
+        :param int frequency: (optional) The number of times the relationship is
+        mentioned.
+        :param list[QueryRelationsArgument] arguments: (optional) Information about the
+        relationship.
+        :param list[QueryEvidence] evidence: (optional) List of different evidentiary
+        items to support the result.
         """
         self.type = type
         self.frequency = frequency
@@ -6121,10 +6697,13 @@ class QueryResult(object):
     QueryResult.
 
     :attr str id: (optional) The unique identifier of the document.
-    :attr float score: (optional) *Deprecated* This field is now part of the `result_metadata` object.
+    :attr float score: (optional) *Deprecated* This field is now part of the
+    `result_metadata` object.
     :attr object metadata: (optional) Metadata of the document.
-    :attr str collection_id: (optional) The collection ID of the collection containing the document for this result.
-    :attr QueryResultResultMetadata result_metadata: (optional) Metadata of the query result.
+    :attr str collection_id: (optional) The collection ID of the collection containing the
+    document for this result.
+    :attr QueryResultResultMetadata result_metadata: (optional) Metadata of the query
+    result.
     """
 
     def __init__(self,
@@ -6138,10 +6717,13 @@ class QueryResult(object):
         Initialize a QueryResult object.
 
         :param str id: (optional) The unique identifier of the document.
-        :param float score: (optional) *Deprecated* This field is now part of the `result_metadata` object.
+        :param float score: (optional) *Deprecated* This field is now part of the
+        `result_metadata` object.
         :param object metadata: (optional) Metadata of the document.
-        :param str collection_id: (optional) The collection ID of the collection containing the document for this result.
-        :param QueryResultResultMetadata result_metadata: (optional) Metadata of the query result.
+        :param str collection_id: (optional) The collection ID of the collection
+        containing the document for this result.
+        :param QueryResultResultMetadata result_metadata: (optional) Metadata of the query
+        result.
         :param **kwargs: (optional) Any additional properties.
         """
         self.id = id
@@ -6227,14 +6809,16 @@ class QueryResultResultMetadata(object):
     """
     Metadata of a query result.
 
-    :attr float score: (optional) The confidence score of the result's analysis. A higher score indicating greater confidence.
+    :attr float score: (optional) The confidence score of the result's analysis. A higher
+    score indicating greater confidence.
     """
 
     def __init__(self, score=None):
         """
         Initialize a QueryResultResultMetadata object.
 
-        :param float score: (optional) The confidence score of the result's analysis. A higher score indicating greater confidence.
+        :param float score: (optional) The confidence score of the result's analysis. A
+        higher score indicating greater confidence.
         """
         self.score = score
 
@@ -6273,15 +6857,18 @@ class SegmentSettings(object):
     A list of Document Segmentation settings.
 
     :attr bool enabled: (optional) Enables/disables the Document Segmentation feature.
-    :attr list[str] selector_tags: (optional) Defines the heading level that splits into document segments. Valid values are h1, h2, h3, h4, h5, h6.
+    :attr list[str] selector_tags: (optional) Defines the heading level that splits into
+    document segments. Valid values are h1, h2, h3, h4, h5, h6.
     """
 
     def __init__(self, enabled=None, selector_tags=None):
         """
         Initialize a SegmentSettings object.
 
-        :param bool enabled: (optional) Enables/disables the Document Segmentation feature.
-        :param list[str] selector_tags: (optional) Defines the heading level that splits into document segments. Valid values are h1, h2, h3, h4, h5, h6.
+        :param bool enabled: (optional) Enables/disables the Document Segmentation
+        feature.
+        :param list[str] selector_tags: (optional) Defines the heading level that splits
+        into document segments. Valid values are h1, h2, h3, h4, h5, h6.
         """
         self.enabled = enabled
         self.selector_tags = selector_tags
@@ -6326,10 +6913,13 @@ class TestDocument(object):
 
     :attr str configuration_id: (optional) The unique identifier for the configuration.
     :attr str status: (optional) Status of the preview operation.
-    :attr int enriched_field_units: (optional) The number of 10-kB chunks of field data that were enriched. This can be used to estimate the cost of running a real ingestion.
+    :attr int enriched_field_units: (optional) The number of 10-kB chunks of field data
+    that were enriched. This can be used to estimate the cost of running a real ingestion.
     :attr str original_media_type: (optional) Format of the test document.
-    :attr list[DocumentSnapshot] snapshots: (optional) An array of objects that describe each step in the preview process.
-    :attr list[Notice] notices: (optional) An array of notice messages about the preview operation.
+    :attr list[DocumentSnapshot] snapshots: (optional) An array of objects that describe
+    each step in the preview process.
+    :attr list[Notice] notices: (optional) An array of notice messages about the preview
+    operation.
     """
 
     def __init__(self,
@@ -6342,12 +6932,17 @@ class TestDocument(object):
         """
         Initialize a TestDocument object.
 
-        :param str configuration_id: (optional) The unique identifier for the configuration.
+        :param str configuration_id: (optional) The unique identifier for the
+        configuration.
         :param str status: (optional) Status of the preview operation.
-        :param int enriched_field_units: (optional) The number of 10-kB chunks of field data that were enriched. This can be used to estimate the cost of running a real ingestion.
+        :param int enriched_field_units: (optional) The number of 10-kB chunks of field
+        data that were enriched. This can be used to estimate the cost of running a real
+        ingestion.
         :param str original_media_type: (optional) Format of the test document.
-        :param list[DocumentSnapshot] snapshots: (optional) An array of objects that describe each step in the preview process.
-        :param list[Notice] notices: (optional) An array of notice messages about the preview operation.
+        :param list[DocumentSnapshot] snapshots: (optional) An array of objects that
+        describe each step in the preview process.
+        :param list[Notice] notices: (optional) An array of notice messages about the
+        preview operation.
         """
         self.configuration_id = configuration_id
         self.status = status
@@ -6388,10 +6983,10 @@ class TestDocument(object):
         if hasattr(self, 'status') and self.status is not None:
             _dict['status'] = self.status
         if hasattr(self, 'enriched_field_units'
-                  ) and self.enriched_field_units is not None:
+                   ) and self.enriched_field_units is not None:
             _dict['enriched_field_units'] = self.enriched_field_units
         if hasattr(self, 'original_media_type'
-                  ) and self.original_media_type is not None:
+                   ) and self.original_media_type is not None:
             _dict['original_media_type'] = self.original_media_type
         if hasattr(self, 'snapshots') and self.snapshots is not None:
             _dict['snapshots'] = [x._to_dict() for x in self.snapshots]
@@ -6688,7 +7283,7 @@ class TrainingQuery(object):
         if hasattr(self, 'query_id') and self.query_id is not None:
             _dict['query_id'] = self.query_id
         if hasattr(self, 'natural_language_query'
-                  ) and self.natural_language_query is not None:
+                   ) and self.natural_language_query is not None:
             _dict['natural_language_query'] = self.natural_language_query
         if hasattr(self, 'filter') and self.filter is not None:
             _dict['filter'] = self.filter
@@ -6797,19 +7392,19 @@ class TrainingStatus(object):
         if hasattr(self, 'processing') and self.processing is not None:
             _dict['processing'] = self.processing
         if hasattr(self, 'minimum_queries_added'
-                  ) and self.minimum_queries_added is not None:
+                   ) and self.minimum_queries_added is not None:
             _dict['minimum_queries_added'] = self.minimum_queries_added
         if hasattr(self, 'minimum_examples_added'
-                  ) and self.minimum_examples_added is not None:
+                   ) and self.minimum_examples_added is not None:
             _dict['minimum_examples_added'] = self.minimum_examples_added
         if hasattr(self, 'sufficient_label_diversity'
-                  ) and self.sufficient_label_diversity is not None:
+                   ) and self.sufficient_label_diversity is not None:
             _dict[
                 'sufficient_label_diversity'] = self.sufficient_label_diversity
         if hasattr(self, 'notices') and self.notices is not None:
             _dict['notices'] = self.notices
         if hasattr(self, 'successfully_trained'
-                  ) and self.successfully_trained is not None:
+                   ) and self.successfully_trained is not None:
             _dict['successfully_trained'] = datetime_to_string(
                 self.successfully_trained)
         if hasattr(self, 'data_updated') and self.data_updated is not None:
@@ -7034,7 +7629,8 @@ class Calculation(object):
     """
     Calculation.
 
-    :attr str field: (optional) The field where the aggregation is located in the document.
+    :attr str field: (optional) The field where the aggregation is located in the
+    document.
     :attr float value: (optional) Value of the aggregation.
     """
 
@@ -7048,11 +7644,14 @@ class Calculation(object):
         """
         Initialize a Calculation object.
 
-        :param str type: (optional) The type of aggregation command used. For example: term, filter, max, min, etc.
+        :param str type: (optional) The type of aggregation command used. For example:
+        term, filter, max, min, etc.
         :param list[AggregationResult] results: (optional)
         :param int matching_results: (optional) Number of matching results.
-        :param list[QueryAggregation] aggregations: (optional) Aggregations returned by the Discovery service.
-        :param str field: (optional) The field where the aggregation is located in the document.
+        :param list[QueryAggregation] aggregations: (optional) Aggregations returned by
+        the Discovery service.
+        :param str field: (optional) The field where the aggregation is located in the
+        document.
         :param float value: (optional) Value of the aggregation.
         """
         self.field = field
@@ -7108,10 +7707,12 @@ class Filter(object):
         """
         Initialize a Filter object.
 
-        :param str type: (optional) The type of aggregation command used. For example: term, filter, max, min, etc.
+        :param str type: (optional) The type of aggregation command used. For example:
+        term, filter, max, min, etc.
         :param list[AggregationResult] results: (optional)
         :param int matching_results: (optional) Number of matching results.
-        :param list[QueryAggregation] aggregations: (optional) Aggregations returned by the Discovery service.
+        :param list[QueryAggregation] aggregations: (optional) Aggregations returned by
+        the Discovery service.
         :param str match: (optional) The match the aggregated results queried for.
         """
         self.match = match
@@ -7150,7 +7751,8 @@ class Histogram(object):
     """
     Histogram.
 
-    :attr str field: (optional) The field where the aggregation is located in the document.
+    :attr str field: (optional) The field where the aggregation is located in the
+    document.
     :attr int interval: (optional) Interval of the aggregation. (For 'histogram' type).
     """
 
@@ -7164,12 +7766,16 @@ class Histogram(object):
         """
         Initialize a Histogram object.
 
-        :param str type: (optional) The type of aggregation command used. For example: term, filter, max, min, etc.
+        :param str type: (optional) The type of aggregation command used. For example:
+        term, filter, max, min, etc.
         :param list[AggregationResult] results: (optional)
         :param int matching_results: (optional) Number of matching results.
-        :param list[QueryAggregation] aggregations: (optional) Aggregations returned by the Discovery service.
-        :param str field: (optional) The field where the aggregation is located in the document.
-        :param int interval: (optional) Interval of the aggregation. (For 'histogram' type).
+        :param list[QueryAggregation] aggregations: (optional) Aggregations returned by
+        the Discovery service.
+        :param str field: (optional) The field where the aggregation is located in the
+        document.
+        :param int interval: (optional) Interval of the aggregation. (For 'histogram'
+        type).
         """
         self.field = field
         self.interval = interval
@@ -7224,11 +7830,14 @@ class Nested(object):
         """
         Initialize a Nested object.
 
-        :param str type: (optional) The type of aggregation command used. For example: term, filter, max, min, etc.
+        :param str type: (optional) The type of aggregation command used. For example:
+        term, filter, max, min, etc.
         :param list[AggregationResult] results: (optional)
         :param int matching_results: (optional) Number of matching results.
-        :param list[QueryAggregation] aggregations: (optional) Aggregations returned by the Discovery service.
-        :param str path: (optional) The area of the results the aggregation was restricted to.
+        :param list[QueryAggregation] aggregations: (optional) Aggregations returned by
+        the Discovery service.
+        :param str path: (optional) The area of the results the aggregation was restricted
+        to.
         """
         self.path = path
 
@@ -7266,7 +7875,8 @@ class Term(object):
     """
     Term.
 
-    :attr str field: (optional) The field where the aggregation is located in the document.
+    :attr str field: (optional) The field where the aggregation is located in the
+    document.
     :attr int count: (optional)
     """
 
@@ -7280,11 +7890,14 @@ class Term(object):
         """
         Initialize a Term object.
 
-        :param str type: (optional) The type of aggregation command used. For example: term, filter, max, min, etc.
+        :param str type: (optional) The type of aggregation command used. For example:
+        term, filter, max, min, etc.
         :param list[AggregationResult] results: (optional)
         :param int matching_results: (optional) Number of matching results.
-        :param list[QueryAggregation] aggregations: (optional) Aggregations returned by the Discovery service.
-        :param str field: (optional) The field where the aggregation is located in the document.
+        :param list[QueryAggregation] aggregations: (optional) Aggregations returned by
+        the Discovery service.
+        :param str field: (optional) The field where the aggregation is located in the
+        document.
         :param int count: (optional)
         """
         self.field = field
@@ -7328,9 +7941,14 @@ class Timeslice(object):
     """
     Timeslice.
 
-    :attr str field: (optional) The field where the aggregation is located in the document.
-    :attr str interval: (optional) Interval of the aggregation. Valid date interval values are second/seconds minute/minutes, hour/hours, day/days, week/weeks, month/months, and year/years.
-    :attr bool anomaly: (optional) Used to inducate that anomaly detection should be performed. Anomaly detection is used to locate unusual datapoints within a time series.
+    :attr str field: (optional) The field where the aggregation is located in the
+    document.
+    :attr str interval: (optional) Interval of the aggregation. Valid date interval values
+    are second/seconds minute/minutes, hour/hours, day/days, week/weeks, month/months, and
+    year/years.
+    :attr bool anomaly: (optional) Used to inducate that anomaly detection should be
+    performed. Anomaly detection is used to locate unusual datapoints within a time
+    series.
     """
 
     def __init__(self,
@@ -7344,13 +7962,20 @@ class Timeslice(object):
         """
         Initialize a Timeslice object.
 
-        :param str type: (optional) The type of aggregation command used. For example: term, filter, max, min, etc.
+        :param str type: (optional) The type of aggregation command used. For example:
+        term, filter, max, min, etc.
         :param list[AggregationResult] results: (optional)
         :param int matching_results: (optional) Number of matching results.
-        :param list[QueryAggregation] aggregations: (optional) Aggregations returned by the Discovery service.
-        :param str field: (optional) The field where the aggregation is located in the document.
-        :param str interval: (optional) Interval of the aggregation. Valid date interval values are second/seconds minute/minutes, hour/hours, day/days, week/weeks, month/months, and year/years.
-        :param bool anomaly: (optional) Used to inducate that anomaly detection should be performed. Anomaly detection is used to locate unusual datapoints within a time series.
+        :param list[QueryAggregation] aggregations: (optional) Aggregations returned by
+        the Discovery service.
+        :param str field: (optional) The field where the aggregation is located in the
+        document.
+        :param str interval: (optional) Interval of the aggregation. Valid date interval
+        values are second/seconds minute/minutes, hour/hours, day/days, week/weeks,
+        month/months, and year/years.
+        :param bool anomaly: (optional) Used to inducate that anomaly detection should be
+        performed. Anomaly detection is used to locate unusual datapoints within a time
+        series.
         """
         self.field = field
         self.interval = interval
@@ -7412,10 +8037,12 @@ class TopHits(object):
         """
         Initialize a TopHits object.
 
-        :param str type: (optional) The type of aggregation command used. For example: term, filter, max, min, etc.
+        :param str type: (optional) The type of aggregation command used. For example:
+        term, filter, max, min, etc.
         :param list[AggregationResult] results: (optional)
         :param int matching_results: (optional) Number of matching results.
-        :param list[QueryAggregation] aggregations: (optional) Aggregations returned by the Discovery service.
+        :param list[QueryAggregation] aggregations: (optional) Aggregations returned by
+        the Discovery service.
         :param int size: (optional) Number of top hits returned by the aggregation.
         :param TopHitsResults hits: (optional)
         """

--- a/watson_developer_cloud/language_translator_v2.py
+++ b/watson_developer_cloud/language_translator_v2.py
@@ -25,7 +25,6 @@ from __future__ import absolute_import
 
 import json
 from .watson_service import WatsonService
-from .utils import deprecated
 
 ##############################################################################
 # Service
@@ -93,7 +92,6 @@ class LanguageTranslatorV2(WatsonService):
     # Translation
     #########################
 
-    @deprecated('Use Language Translator V3.')
     def translate(self,
                   text,
                   model_id=None,
@@ -144,7 +142,6 @@ class LanguageTranslatorV2(WatsonService):
     # Identification
     #########################
 
-    @deprecated('Use Language Translator V3.')
     def identify(self, text, **kwargs):
         """
         Identify language.
@@ -172,7 +169,6 @@ class LanguageTranslatorV2(WatsonService):
             accept_json=True)
         return response
 
-    @deprecated('Use Language Translator V3.')
     def list_identifiable_languages(self, **kwargs):
         """
         List identifiable languages.
@@ -196,7 +192,6 @@ class LanguageTranslatorV2(WatsonService):
     # Models
     #########################
 
-    @deprecated('Use Language Translator V3.')
     def create_model(self,
                      base_model_id,
                      name=None,
@@ -280,7 +275,6 @@ class LanguageTranslatorV2(WatsonService):
             accept_json=True)
         return response
 
-    @deprecated('Use Language Translator V3.')
     def delete_model(self, model_id, **kwargs):
         """
         Delete model.
@@ -302,7 +296,6 @@ class LanguageTranslatorV2(WatsonService):
             method='DELETE', url=url, headers=headers, accept_json=True)
         return response
 
-    @deprecated('Use Language Translator V3.')
     def get_model(self, model_id, **kwargs):
         """
         Get model details.
@@ -325,7 +318,6 @@ class LanguageTranslatorV2(WatsonService):
             method='GET', url=url, headers=headers, accept_json=True)
         return response
 
-    @deprecated('Use Language Translator V3.')
     def list_models(self,
                     source=None,
                     target=None,

--- a/watson_developer_cloud/language_translator_v2.py
+++ b/watson_developer_cloud/language_translator_v2.py
@@ -25,6 +25,7 @@ from __future__ import absolute_import
 
 import json
 from .watson_service import WatsonService
+from .utils import deprecated
 
 ##############################################################################
 # Service
@@ -92,6 +93,7 @@ class LanguageTranslatorV2(WatsonService):
     # Translation
     #########################
 
+    @deprecated('Use Language Translator V3.')
     def translate(self,
                   text,
                   model_id=None,
@@ -142,6 +144,7 @@ class LanguageTranslatorV2(WatsonService):
     # Identification
     #########################
 
+    @deprecated('Use Language Translator V3.')
     def identify(self, text, **kwargs):
         """
         Identify language.
@@ -169,6 +172,7 @@ class LanguageTranslatorV2(WatsonService):
             accept_json=True)
         return response
 
+    @deprecated('Use Language Translator V3.')
     def list_identifiable_languages(self, **kwargs):
         """
         List identifiable languages.
@@ -192,6 +196,7 @@ class LanguageTranslatorV2(WatsonService):
     # Models
     #########################
 
+    @deprecated('Use Language Translator V3.')
     def create_model(self,
                      base_model_id,
                      name=None,
@@ -275,6 +280,7 @@ class LanguageTranslatorV2(WatsonService):
             accept_json=True)
         return response
 
+    @deprecated('Use Language Translator V3.')
     def delete_model(self, model_id, **kwargs):
         """
         Delete model.
@@ -296,6 +302,7 @@ class LanguageTranslatorV2(WatsonService):
             method='DELETE', url=url, headers=headers, accept_json=True)
         return response
 
+    @deprecated('Use Language Translator V3.')
     def get_model(self, model_id, **kwargs):
         """
         Get model details.
@@ -318,6 +325,7 @@ class LanguageTranslatorV2(WatsonService):
             method='GET', url=url, headers=headers, accept_json=True)
         return response
 
+    @deprecated('Use Language Translator V3.')
     def list_models(self,
                     source=None,
                     target=None,

--- a/watson_developer_cloud/natural_language_classifier_v1.py
+++ b/watson_developer_cloud/natural_language_classifier_v1.py
@@ -36,12 +36,13 @@ class NaturalLanguageClassifierV1(WatsonService):
 
     default_url = 'https://gateway.watsonplatform.net/natural-language-classifier/api'
 
-    def __init__(
-            self,
-            url=default_url,
-            username=None,
-            password=None,
-    ):
+    def __init__(self,
+                 url=default_url,
+                 username=None,
+                 password=None,
+                 iam_api_key=None,
+                 iam_access_token=None,
+                 iam_url=None):
         """
         Construct a new client for the Natural Language Classifier service.
 
@@ -61,6 +62,17 @@ class NaturalLanguageClassifierV1(WatsonService):
                Bluemix, the credentials will be automatically loaded from the
                `VCAP_SERVICES` environment variable.
 
+        :param str iam_api_key: An API key that can be used to request IAM tokens. If
+               this API key is provided, the SDK will manage the token and handle the
+               refreshing.
+
+        :param str iam_access_token:  An IAM access token is fully managed by the application.
+               Responsibility falls on the application to refresh the token, either before
+               it expires or reactively upon receiving a 401 from the service as any requests
+               made with an expired token will fail.
+
+        :param str iam_url: An optional URL for the IAM service API. Defaults to
+               'https://iam.ng.bluemix.net/identity/token'.
         """
 
         WatsonService.__init__(
@@ -69,6 +81,9 @@ class NaturalLanguageClassifierV1(WatsonService):
             url=url,
             username=username,
             password=password,
+            iam_api_key=iam_api_key,
+            iam_access_token=iam_access_token,
+            iam_url=iam_url,
             use_vcap_services=True)
 
     #########################

--- a/watson_developer_cloud/natural_language_classifier_v1.py
+++ b/watson_developer_cloud/natural_language_classifier_v1.py
@@ -14,10 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """
-IBM Watson Natural Language Classifier uses machine learning algorithms to return the top
-matching predefined classes for short text input. You create and train a classifier to
-connect predefined classes to example texts so that the service can apply those classes to
-new inputs.
+IBM Watson&trade; Natural Language Classifier uses machine learning algorithms to return
+the top matching predefined classes for short text input. You create and train a
+classifier to connect predefined classes to example texts so that the service can apply
+those classes to new inputs.
 """
 
 from __future__ import absolute_import
@@ -36,13 +36,12 @@ class NaturalLanguageClassifierV1(WatsonService):
 
     default_url = 'https://gateway.watsonplatform.net/natural-language-classifier/api'
 
-    def __init__(self,
-                 url=default_url,
-                 username=None,
-                 password=None,
-                 iam_api_key=None,
-                 iam_access_token=None,
-                 iam_url=None):
+    def __init__(
+            self,
+            url=default_url,
+            username=None,
+            password=None,
+    ):
         """
         Construct a new client for the Natural Language Classifier service.
 
@@ -62,17 +61,6 @@ class NaturalLanguageClassifierV1(WatsonService):
                Bluemix, the credentials will be automatically loaded from the
                `VCAP_SERVICES` environment variable.
 
-        :param str iam_api_key: An API key that can be used to request IAM tokens. If
-               this API key is provided, the SDK will manage the token and handle the
-               refreshing.
-
-        :param str iam_access_token:  An IAM access token is fully managed by the application.
-               Responsibility falls on the application to refresh the token, either before
-               it expires or reactively upon receiving a 401 from the service as any requests
-               made with an expired token will fail.
-
-        :param str iam_url: An optional URL for the IAM service API. Defaults to
-               'https://iam.ng.bluemix.net/identity/token'.
         """
 
         WatsonService.__init__(
@@ -81,9 +69,6 @@ class NaturalLanguageClassifierV1(WatsonService):
             url=url,
             username=username,
             password=password,
-            iam_api_key=iam_api_key,
-            iam_access_token=iam_access_token,
-            iam_url=iam_url,
             use_vcap_services=True)
 
     #########################
@@ -126,8 +111,8 @@ class NaturalLanguageClassifierV1(WatsonService):
         Classify multiple phrases.
 
         Returns label information for multiple phrases. The status must be `Available`
-        before you can use the classifier to classify text.  Note that classifying
-        Japanese texts is a beta feature.
+        before you can use the classifier to classify text.
+        Note that classifying Japanese texts is a beta feature.
 
         :param str classifier_id: Classifier ID to use.
         :param list[ClassifyInput] collection: The submitted phrases.
@@ -172,8 +157,16 @@ class NaturalLanguageClassifierV1(WatsonService):
         Sends data to create and train a classifier and returns information about the new
         classifier.
 
-        :param file metadata: Metadata in JSON format. The metadata identifies the language of the data, and an optional name to identify the classifier. Specify the language with the 2-letter primary language code as assigned in ISO standard 639.  Supported languages are English (`en`), Arabic (`ar`), French (`fr`), German, (`de`), Italian (`it`), Japanese (`ja`), Korean (`ko`), Brazilian Portuguese (`pt`), and Spanish (`es`).
-        :param file training_data: Training data in CSV format. Each text value must have at least one class. The data can include up to 20,000 records. For details, see [Data preparation](https://console.bluemix.net/docs/services/natural-language-classifier/using-your-data.html).
+        :param file metadata: Metadata in JSON format. The metadata identifies the
+        language of the data, and an optional name to identify the classifier. Specify the
+        language with the 2-letter primary language code as assigned in ISO standard 639.
+        Supported languages are English (`en`), Arabic (`ar`), French (`fr`), German,
+        (`de`), Italian (`it`), Japanese (`ja`), Korean (`ko`), Brazilian Portuguese
+        (`pt`), and Spanish (`es`).
+        :param file training_data: Training data in CSV format. Each text value must have
+        at least one class. The data can include up to 20,000 records. For details, see
+        [Data
+        preparation](https://console.bluemix.net/docs/services/natural-language-classifier/using-your-data.html).
         :param str metadata_filename: The filename for training_metadata.
         :param str training_data_filename: The filename for training_data.
         :param dict headers: A `dict` containing the request headers
@@ -281,7 +274,8 @@ class Classification(object):
     :attr str url: (optional) Link to the classifier.
     :attr str text: (optional) The submitted phrase.
     :attr str top_class: (optional) The class with the highest confidence.
-    :attr list[ClassifiedClass] classes: (optional) An array of up to ten class-confidence pairs sorted in descending order of confidence.
+    :attr list[ClassifiedClass] classes: (optional) An array of up to ten class-confidence
+    pairs sorted in descending order of confidence.
     """
 
     def __init__(self,
@@ -297,7 +291,8 @@ class Classification(object):
         :param str url: (optional) Link to the classifier.
         :param str text: (optional) The submitted phrase.
         :param str top_class: (optional) The class with the highest confidence.
-        :param list[ClassifiedClass] classes: (optional) An array of up to ten class-confidence pairs sorted in descending order of confidence.
+        :param list[ClassifiedClass] classes: (optional) An array of up to ten
+        class-confidence pairs sorted in descending order of confidence.
         """
         self.classifier_id = classifier_id
         self.url = url
@@ -359,7 +354,8 @@ class ClassificationCollection(object):
 
     :attr str classifier_id: (optional) Unique identifier for this classifier.
     :attr str url: (optional) Link to the classifier.
-    :attr list[CollectionItem] collection: (optional) An array of classifier responses for each submitted phrase.
+    :attr list[CollectionItem] collection: (optional) An array of classifier responses for
+    each submitted phrase.
     """
 
     def __init__(self, classifier_id=None, url=None, collection=None):
@@ -368,7 +364,8 @@ class ClassificationCollection(object):
 
         :param str classifier_id: (optional) Unique identifier for this classifier.
         :param str url: (optional) Link to the classifier.
-        :param list[CollectionItem] collection: (optional) An array of classifier responses for each submitted phrase.
+        :param list[CollectionItem] collection: (optional) An array of classifier
+        responses for each submitted phrase.
         """
         self.classifier_id = classifier_id
         self.url = url
@@ -418,7 +415,8 @@ class ClassifiedClass(object):
     """
     Class and confidence.
 
-    :attr float confidence: (optional) A decimal percentage that represents the confidence that Watson has in this class. Higher values represent higher confidences.
+    :attr float confidence: (optional) A decimal percentage that represents the confidence
+    that Watson has in this class. Higher values represent higher confidences.
     :attr str class_name: (optional) Class label.
     """
 
@@ -426,7 +424,9 @@ class ClassifiedClass(object):
         """
         Initialize a ClassifiedClass object.
 
-        :param float confidence: (optional) A decimal percentage that represents the confidence that Watson has in this class. Higher values represent higher confidences.
+        :param float confidence: (optional) A decimal percentage that represents the
+        confidence that Watson has in this class. Higher values represent higher
+        confidences.
         :param str class_name: (optional) Class label.
         """
         self.confidence = confidence
@@ -494,7 +494,8 @@ class Classifier(object):
         :param str classifier_id: Unique identifier for this classifier.
         :param str name: (optional) User-supplied name for the classifier.
         :param str status: (optional) The state of the classifier.
-        :param datetime created: (optional) Date and time (UTC) the classifier was created.
+        :param datetime created: (optional) Date and time (UTC) the classifier was
+        created.
         :param str status_description: (optional) Additional detail about the status.
         :param str language: (optional) The language used for the classifier.
         """
@@ -573,14 +574,16 @@ class ClassifierList(object):
     """
     List of available classifiers.
 
-    :attr list[Classifier] classifiers: The classifiers available to the user. Returns an empty array if no classifiers are available.
+    :attr list[Classifier] classifiers: The classifiers available to the user. Returns an
+    empty array if no classifiers are available.
     """
 
     def __init__(self, classifiers):
         """
         Initialize a ClassifierList object.
 
-        :param list[Classifier] classifiers: The classifiers available to the user. Returns an empty array if no classifiers are available.
+        :param list[Classifier] classifiers: The classifiers available to the user.
+        Returns an empty array if no classifiers are available.
         """
         self.classifiers = classifiers
 
@@ -674,7 +677,8 @@ class CollectionItem(object):
 
     :attr str text: (optional) The submitted phrase.
     :attr str top_class: (optional) The class with the highest confidence.
-    :attr list[ClassifiedClass] classes: (optional) An array of up to ten class-confidence pairs sorted in descending order of confidence.
+    :attr list[ClassifiedClass] classes: (optional) An array of up to ten class-confidence
+    pairs sorted in descending order of confidence.
     """
 
     def __init__(self, text=None, top_class=None, classes=None):
@@ -683,7 +687,8 @@ class CollectionItem(object):
 
         :param str text: (optional) The submitted phrase.
         :param str top_class: (optional) The class with the highest confidence.
-        :param list[ClassifiedClass] classes: (optional) An array of up to ten class-confidence pairs sorted in descending order of confidence.
+        :param list[ClassifiedClass] classes: (optional) An array of up to ten
+        class-confidence pairs sorted in descending order of confidence.
         """
         self.text = text
         self.top_class = top_class

--- a/watson_developer_cloud/natural_language_understanding_v1.py
+++ b/watson_developer_cloud/natural_language_understanding_v1.py
@@ -124,29 +124,41 @@ class NaturalLanguageUnderstandingV1(WatsonService):
         Analyze text, HTML, or a public webpage.
 
         Analyzes text, HTML, or a public webpage with one or more text analysis features.
-        ### Concepts Identify general concepts that are referenced or alluded to in your
-        content. Concepts that are detected typically have an associated link to a DBpedia
-        resource.  ### Emotion Detect anger, disgust, fear, joy, or sadness that is
-        conveyed by your content. Emotion information can be returned for detected
-        entities, keywords, or user-specified target phrases found in the text.  ###
-        Entities Detect important people, places, geopolitical entities and other types of
-        entities in your content. Entity detection recognizes consecutive coreferences of
-        each entity. For example, analysis of the following text would count \"Barack
-        Obama\" and \"He\" as the same entity:  \"Barack Obama was the 44th President of
-        the United States. He took office in January 2009.\"  ### Keywords Determine the
-        most important keywords in your content. Keyword phrases are organized by
-        relevance in the results.  ### Metadata Get author information, publication date,
-        and the title of your text/HTML content.  ### Relations Recognize when two
-        entities are related, and identify the type of relation.  For example, you can
-        identify an \"awardedTo\" relation between an award and its recipient.  ###
-        Semantic Roles Parse sentences into subject-action-object form, and identify
-        entities and keywords that are subjects or objects of an action.  ### Sentiment
+        ### Concepts
+        Identify general concepts that are referenced or alluded to in your content.
+        Concepts that are detected typically have an associated link to a DBpedia
+        resource.
+        ### Emotion
+        Detect anger, disgust, fear, joy, or sadness that is conveyed by your content.
+        Emotion information can be returned for detected entities, keywords, or
+        user-specified target phrases found in the text.
+        ### Entities
+        Detect important people, places, geopolitical entities and other types of entities
+        in your content. Entity detection recognizes consecutive coreferences of each
+        entity. For example, analysis of the following text would count \"Barack Obama\"
+        and \"He\" as the same entity:
+        \"Barack Obama was the 44th President of the United States. He took office in
+        January 2009.\"
+        ### Keywords
+        Determine the most important keywords in your content. Keyword phrases are
+        organized by relevance in the results.
+        ### Metadata
+        Get author information, publication date, and the title of your text/HTML content.
+        ### Relations
+        Recognize when two entities are related, and identify the type of relation.  For
+        example, you can identify an \"awardedTo\" relation between an award and its
+        recipient.
+        ### Semantic Roles
+        Parse sentences into subject-action-object form, and identify entities and
+        keywords that are subjects or objects of an action.
+        ### Sentiment
         Determine whether your content conveys postive or negative sentiment. Sentiment
         information can be returned for detected entities, keywords, or user-specified
-        target phrases found in the text.   ### Categories Categorize your content into a
-        hierarchical 5-level taxonomy. For example, \"Leonardo DiCaprio won an Oscar\"
-        returns \"/art and entertainment/movies and tv/movies\" as the most confident
-        classification.
+        target phrases found in the text.
+        ### Categories
+        Categorize your content into a hierarchical 5-level taxonomy. For example,
+        \"Leonardo DiCaprio won an Oscar\" returns \"/art and entertainment/movies and
+        tv/movies\" as the most confident classification.
 
         :param Features features: Specific features to analyze the document for.
         :param str text: The plain text to analyze.
@@ -154,10 +166,13 @@ class NaturalLanguageUnderstandingV1(WatsonService):
         :param str url: The web page to analyze.
         :param bool clean: Remove website elements, such as links, ads, etc.
         :param str xpath: XPath query for targeting nodes in HTML.
-        :param bool fallback_to_raw: Whether to use raw HTML content if text cleaning fails.
+        :param bool fallback_to_raw: Whether to use raw HTML content if text cleaning
+        fails.
         :param bool return_analyzed_text: Whether or not to return the analyzed text.
-        :param str language: ISO 639-1 code indicating the language to use in the analysis.
-        :param int limit_text_characters: Sets the maximum number of characters that are processed by the service.
+        :param str language: ISO 639-1 code indicating the language to use in the
+        analysis.
+        :param int limit_text_characters: Sets the maximum number of characters that are
+        processed by the service.
         :param dict headers: A `dict` containing the request headers
         :return: A `dict` containing the `AnalysisResults` response.
         :rtype: dict
@@ -260,14 +275,22 @@ class AnalysisResults(object):
     :attr str analyzed_text: (optional) Text that was used in the analysis.
     :attr str retrieved_url: (optional) URL that was used to retrieve HTML content.
     :attr Usage usage: (optional) API usage information for the request.
-    :attr list[ConceptsResult] concepts: (optional) The general concepts referenced or alluded to in the specified content.
-    :attr list[EntitiesResult] entities: (optional) The important entities in the specified content.
-    :attr list[KeywordsResult] keywords: (optional) The important keywords in content organized by relevance.
-    :attr list[CategoriesResult] categories: (optional) The hierarchical 5-level taxonomy the content is categorized into.
-    :attr EmotionResult emotion: (optional) The anger, disgust, fear, joy, or sadness conveyed by the content.
-    :attr MetadataResult metadata: (optional) The metadata holds author information, publication date and the title of the text/HTML content.
-    :attr list[RelationsResult] relations: (optional) The relationships between entities in the content.
-    :attr list[SemanticRolesResult] semantic_roles: (optional) The subjects of actions and the objects the actions act upon.
+    :attr list[ConceptsResult] concepts: (optional) The general concepts referenced or
+    alluded to in the specified content.
+    :attr list[EntitiesResult] entities: (optional) The important entities in the
+    specified content.
+    :attr list[KeywordsResult] keywords: (optional) The important keywords in content
+    organized by relevance.
+    :attr list[CategoriesResult] categories: (optional) The hierarchical 5-level taxonomy
+    the content is categorized into.
+    :attr EmotionResult emotion: (optional) The anger, disgust, fear, joy, or sadness
+    conveyed by the content.
+    :attr MetadataResult metadata: (optional) The metadata holds author information,
+    publication date and the title of the text/HTML content.
+    :attr list[RelationsResult] relations: (optional) The relationships between entities
+    in the content.
+    :attr list[SemanticRolesResult] semantic_roles: (optional) The subjects of actions and
+    the objects the actions act upon.
     :attr SentimentResult sentiment: (optional) The sentiment of the content.
     """
 
@@ -292,14 +315,22 @@ class AnalysisResults(object):
         :param str analyzed_text: (optional) Text that was used in the analysis.
         :param str retrieved_url: (optional) URL that was used to retrieve HTML content.
         :param Usage usage: (optional) API usage information for the request.
-        :param list[ConceptsResult] concepts: (optional) The general concepts referenced or alluded to in the specified content.
-        :param list[EntitiesResult] entities: (optional) The important entities in the specified content.
-        :param list[KeywordsResult] keywords: (optional) The important keywords in content organized by relevance.
-        :param list[CategoriesResult] categories: (optional) The hierarchical 5-level taxonomy the content is categorized into.
-        :param EmotionResult emotion: (optional) The anger, disgust, fear, joy, or sadness conveyed by the content.
-        :param MetadataResult metadata: (optional) The metadata holds author information, publication date and the title of the text/HTML content.
-        :param list[RelationsResult] relations: (optional) The relationships between entities in the content.
-        :param list[SemanticRolesResult] semantic_roles: (optional) The subjects of actions and the objects the actions act upon.
+        :param list[ConceptsResult] concepts: (optional) The general concepts referenced
+        or alluded to in the specified content.
+        :param list[EntitiesResult] entities: (optional) The important entities in the
+        specified content.
+        :param list[KeywordsResult] keywords: (optional) The important keywords in content
+        organized by relevance.
+        :param list[CategoriesResult] categories: (optional) The hierarchical 5-level
+        taxonomy the content is categorized into.
+        :param EmotionResult emotion: (optional) The anger, disgust, fear, joy, or sadness
+        conveyed by the content.
+        :param MetadataResult metadata: (optional) The metadata holds author information,
+        publication date and the title of the text/HTML content.
+        :param list[RelationsResult] relations: (optional) The relationships between
+        entities in the content.
+        :param list[SemanticRolesResult] semantic_roles: (optional) The subjects of
+        actions and the objects the actions act upon.
         :param SentimentResult sentiment: (optional) The sentiment of the content.
         """
         self.language = language
@@ -518,15 +549,18 @@ class CategoriesResult(object):
     The hierarchical 5-level taxonomy the content is categorized into.
 
     :attr str label: (optional) The path to the category through the taxonomy hierarchy.
-    :attr float score: (optional) Confidence score for the category classification. Higher values indicate greater confidence.
+    :attr float score: (optional) Confidence score for the category classification. Higher
+    values indicate greater confidence.
     """
 
     def __init__(self, label=None, score=None):
         """
         Initialize a CategoriesResult object.
 
-        :param str label: (optional) The path to the category through the taxonomy hierarchy.
-        :param float score: (optional) Confidence score for the category classification. Higher values indicate greater confidence.
+        :param str label: (optional) The path to the category through the taxonomy
+        hierarchy.
+        :param float score: (optional) Confidence score for the category classification.
+        Higher values indicate greater confidence.
         """
         self.label = label
         self.score = score
@@ -616,7 +650,8 @@ class ConceptsResult(object):
     The general concepts referenced or alluded to in the specified content.
 
     :attr str text: (optional) Name of the concept.
-    :attr float relevance: (optional) Relevance score between 0 and 1. Higher scores indicate greater relevance.
+    :attr float relevance: (optional) Relevance score between 0 and 1. Higher scores
+    indicate greater relevance.
     :attr str dbpedia_resource: (optional) Link to the corresponding DBpedia resource.
     """
 
@@ -625,8 +660,10 @@ class ConceptsResult(object):
         Initialize a ConceptsResult object.
 
         :param str text: (optional) Name of the concept.
-        :param float relevance: (optional) Relevance score between 0 and 1. Higher scores indicate greater relevance.
-        :param str dbpedia_resource: (optional) Link to the corresponding DBpedia resource.
+        :param float relevance: (optional) Relevance score between 0 and 1. Higher scores
+        indicate greater relevance.
+        :param str dbpedia_resource: (optional) Link to the corresponding DBpedia
+        resource.
         """
         self.text = text
         self.relevance = relevance
@@ -685,7 +722,8 @@ class DisambiguationResult(object):
         Initialize a DisambiguationResult object.
 
         :param str name: (optional) Common entity name.
-        :param str dbpedia_resource: (optional) Link to the corresponding DBpedia resource.
+        :param str dbpedia_resource: (optional) Link to the corresponding DBpedia
+        resource.
         :param list[str] subtype: (optional) Entity subtype information.
         """
         self.name = name
@@ -735,14 +773,16 @@ class DocumentEmotionResults(object):
     """
     An object containing the emotion results of a document.
 
-    :attr EmotionScores emotion: (optional) An object containing the emotion results for the document.
+    :attr EmotionScores emotion: (optional) An object containing the emotion results for
+    the document.
     """
 
     def __init__(self, emotion=None):
         """
         Initialize a DocumentEmotionResults object.
 
-        :param EmotionScores emotion: (optional) An object containing the emotion results for the document.
+        :param EmotionScores emotion: (optional) An object containing the emotion results
+        for the document.
         """
         self.emotion = emotion
 
@@ -780,7 +820,8 @@ class DocumentSentimentResults(object):
     """
     DocumentSentimentResults.
 
-    :attr str label: (optional) Indicates whether the sentiment is positive, neutral, or negative.
+    :attr str label: (optional) Indicates whether the sentiment is positive, neutral, or
+    negative.
     :attr float score: (optional) Sentiment score from -1 (negative) to 1 (positive).
     """
 
@@ -788,7 +829,8 @@ class DocumentSentimentResults(object):
         """
         Initialize a DocumentSentimentResults object.
 
-        :param str label: (optional) Indicates whether the sentiment is positive, neutral, or negative.
+        :param str label: (optional) Indicates whether the sentiment is positive, neutral,
+        or negative.
         :param float score: (optional) Sentiment score from -1 (negative) to 1 (positive).
         """
         self.label = label
@@ -832,16 +874,20 @@ class EmotionOptions(object):
     """
     Whether or not to return emotion analysis of the content.
 
-    :attr bool document: (optional) Set this to false to hide document-level emotion results.
-    :attr list[str] targets: (optional) Emotion results will be returned for each target string that is found in the document.
+    :attr bool document: (optional) Set this to false to hide document-level emotion
+    results.
+    :attr list[str] targets: (optional) Emotion results will be returned for each target
+    string that is found in the document.
     """
 
     def __init__(self, document=None, targets=None):
         """
         Initialize a EmotionOptions object.
 
-        :param bool document: (optional) Set this to false to hide document-level emotion results.
-        :param list[str] targets: (optional) Emotion results will be returned for each target string that is found in the document.
+        :param bool document: (optional) Set this to false to hide document-level emotion
+        results.
+        :param list[str] targets: (optional) Emotion results will be returned for each
+        target string that is found in the document.
         """
         self.document = document
         self.targets = targets
@@ -886,16 +932,20 @@ class EmotionResult(object):
     Emotion information can be returned for detected entities, keywords, or user-specified
     target phrases found in the text.
 
-    :attr DocumentEmotionResults document: (optional) The returned emotion results across the document.
-    :attr list[TargetedEmotionResults] targets: (optional) The returned emotion results per specified target.
+    :attr DocumentEmotionResults document: (optional) The returned emotion results across
+    the document.
+    :attr list[TargetedEmotionResults] targets: (optional) The returned emotion results
+    per specified target.
     """
 
     def __init__(self, document=None, targets=None):
         """
         Initialize a EmotionResult object.
 
-        :param DocumentEmotionResults document: (optional) The returned emotion results across the document.
-        :param list[TargetedEmotionResults] targets: (optional) The returned emotion results per specified target.
+        :param DocumentEmotionResults document: (optional) The returned emotion results
+        across the document.
+        :param list[TargetedEmotionResults] targets: (optional) The returned emotion
+        results per specified target.
         """
         self.document = document
         self.targets = targets
@@ -942,11 +992,16 @@ class EmotionScores(object):
     """
     EmotionScores.
 
-    :attr float anger: (optional) Anger score from 0 to 1. A higher score means that the text is more likely to convey anger.
-    :attr float disgust: (optional) Disgust score from 0 to 1. A higher score means that the text is more likely to convey disgust.
-    :attr float fear: (optional) Fear score from 0 to 1. A higher score means that the text is more likely to convey fear.
-    :attr float joy: (optional) Joy score from 0 to 1. A higher score means that the text is more likely to convey joy.
-    :attr float sadness: (optional) Sadness score from 0 to 1. A higher score means that the text is more likely to convey sadness.
+    :attr float anger: (optional) Anger score from 0 to 1. A higher score means that the
+    text is more likely to convey anger.
+    :attr float disgust: (optional) Disgust score from 0 to 1. A higher score means that
+    the text is more likely to convey disgust.
+    :attr float fear: (optional) Fear score from 0 to 1. A higher score means that the
+    text is more likely to convey fear.
+    :attr float joy: (optional) Joy score from 0 to 1. A higher score means that the text
+    is more likely to convey joy.
+    :attr float sadness: (optional) Sadness score from 0 to 1. A higher score means that
+    the text is more likely to convey sadness.
     """
 
     def __init__(self,
@@ -958,11 +1013,16 @@ class EmotionScores(object):
         """
         Initialize a EmotionScores object.
 
-        :param float anger: (optional) Anger score from 0 to 1. A higher score means that the text is more likely to convey anger.
-        :param float disgust: (optional) Disgust score from 0 to 1. A higher score means that the text is more likely to convey disgust.
-        :param float fear: (optional) Fear score from 0 to 1. A higher score means that the text is more likely to convey fear.
-        :param float joy: (optional) Joy score from 0 to 1. A higher score means that the text is more likely to convey joy.
-        :param float sadness: (optional) Sadness score from 0 to 1. A higher score means that the text is more likely to convey sadness.
+        :param float anger: (optional) Anger score from 0 to 1. A higher score means that
+        the text is more likely to convey anger.
+        :param float disgust: (optional) Disgust score from 0 to 1. A higher score means
+        that the text is more likely to convey disgust.
+        :param float fear: (optional) Fear score from 0 to 1. A higher score means that
+        the text is more likely to convey fear.
+        :param float joy: (optional) Joy score from 0 to 1. A higher score means that the
+        text is more likely to convey joy.
+        :param float sadness: (optional) Sadness score from 0 to 1. A higher score means
+        that the text is more likely to convey sadness.
         """
         self.anger = anger
         self.disgust = disgust
@@ -1022,10 +1082,14 @@ class EntitiesOptions(object):
     detected in the analyzed content.
 
     :attr int limit: (optional) Maximum number of entities to return.
-    :attr bool mentions: (optional) Set this to true to return locations of entity mentions.
-    :attr str model: (optional) Enter a custom model ID to override the standard entity detection model.
-    :attr bool sentiment: (optional) Set this to true to return sentiment information for detected entities.
-    :attr bool emotion: (optional) Set this to true to analyze emotion for detected keywords.
+    :attr bool mentions: (optional) Set this to true to return locations of entity
+    mentions.
+    :attr str model: (optional) Enter a custom model ID to override the standard entity
+    detection model.
+    :attr bool sentiment: (optional) Set this to true to return sentiment information for
+    detected entities.
+    :attr bool emotion: (optional) Set this to true to analyze emotion for detected
+    keywords.
     """
 
     def __init__(self,
@@ -1038,10 +1102,14 @@ class EntitiesOptions(object):
         Initialize a EntitiesOptions object.
 
         :param int limit: (optional) Maximum number of entities to return.
-        :param bool mentions: (optional) Set this to true to return locations of entity mentions.
-        :param str model: (optional) Enter a custom model ID to override the standard entity detection model.
-        :param bool sentiment: (optional) Set this to true to return sentiment information for detected entities.
-        :param bool emotion: (optional) Set this to true to analyze emotion for detected keywords.
+        :param bool mentions: (optional) Set this to true to return locations of entity
+        mentions.
+        :param str model: (optional) Enter a custom model ID to override the standard
+        entity detection model.
+        :param bool sentiment: (optional) Set this to true to return sentiment information
+        for detected entities.
+        :param bool emotion: (optional) Set this to true to analyze emotion for detected
+        keywords.
         """
         self.limit = limit
         self.mentions = mentions
@@ -1102,12 +1170,16 @@ class EntitiesResult(object):
 
     :attr str type: (optional) Entity type.
     :attr str text: (optional) The name of the entity.
-    :attr float relevance: (optional) Relevance score from 0 to 1. Higher values indicate greater relevance.
+    :attr float relevance: (optional) Relevance score from 0 to 1. Higher values indicate
+    greater relevance.
     :attr list[EntityMention] mentions: (optional) Entity mentions and locations.
     :attr int count: (optional) How many times the entity was mentioned in the text.
-    :attr EmotionScores emotion: (optional) Emotion analysis results for the entity, enabled with the "emotion" option.
-    :attr FeatureSentimentResults sentiment: (optional) Sentiment analysis results for the entity, enabled with the "sentiment" option.
-    :attr DisambiguationResult disambiguation: (optional) Disambiguation information for the entity.
+    :attr EmotionScores emotion: (optional) Emotion analysis results for the entity,
+    enabled with the "emotion" option.
+    :attr FeatureSentimentResults sentiment: (optional) Sentiment analysis results for the
+    entity, enabled with the "sentiment" option.
+    :attr DisambiguationResult disambiguation: (optional) Disambiguation information for
+    the entity.
     """
 
     def __init__(self,
@@ -1124,12 +1196,16 @@ class EntitiesResult(object):
 
         :param str type: (optional) Entity type.
         :param str text: (optional) The name of the entity.
-        :param float relevance: (optional) Relevance score from 0 to 1. Higher values indicate greater relevance.
+        :param float relevance: (optional) Relevance score from 0 to 1. Higher values
+        indicate greater relevance.
         :param list[EntityMention] mentions: (optional) Entity mentions and locations.
         :param int count: (optional) How many times the entity was mentioned in the text.
-        :param EmotionScores emotion: (optional) Emotion analysis results for the entity, enabled with the "emotion" option.
-        :param FeatureSentimentResults sentiment: (optional) Sentiment analysis results for the entity, enabled with the "sentiment" option.
-        :param DisambiguationResult disambiguation: (optional) Disambiguation information for the entity.
+        :param EmotionScores emotion: (optional) Emotion analysis results for the entity,
+        enabled with the "emotion" option.
+        :param FeatureSentimentResults sentiment: (optional) Sentiment analysis results
+        for the entity, enabled with the "sentiment" option.
+        :param DisambiguationResult disambiguation: (optional) Disambiguation information
+        for the entity.
         """
         self.type = type
         self.text = text
@@ -1207,7 +1283,8 @@ class EntityMention(object):
     EntityMention.
 
     :attr str text: (optional) Entity mention text.
-    :attr list[int] location: (optional) Character offsets indicating the beginning and end of the mention in the analyzed text.
+    :attr list[int] location: (optional) Character offsets indicating the beginning and
+    end of the mention in the analyzed text.
     """
 
     def __init__(self, text=None, location=None):
@@ -1215,7 +1292,8 @@ class EntityMention(object):
         Initialize a EntityMention object.
 
         :param str text: (optional) Entity mention text.
-        :param list[int] location: (optional) Character offsets indicating the beginning and end of the mention in the analyzed text.
+        :param list[int] location: (optional) Character offsets indicating the beginning
+        and end of the mention in the analyzed text.
         """
         self.text = text
         self.location = location
@@ -1303,15 +1381,25 @@ class Features(object):
     """
     Analysis features and options.
 
-    :attr ConceptsOptions concepts: (optional) Whether or not to return the concepts that are mentioned in the analyzed text.
-    :attr EmotionOptions emotion: (optional) Whether or not to extract the emotions implied in the analyzed text.
-    :attr EntitiesOptions entities: (optional) Whether or not to extract detected entity objects from the analyzed text.
-    :attr KeywordsOptions keywords: (optional) Whether or not to return the keywords in the analyzed text.
-    :attr MetadataOptions metadata: (optional) Whether or not the author, publication date, and title of the analyzed text should be returned. This parameter is only available for URL and HTML input.
-    :attr RelationsOptions relations: (optional) Whether or not to return the relationships between detected entities in the analyzed text.
-    :attr SemanticRolesOptions semantic_roles: (optional) Whether or not to return the subject-action-object relations from the analyzed text.
-    :attr SentimentOptions sentiment: (optional) Whether or not to return the overall sentiment of the analyzed text.
-    :attr CategoriesOptions categories: (optional) Whether or not to return the high level category the content is categorized as (i.e. news, art).
+    :attr ConceptsOptions concepts: (optional) Whether or not to return the concepts that
+    are mentioned in the analyzed text.
+    :attr EmotionOptions emotion: (optional) Whether or not to extract the emotions
+    implied in the analyzed text.
+    :attr EntitiesOptions entities: (optional) Whether or not to extract detected entity
+    objects from the analyzed text.
+    :attr KeywordsOptions keywords: (optional) Whether or not to return the keywords in
+    the analyzed text.
+    :attr MetadataOptions metadata: (optional) Whether or not the author, publication
+    date, and title of the analyzed text should be returned. This parameter is only
+    available for URL and HTML input.
+    :attr RelationsOptions relations: (optional) Whether or not to return the
+    relationships between detected entities in the analyzed text.
+    :attr SemanticRolesOptions semantic_roles: (optional) Whether or not to return the
+    subject-action-object relations from the analyzed text.
+    :attr SentimentOptions sentiment: (optional) Whether or not to return the overall
+    sentiment of the analyzed text.
+    :attr CategoriesOptions categories: (optional) Whether or not to return the high level
+    category the content is categorized as (i.e. news, art).
     """
 
     def __init__(self,
@@ -1327,15 +1415,25 @@ class Features(object):
         """
         Initialize a Features object.
 
-        :param ConceptsOptions concepts: (optional) Whether or not to return the concepts that are mentioned in the analyzed text.
-        :param EmotionOptions emotion: (optional) Whether or not to extract the emotions implied in the analyzed text.
-        :param EntitiesOptions entities: (optional) Whether or not to extract detected entity objects from the analyzed text.
-        :param KeywordsOptions keywords: (optional) Whether or not to return the keywords in the analyzed text.
-        :param MetadataOptions metadata: (optional) Whether or not the author, publication date, and title of the analyzed text should be returned. This parameter is only available for URL and HTML input.
-        :param RelationsOptions relations: (optional) Whether or not to return the relationships between detected entities in the analyzed text.
-        :param SemanticRolesOptions semantic_roles: (optional) Whether or not to return the subject-action-object relations from the analyzed text.
-        :param SentimentOptions sentiment: (optional) Whether or not to return the overall sentiment of the analyzed text.
-        :param CategoriesOptions categories: (optional) Whether or not to return the high level category the content is categorized as (i.e. news, art).
+        :param ConceptsOptions concepts: (optional) Whether or not to return the concepts
+        that are mentioned in the analyzed text.
+        :param EmotionOptions emotion: (optional) Whether or not to extract the emotions
+        implied in the analyzed text.
+        :param EntitiesOptions entities: (optional) Whether or not to extract detected
+        entity objects from the analyzed text.
+        :param KeywordsOptions keywords: (optional) Whether or not to return the keywords
+        in the analyzed text.
+        :param MetadataOptions metadata: (optional) Whether or not the author, publication
+        date, and title of the analyzed text should be returned. This parameter is only
+        available for URL and HTML input.
+        :param RelationsOptions relations: (optional) Whether or not to return the
+        relationships between detected entities in the analyzed text.
+        :param SemanticRolesOptions semantic_roles: (optional) Whether or not to return
+        the subject-action-object relations from the analyzed text.
+        :param SentimentOptions sentiment: (optional) Whether or not to return the overall
+        sentiment of the analyzed text.
+        :param CategoriesOptions categories: (optional) Whether or not to return the high
+        level category the content is categorized as (i.e. news, art).
         """
         self.concepts = concepts
         self.emotion = emotion
@@ -1462,14 +1560,61 @@ class Feed(object):
         return not self == other
 
 
+class InlineResponse200(object):
+    """
+    InlineResponse200.
+
+    :attr str deleted: (optional) model_id of the deleted model.
+    """
+
+    def __init__(self, deleted=None):
+        """
+        Initialize a InlineResponse200 object.
+
+        :param str deleted: (optional) model_id of the deleted model.
+        """
+        self.deleted = deleted
+
+    @classmethod
+    def _from_dict(cls, _dict):
+        """Initialize a InlineResponse200 object from a json dictionary."""
+        args = {}
+        if 'deleted' in _dict:
+            args['deleted'] = _dict.get('deleted')
+        return cls(**args)
+
+    def _to_dict(self):
+        """Return a json dictionary representing this model."""
+        _dict = {}
+        if hasattr(self, 'deleted') and self.deleted is not None:
+            _dict['deleted'] = self.deleted
+        return _dict
+
+    def __str__(self):
+        """Return a `str` version of this InlineResponse200 object."""
+        return json.dumps(self._to_dict(), indent=2)
+
+    def __eq__(self, other):
+        """Return `true` when self and other are equal, false otherwise."""
+        if not isinstance(other, self.__class__):
+            return False
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        """Return `true` when self and other are not equal, false otherwise."""
+        return not self == other
+
+
 class KeywordsOptions(object):
     """
     An option indicating whether or not important keywords from the analyzed content
     should be returned.
 
     :attr int limit: (optional) Maximum number of keywords to return.
-    :attr bool sentiment: (optional) Set this to true to return sentiment information for detected keywords.
-    :attr bool emotion: (optional) Set this to true to analyze emotion for detected keywords.
+    :attr bool sentiment: (optional) Set this to true to return sentiment information for
+    detected keywords.
+    :attr bool emotion: (optional) Set this to true to analyze emotion for detected
+    keywords.
     """
 
     def __init__(self, limit=None, sentiment=None, emotion=None):
@@ -1477,8 +1622,10 @@ class KeywordsOptions(object):
         Initialize a KeywordsOptions object.
 
         :param int limit: (optional) Maximum number of keywords to return.
-        :param bool sentiment: (optional) Set this to true to return sentiment information for detected keywords.
-        :param bool emotion: (optional) Set this to true to analyze emotion for detected keywords.
+        :param bool sentiment: (optional) Set this to true to return sentiment information
+        for detected keywords.
+        :param bool emotion: (optional) Set this to true to analyze emotion for detected
+        keywords.
         """
         self.limit = limit
         self.sentiment = sentiment
@@ -1526,10 +1673,13 @@ class KeywordsResult(object):
     """
     The most important keywords in the content, organized by relevance.
 
-    :attr float relevance: (optional) Relevance score from 0 to 1. Higher values indicate greater relevance.
+    :attr float relevance: (optional) Relevance score from 0 to 1. Higher values indicate
+    greater relevance.
     :attr str text: (optional) The keyword text.
-    :attr EmotionScores emotion: (optional) Emotion analysis results for the keyword, enabled with the "emotion" option.
-    :attr FeatureSentimentResults sentiment: (optional) Sentiment analysis results for the keyword, enabled with the "sentiment" option.
+    :attr EmotionScores emotion: (optional) Emotion analysis results for the keyword,
+    enabled with the "emotion" option.
+    :attr FeatureSentimentResults sentiment: (optional) Sentiment analysis results for the
+    keyword, enabled with the "sentiment" option.
     """
 
     def __init__(self, relevance=None, text=None, emotion=None,
@@ -1537,10 +1687,13 @@ class KeywordsResult(object):
         """
         Initialize a KeywordsResult object.
 
-        :param float relevance: (optional) Relevance score from 0 to 1. Higher values indicate greater relevance.
+        :param float relevance: (optional) Relevance score from 0 to 1. Higher values
+        indicate greater relevance.
         :param str text: (optional) The keyword text.
-        :param EmotionScores emotion: (optional) Emotion analysis results for the keyword, enabled with the "emotion" option.
-        :param FeatureSentimentResults sentiment: (optional) Sentiment analysis results for the keyword, enabled with the "sentiment" option.
+        :param EmotionScores emotion: (optional) Emotion analysis results for the keyword,
+        enabled with the "emotion" option.
+        :param FeatureSentimentResults sentiment: (optional) Sentiment analysis results
+        for the keyword, enabled with the "sentiment" option.
         """
         self.relevance = relevance
         self.text = text
@@ -1717,7 +1870,8 @@ class MetadataResult(object):
         Initialize a MetadataResult object.
 
         :param list[Author] authors: (optional) The authors of the document.
-        :param str publication_date: (optional) The publication date in the format ISO 8601.
+        :param str publication_date: (optional) The publication date in the format ISO
+        8601.
         :param str title: (optional) The title of the document.
         :param str image: (optional) URL of a prominent image on the webpage.
         :param list[Feed] feeds: (optional) RSS/ATOM feeds found on the webpage.
@@ -1743,7 +1897,7 @@ class MetadataResult(object):
         if 'image' in _dict:
             args['image'] = _dict.get('image')
         if 'feeds' in _dict:
-            args['feeds'] = [Feed._from_dict(x) for x in _dict.get('feeds')]
+            args['feeds'] = [Feed._from_dict(x) for x in (_dict.get('feeds'))]
         return cls(**args)
 
     def _to_dict(self):
@@ -1797,7 +1951,8 @@ class Model(object):
 
         :param str status: (optional) Shows as available if the model is ready for use.
         :param str model_id: (optional) Unique model ID.
-        :param str language: (optional) ISO 639-1 code indicating the language of the model.
+        :param str language: (optional) ISO 639-1 code indicating the language of the
+        model.
         :param str description: (optional) Model description.
         """
         self.status = status
@@ -1852,7 +2007,8 @@ class RelationArgument(object):
     RelationArgument.
 
     :attr list[RelationEntity] entities: (optional)
-    :attr list[int] location: (optional) Character offsets indicating the beginning and end of the mention in the analyzed text.
+    :attr list[int] location: (optional) Character offsets indicating the beginning and
+    end of the mention in the analyzed text.
     :attr str text: (optional) Text that corresponds to the argument.
     """
 
@@ -1861,7 +2017,8 @@ class RelationArgument(object):
         Initialize a RelationArgument object.
 
         :param list[RelationEntity] entities: (optional)
-        :param list[int] location: (optional) Character offsets indicating the beginning and end of the mention in the analyzed text.
+        :param list[int] location: (optional) Character offsets indicating the beginning
+        and end of the mention in the analyzed text.
         :param str text: (optional) Text that corresponds to the argument.
         """
         self.entities = entities
@@ -1972,7 +2129,8 @@ class RelationsOptions(object):
         """
         Initialize a RelationsOptions object.
 
-        :param str model: (optional) Enter a custom model ID to override the default model.
+        :param str model: (optional) Enter a custom model ID to override the default
+        model.
         """
         self.model = model
 
@@ -2010,20 +2168,24 @@ class RelationsResult(object):
     """
     The relations between entities found in the content.
 
-    :attr float score: (optional) Confidence score for the relation. Higher values indicate greater confidence.
+    :attr float score: (optional) Confidence score for the relation. Higher values
+    indicate greater confidence.
     :attr str sentence: (optional) The sentence that contains the relation.
     :attr str type: (optional) The type of the relation.
-    :attr list[RelationArgument] arguments: (optional) The extracted relation objects from the text.
+    :attr list[RelationArgument] arguments: (optional) The extracted relation objects from
+    the text.
     """
 
     def __init__(self, score=None, sentence=None, type=None, arguments=None):
         """
         Initialize a RelationsResult object.
 
-        :param float score: (optional) Confidence score for the relation. Higher values indicate greater confidence.
+        :param float score: (optional) Confidence score for the relation. Higher values
+        indicate greater confidence.
         :param str sentence: (optional) The sentence that contains the relation.
         :param str type: (optional) The type of the relation.
-        :param list[RelationArgument] arguments: (optional) The extracted relation objects from the text.
+        :param list[RelationArgument] arguments: (optional) The extracted relation objects
+        from the text.
         """
         self.score = score
         self.sentence = sentence
@@ -2292,8 +2454,10 @@ class SemanticRolesOptions(object):
     the analyzed content.
 
     :attr int limit: (optional) Maximum number of semantic_roles results to return.
-    :attr bool keywords: (optional) Set this to true to return keyword information for subjects and objects.
-    :attr bool entities: (optional) Set this to true to return entity information for subjects and objects.
+    :attr bool keywords: (optional) Set this to true to return keyword information for
+    subjects and objects.
+    :attr bool entities: (optional) Set this to true to return entity information for
+    subjects and objects.
     """
 
     def __init__(self, limit=None, keywords=None, entities=None):
@@ -2301,8 +2465,10 @@ class SemanticRolesOptions(object):
         Initialize a SemanticRolesOptions object.
 
         :param int limit: (optional) Maximum number of semantic_roles results to return.
-        :param bool keywords: (optional) Set this to true to return keyword information for subjects and objects.
-        :param bool entities: (optional) Set this to true to return entity information for subjects and objects.
+        :param bool keywords: (optional) Set this to true to return keyword information
+        for subjects and objects.
+        :param bool entities: (optional) Set this to true to return entity information for
+        subjects and objects.
         """
         self.limit = limit
         self.keywords = keywords
@@ -2350,8 +2516,10 @@ class SemanticRolesResult(object):
     """
     The object containing the actions and the objects the actions act upon.
 
-    :attr str sentence: (optional) Sentence from the source that contains the subject, action, and object.
-    :attr SemanticRolesSubject subject: (optional) The extracted subject from the sentence.
+    :attr str sentence: (optional) Sentence from the source that contains the subject,
+    action, and object.
+    :attr SemanticRolesSubject subject: (optional) The extracted subject from the
+    sentence.
     :attr SemanticRolesAction action: (optional) The extracted action from the sentence.
     :attr SemanticRolesObject object: (optional) The extracted object from the sentence.
     """
@@ -2360,10 +2528,14 @@ class SemanticRolesResult(object):
         """
         Initialize a SemanticRolesResult object.
 
-        :param str sentence: (optional) Sentence from the source that contains the subject, action, and object.
-        :param SemanticRolesSubject subject: (optional) The extracted subject from the sentence.
-        :param SemanticRolesAction action: (optional) The extracted action from the sentence.
-        :param SemanticRolesObject object: (optional) The extracted object from the sentence.
+        :param str sentence: (optional) Sentence from the source that contains the
+        subject, action, and object.
+        :param SemanticRolesSubject subject: (optional) The extracted subject from the
+        sentence.
+        :param SemanticRolesAction action: (optional) The extracted action from the
+        sentence.
+        :param SemanticRolesObject object: (optional) The extracted object from the
+        sentence.
         """
         self.sentence = sentence
         self.subject = subject
@@ -2537,16 +2709,20 @@ class SentimentOptions(object):
     An option specifying if sentiment of detected entities, keywords, or phrases should be
     returned.
 
-    :attr bool document: (optional) Set this to false to hide document-level sentiment results.
-    :attr list[str] targets: (optional) Sentiment results will be returned for each target string that is found in the document.
+    :attr bool document: (optional) Set this to false to hide document-level sentiment
+    results.
+    :attr list[str] targets: (optional) Sentiment results will be returned for each target
+    string that is found in the document.
     """
 
     def __init__(self, document=None, targets=None):
         """
         Initialize a SentimentOptions object.
 
-        :param bool document: (optional) Set this to false to hide document-level sentiment results.
-        :param list[str] targets: (optional) Sentiment results will be returned for each target string that is found in the document.
+        :param bool document: (optional) Set this to false to hide document-level
+        sentiment results.
+        :param list[str] targets: (optional) Sentiment results will be returned for each
+        target string that is found in the document.
         """
         self.document = document
         self.targets = targets
@@ -2590,7 +2766,8 @@ class SentimentResult(object):
     The sentiment of the content.
 
     :attr DocumentSentimentResults document: (optional) The document level sentiment.
-    :attr list[TargetedSentimentResults] targets: (optional) The targeted sentiment to analyze.
+    :attr list[TargetedSentimentResults] targets: (optional) The targeted sentiment to
+    analyze.
     """
 
     def __init__(self, document=None, targets=None):
@@ -2598,7 +2775,8 @@ class SentimentResult(object):
         Initialize a SentimentResult object.
 
         :param DocumentSentimentResults document: (optional) The document level sentiment.
-        :param list[TargetedSentimentResults] targets: (optional) The targeted sentiment to analyze.
+        :param list[TargetedSentimentResults] targets: (optional) The targeted sentiment
+        to analyze.
         """
         self.document = document
         self.targets = targets
@@ -2646,7 +2824,8 @@ class TargetedEmotionResults(object):
     An object containing the emotion results for the target.
 
     :attr str text: (optional) Targeted text.
-    :attr EmotionScores emotion: (optional) An object containing the emotion results for the target.
+    :attr EmotionScores emotion: (optional) An object containing the emotion results for
+    the target.
     """
 
     def __init__(self, text=None, emotion=None):
@@ -2654,7 +2833,8 @@ class TargetedEmotionResults(object):
         Initialize a TargetedEmotionResults object.
 
         :param str text: (optional) Targeted text.
-        :param EmotionScores emotion: (optional) An object containing the emotion results for the target.
+        :param EmotionScores emotion: (optional) An object containing the emotion results
+        for the target.
         """
         self.text = text
         self.emotion = emotion

--- a/watson_developer_cloud/natural_language_understanding_v1.py
+++ b/watson_developer_cloud/natural_language_understanding_v1.py
@@ -1897,7 +1897,7 @@ class MetadataResult(object):
         if 'image' in _dict:
             args['image'] = _dict.get('image')
         if 'feeds' in _dict:
-            args['feeds'] = [Feed._from_dict(x) for x in (_dict.get('feeds'))]
+            args['feeds'] = [Feed._from_dict(x) for x in _dict.get('feeds')]
         return cls(**args)
 
     def _to_dict(self):

--- a/watson_developer_cloud/personality_insights_v3.py
+++ b/watson_developer_cloud/personality_insights_v3.py
@@ -119,9 +119,9 @@ class PersonalityInsightsV3(WatsonService):
 
     def profile(self,
                 content,
-                content_type,
-                accept=None,
+                content_type='application/json',
                 content_language=None,
+                accept='application/json',
                 accept_language=None,
                 raw_scores=None,
                 csv_headers=None,
@@ -161,9 +161,6 @@ class PersonalityInsightsV3(WatsonService):
         :param str content_type: The type of the input: application/json, text/html, or
         text/plain. A character encoding can be specified by including a `charset`
         parameter. For example, 'text/html;charset=utf-8'.
-        :param str accept: The type of the response: application/json or text/csv. A
-        character encoding can be specified by including a `charset` parameter. For
-        example, 'text/csv;charset=utf-8'.
         :param str content_language: The language of the input text for the request:
         Arabic, English, Japanese, Korean, or Spanish. Regional variants are treated as
         their parent language; for example, `en-US` is interpreted as `en`.
@@ -175,6 +172,9 @@ class PersonalityInsightsV3(WatsonService):
         items that specify a different language are ignored; omit this parameter to base
         the language on the specification of the content items. You can specify any
         combination of languages for **Content-Language** and **Accept-Language**.
+        :param str accept: The type of the response: application/json or text/csv. A
+        character encoding can be specified by including a `charset` parameter. For
+        example, 'text/csv;charset=utf-8'.
         :param str accept_language: The desired language of the response. For
         two-character arguments, regional variants are treated as their parent language;
         for example, `en-US` is interpreted as `en`. You can specify any combination of
@@ -197,9 +197,9 @@ class PersonalityInsightsV3(WatsonService):
             raise ValueError('content_type must be provided')
         headers = {
             'Content-Type': content_type,
-            'Accept': accept,
             'Content-Language': content_language,
-            'Accept-Language': accept_language
+            'Accept-Language': accept_language,
+            'Accept': accept
         }
         if 'headers' in kwargs:
             headers.update(kwargs.get('headers'))
@@ -220,7 +220,7 @@ class PersonalityInsightsV3(WatsonService):
             headers=headers,
             params=params,
             data=data,
-            accept_json=True)
+            accept_json=(accept is None or accept == 'application/json'))
         return response
 
 
@@ -381,7 +381,7 @@ class ConsumptionPreferences(object):
         """Return a json dictionary representing this model."""
         _dict = {}
         if hasattr(self, 'consumption_preference_id'
-                   ) and self.consumption_preference_id is not None:
+                  ) and self.consumption_preference_id is not None:
             _dict['consumption_preference_id'] = self.consumption_preference_id
         if hasattr(self, 'name') and self.name is not None:
             _dict['name'] = self.name
@@ -464,13 +464,13 @@ class ConsumptionPreferencesCategory(object):
         """Return a json dictionary representing this model."""
         _dict = {}
         if hasattr(self, 'consumption_preference_category_id'
-                   ) and self.consumption_preference_category_id is not None:
+                  ) and self.consumption_preference_category_id is not None:
             _dict[
                 'consumption_preference_category_id'] = self.consumption_preference_category_id
         if hasattr(self, 'name') and self.name is not None:
             _dict['name'] = self.name
         if hasattr(self, 'consumption_preferences'
-                   ) and self.consumption_preferences is not None:
+                  ) and self.consumption_preferences is not None:
             _dict['consumption_preferences'] = [
                 x._to_dict() for x in self.consumption_preferences
             ]
@@ -800,7 +800,7 @@ class Profile(object):
                 'Required property \'personality\' not present in Profile JSON'
             )
         if 'needs' in _dict:
-            args['needs'] = [Trait._from_dict(x) for x in (_dict.get('needs'))]
+            args['needs'] = [Trait._from_dict(x) for x in _dict.get('needs')]
         else:
             raise ValueError(
                 'Required property \'needs\' not present in Profile JSON')
@@ -851,7 +851,7 @@ class Profile(object):
         if hasattr(self, 'behavior') and self.behavior is not None:
             _dict['behavior'] = [x._to_dict() for x in self.behavior]
         if hasattr(self, 'consumption_preferences'
-                   ) and self.consumption_preferences is not None:
+                  ) and self.consumption_preferences is not None:
             _dict['consumption_preferences'] = [
                 x._to_dict() for x in self.consumption_preferences
             ]

--- a/watson_developer_cloud/personality_insights_v3.py
+++ b/watson_developer_cloud/personality_insights_v3.py
@@ -14,8 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """
-The IBM Watson Personality Insights service enables applications to derive insights from
-social media, enterprise data, or other digital communications. The service uses
+The IBM Watson&trade; Personality Insights service enables applications to derive insights
+from social media, enterprise data, or other digital communications. The service uses
 linguistic analytics to infer individuals' intrinsic personality characteristics,
 including Big Five, Needs, and Values, from digital communications such as email, text
 messages, tweets, and forum posts.
@@ -119,33 +119,74 @@ class PersonalityInsightsV3(WatsonService):
 
     def profile(self,
                 content,
-                content_type='application/json',
+                content_type,
+                accept=None,
                 content_language=None,
-                accept='application/json',
                 accept_language=None,
                 raw_scores=None,
                 csv_headers=None,
                 consumption_preferences=None,
                 **kwargs):
         """
-        Generates a personality profile based on input text.
+        Get profile.
 
-        Derives personality insights for up to 20 MB of input content written by an
-        author, though the service requires much less text to produce an accurate profile;
-        for more information, see [Providing sufficient
+        Generates a personality profile for the author of the input text. The service
+        accepts a maximum of 20 MB of input content, but it requires much less text to
+        produce an accurate profile; for more information, see [Providing sufficient
         input](https://console.bluemix.net/docs/services/personality-insights/input.html#sufficient).
-        Accepts input in Arabic, English, Japanese, Korean, or Spanish and produces output
-        in one of eleven languages. Provide plain text, HTML, or JSON content, and receive
-        results in JSON or CSV format.
+        The service analyzes text in Arabic, English, Japanese, Korean, or Spanish and
+        returns its results in a variety of languages. You can provide plain text, HTML,
+        or JSON input by specifying the **Content-Type** parameter; the default is
+        `text/plain`. Request a JSON or comma-separated values (CSV) response by
+        specifying the **Accept** parameter; CSV output includes a fixed number of columns
+        and optional headers.
+        Per the JSON specification, the default character encoding for JSON content is
+        effectively always UTF-8; per the HTTP specification, the default encoding for
+        plain text and HTML is ISO-8859-1 (effectively, the ASCII character set). When
+        specifying a content type of plain text or HTML, include the `charset` parameter
+        to indicate the character encoding of the input text; for example: `Content-Type:
+        text/plain;charset=utf-8`.
+        For detailed information about calling the service and the responses it can
+        generate, see [Requesting a
+        profile](https://console.bluemix.net/docs/services/personality-insights/input.html),
+        [Understanding a JSON
+        profile](https://console.bluemix.net/docs/services/personality-insights/output.html),
+        and [Understanding a CSV
+        profile](https://console.bluemix.net/docs/services/personality-insights/output-csv.html).
 
-        :param Content content: A maximum of 20 MB of content to analyze, though the service requires much less text; for more information, see [Providing sufficient input](https://console.bluemix.net/docs/services/personality-insights/input.html#sufficient). For JSON input, provide an object of type `Content`
-        :param str content_type: The type of the input: application/json, text/html, or text/plain. A character encoding can be specified by including a `charset` parameter. For example, 'text/html;charset=utf-8'.
-        :param str content_language: The language of the input text for the request: Arabic, English, Japanese, Korean, or Spanish. Regional variants are treated as their parent language; for example, `en-US` is interpreted as `en`. The effect of the `content_language` header depends on the `Content-Type` header. When `Content-Type` is `text/plain` or `text/html`, `content_language` is the only way to specify the language. When `Content-Type` is `application/json`, `content_language` overrides a language specified with the `language` parameter of a `ContentItem` object, and content items that specify a different language are ignored; omit this header to base the language on the specification of the content items. You can specify any combination of languages for `content_language` and `Accept-Language`.
-        :param accept: Type of the response: 'application/json' (default) or 'text/csv'
-        :param str accept_language: The desired language of the response. For two-character arguments, regional variants are treated as their parent language; for example, `en-US` is interpreted as `en`. You can specify any combination of languages for the input and response content.
-        :param bool raw_scores: Indicates whether a raw score in addition to a normalized percentile is returned for each characteristic; raw scores are not compared with a sample population. By default, only normalized percentiles are returned.
-        :param bool csv_headers: Indicates whether column labels are returned with a CSV response. By default, no column labels are returned. Applies only when the **Accept** parameter is set to `text/csv`.
-        :param bool consumption_preferences: Indicates whether consumption preferences are returned with the results. By default, no consumption preferences are returned.
+        :param Content content: A maximum of 20 MB of content to analyze, though the
+        service requires much less text; for more information, see [Providing sufficient
+        input](https://console.bluemix.net/docs/services/personality-insights/input.html#sufficient).
+        For JSON input, provide an object of type `Content`.
+        :param str content_type: The type of the input: application/json, text/html, or
+        text/plain. A character encoding can be specified by including a `charset`
+        parameter. For example, 'text/html;charset=utf-8'.
+        :param str accept: The type of the response: application/json or text/csv. A
+        character encoding can be specified by including a `charset` parameter. For
+        example, 'text/csv;charset=utf-8'.
+        :param str content_language: The language of the input text for the request:
+        Arabic, English, Japanese, Korean, or Spanish. Regional variants are treated as
+        their parent language; for example, `en-US` is interpreted as `en`.
+        The effect of the **Content-Language** parameter depends on the **Content-Type**
+        parameter. When **Content-Type** is `text/plain` or `text/html`,
+        **Content-Language** is the only way to specify the language. When
+        **Content-Type** is `application/json`, **Content-Language** overrides a language
+        specified with the `language` parameter of a `ContentItem` object, and content
+        items that specify a different language are ignored; omit this parameter to base
+        the language on the specification of the content items. You can specify any
+        combination of languages for **Content-Language** and **Accept-Language**.
+        :param str accept_language: The desired language of the response. For
+        two-character arguments, regional variants are treated as their parent language;
+        for example, `en-US` is interpreted as `en`. You can specify any combination of
+        languages for the input and response content.
+        :param bool raw_scores: Indicates whether a raw score in addition to a normalized
+        percentile is returned for each characteristic; raw scores are not compared with a
+        sample population. By default, only normalized percentiles are returned.
+        :param bool csv_headers: Indicates whether column labels are returned with a CSV
+        response. By default, no column labels are returned. Applies only when the
+        **Accept** parameter is set to `text/csv`.
+        :param bool consumption_preferences: Indicates whether consumption preferences are
+        returned with the results. By default, no consumption preferences are returned.
         :param dict headers: A `dict` containing the request headers
         :return: A `dict` containing the `Profile` response.
         :rtype: dict
@@ -156,9 +197,9 @@ class PersonalityInsightsV3(WatsonService):
             raise ValueError('content_type must be provided')
         headers = {
             'Content-Type': content_type,
+            'Accept': accept,
             'Content-Language': content_language,
-            'Accept-Language': accept_language,
-            'Accept': accept
+            'Accept-Language': accept_language
         }
         if 'headers' in kwargs:
             headers.update(kwargs.get('headers'))
@@ -179,7 +220,7 @@ class PersonalityInsightsV3(WatsonService):
             headers=headers,
             params=params,
             data=data,
-            accept_json=(accept is None or accept == 'application/json'))
+            accept_json=True)
         return response
 
 
@@ -192,20 +233,27 @@ class Behavior(object):
     """
     Behavior.
 
-    :attr str trait_id: The unique, non-localized identifier of the characteristic to which the results pertain. IDs have the form `behavior_{value}`.
+    :attr str trait_id: The unique, non-localized identifier of the characteristic to
+    which the results pertain. IDs have the form `behavior_{value}`.
     :attr str name: The user-visible, localized name of the characteristic.
     :attr str category: The category of the characteristic: `behavior` for temporal data.
-    :attr float percentage: For JSON content that is timestamped, the percentage of timestamped input data that occurred during that day of the week or hour of the day. The range is 0 to 1.
+    :attr float percentage: For JSON content that is timestamped, the percentage of
+    timestamped input data that occurred during that day of the week or hour of the day.
+    The range is 0 to 1.
     """
 
     def __init__(self, trait_id, name, category, percentage):
         """
         Initialize a Behavior object.
 
-        :param str trait_id: The unique, non-localized identifier of the characteristic to which the results pertain. IDs have the form `behavior_{value}`.
+        :param str trait_id: The unique, non-localized identifier of the characteristic to
+        which the results pertain. IDs have the form `behavior_{value}`.
         :param str name: The user-visible, localized name of the characteristic.
-        :param str category: The category of the characteristic: `behavior` for temporal data.
-        :param float percentage: For JSON content that is timestamped, the percentage of timestamped input data that occurred during that day of the week or hour of the day. The range is 0 to 1.
+        :param str category: The category of the characteristic: `behavior` for temporal
+        data.
+        :param float percentage: For JSON content that is timestamped, the percentage of
+        timestamped input data that occurred during that day of the week or hour of the
+        day. The range is 0 to 1.
         """
         self.trait_id = trait_id
         self.name = name
@@ -271,18 +319,34 @@ class ConsumptionPreferences(object):
     """
     ConsumptionPreferences.
 
-    :attr str consumption_preference_id: The unique, non-localized identifier of the consumption preference to which the results pertain. IDs have the form `consumption_preferences_{preference}`.
+    :attr str consumption_preference_id: The unique, non-localized identifier of the
+    consumption preference to which the results pertain. IDs have the form
+    `consumption_preferences_{preference}`.
     :attr str name: The user-visible, localized name of the consumption preference.
-    :attr float score: The score for the consumption preference: * `0.0`: Unlikely * `0.5`: Neutral * `1.0`: Likely   The scores for some preferences are binary and do not allow a neutral value. The score is an indication of preference based on the results inferred from the input text, not a normalized percentile.
+    :attr float score: The score for the consumption preference:
+    * `0.0`: Unlikely
+    * `0.5`: Neutral
+    * `1.0`: Likely
+    The scores for some preferences are binary and do not allow a neutral value. The score
+    is an indication of preference based on the results inferred from the input text, not
+    a normalized percentile.
     """
 
     def __init__(self, consumption_preference_id, name, score):
         """
         Initialize a ConsumptionPreferences object.
 
-        :param str consumption_preference_id: The unique, non-localized identifier of the consumption preference to which the results pertain. IDs have the form `consumption_preferences_{preference}`.
+        :param str consumption_preference_id: The unique, non-localized identifier of the
+        consumption preference to which the results pertain. IDs have the form
+        `consumption_preferences_{preference}`.
         :param str name: The user-visible, localized name of the consumption preference.
-        :param float score: The score for the consumption preference: * `0.0`: Unlikely * `0.5`: Neutral * `1.0`: Likely   The scores for some preferences are binary and do not allow a neutral value. The score is an indication of preference based on the results inferred from the input text, not a normalized percentile.
+        :param float score: The score for the consumption preference:
+        * `0.0`: Unlikely
+        * `0.5`: Neutral
+        * `1.0`: Likely
+        The scores for some preferences are binary and do not allow a neutral value. The
+        score is an indication of preference based on the results inferred from the input
+        text, not a normalized percentile.
         """
         self.consumption_preference_id = consumption_preference_id
         self.name = name
@@ -317,7 +381,7 @@ class ConsumptionPreferences(object):
         """Return a json dictionary representing this model."""
         _dict = {}
         if hasattr(self, 'consumption_preference_id'
-                  ) and self.consumption_preference_id is not None:
+                   ) and self.consumption_preference_id is not None:
             _dict['consumption_preference_id'] = self.consumption_preference_id
         if hasattr(self, 'name') and self.name is not None:
             _dict['name'] = self.name
@@ -344,9 +408,12 @@ class ConsumptionPreferencesCategory(object):
     """
     ConsumptionPreferencesCategory.
 
-    :attr str consumption_preference_category_id: The unique, non-localized identifier of the consumption preferences category to which the results pertain. IDs have the form `consumption_preferences_{category}`.
+    :attr str consumption_preference_category_id: The unique, non-localized identifier of
+    the consumption preferences category to which the results pertain. IDs have the form
+    `consumption_preferences_{category}`.
     :attr str name: The user-visible name of the consumption preferences category.
-    :attr list[ConsumptionPreferences] consumption_preferences: Detailed results inferred from the input text for the individual preferences of the category.
+    :attr list[ConsumptionPreferences] consumption_preferences: Detailed results inferred
+    from the input text for the individual preferences of the category.
     """
 
     def __init__(self, consumption_preference_category_id, name,
@@ -354,9 +421,12 @@ class ConsumptionPreferencesCategory(object):
         """
         Initialize a ConsumptionPreferencesCategory object.
 
-        :param str consumption_preference_category_id: The unique, non-localized identifier of the consumption preferences category to which the results pertain. IDs have the form `consumption_preferences_{category}`.
+        :param str consumption_preference_category_id: The unique, non-localized
+        identifier of the consumption preferences category to which the results pertain.
+        IDs have the form `consumption_preferences_{category}`.
         :param str name: The user-visible name of the consumption preferences category.
-        :param list[ConsumptionPreferences] consumption_preferences: Detailed results inferred from the input text for the individual preferences of the category.
+        :param list[ConsumptionPreferences] consumption_preferences: Detailed results
+        inferred from the input text for the individual preferences of the category.
         """
         self.consumption_preference_category_id = consumption_preference_category_id
         self.name = name
@@ -394,13 +464,13 @@ class ConsumptionPreferencesCategory(object):
         """Return a json dictionary representing this model."""
         _dict = {}
         if hasattr(self, 'consumption_preference_category_id'
-                  ) and self.consumption_preference_category_id is not None:
+                   ) and self.consumption_preference_category_id is not None:
             _dict[
                 'consumption_preference_category_id'] = self.consumption_preference_category_id
         if hasattr(self, 'name') and self.name is not None:
             _dict['name'] = self.name
         if hasattr(self, 'consumption_preferences'
-                  ) and self.consumption_preferences is not None:
+                   ) and self.consumption_preferences is not None:
             _dict['consumption_preferences'] = [
                 x._to_dict() for x in self.consumption_preferences
             ]
@@ -425,14 +495,16 @@ class Content(object):
     """
     Content.
 
-    :attr list[ContentItem] content_items: An array of `ContentItem` objects that provides the text that is to be analyzed.
+    :attr list[ContentItem] content_items: An array of `ContentItem` objects that provides
+    the text that is to be analyzed.
     """
 
     def __init__(self, content_items):
         """
         Initialize a Content object.
 
-        :param list[ContentItem] content_items: An array of `ContentItem` objects that provides the text that is to be analyzed.
+        :param list[ContentItem] content_items: An array of `ContentItem` objects that
+        provides the text that is to be analyzed.
         """
         self.content_items = content_items
 
@@ -476,15 +548,34 @@ class ContentItem(object):
     """
     ContentItem.
 
-    :attr str content: The content that is to be analyzed. The service supports up to 20 MB of content for all `ContentItem` objects combined.
+    :attr str content: The content that is to be analyzed. The service supports up to 20
+    MB of content for all `ContentItem` objects combined.
     :attr str id: (optional) A unique identifier for this content item.
-    :attr int created: (optional) A timestamp that identifies when this content was created. Specify a value in milliseconds since the UNIX Epoch (January 1, 1970, at 0:00 UTC). Required only for results that include temporal behavior data.
-    :attr int updated: (optional) A timestamp that identifies when this content was last updated. Specify a value in milliseconds since the UNIX Epoch (January 1, 1970, at 0:00 UTC). Required only for results that include temporal behavior data.
-    :attr str contenttype: (optional) The MIME type of the content. The default is plain text. The tags are stripped from HTML content before it is analyzed; plain text is processed as submitted.
-    :attr str language: (optional) The language identifier (two-letter ISO 639-1 identifier) for the language of the content item. The default is `en` (English). Regional variants are treated as their parent language; for example, `en-US` is interpreted as `en`. A language specified with the **Content-Type** parameter overrides the value of this parameter; any content items that specify a different language are ignored. Omit the **Content-Type** parameter to base the language on the most prevalent specification among the content items; again, content items that specify a different language are ignored. You can specify any combination of languages for the input and response content.
-    :attr str parentid: (optional) The unique ID of the parent content item for this item. Used to identify hierarchical relationships between posts/replies, messages/replies, and so on.
-    :attr bool reply: (optional) Indicates whether this content item is a reply to another content item.
-    :attr bool forward: (optional) Indicates whether this content item is a forwarded/copied version of another content item.
+    :attr int created: (optional) A timestamp that identifies when this content was
+    created. Specify a value in milliseconds since the UNIX Epoch (January 1, 1970, at
+    0:00 UTC). Required only for results that include temporal behavior data.
+    :attr int updated: (optional) A timestamp that identifies when this content was last
+    updated. Specify a value in milliseconds since the UNIX Epoch (January 1, 1970, at
+    0:00 UTC). Required only for results that include temporal behavior data.
+    :attr str contenttype: (optional) The MIME type of the content. The default is plain
+    text. The tags are stripped from HTML content before it is analyzed; plain text is
+    processed as submitted.
+    :attr str language: (optional) The language identifier (two-letter ISO 639-1
+    identifier) for the language of the content item. The default is `en` (English).
+    Regional variants are treated as their parent language; for example, `en-US` is
+    interpreted as `en`. A language specified with the **Content-Type** parameter
+    overrides the value of this parameter; any content items that specify a different
+    language are ignored. Omit the **Content-Type** parameter to base the language on the
+    most prevalent specification among the content items; again, content items that
+    specify a different language are ignored. You can specify any combination of languages
+    for the input and response content.
+    :attr str parentid: (optional) The unique ID of the parent content item for this item.
+    Used to identify hierarchical relationships between posts/replies, messages/replies,
+    and so on.
+    :attr bool reply: (optional) Indicates whether this content item is a reply to another
+    content item.
+    :attr bool forward: (optional) Indicates whether this content item is a
+    forwarded/copied version of another content item.
     """
 
     def __init__(self,
@@ -500,15 +591,34 @@ class ContentItem(object):
         """
         Initialize a ContentItem object.
 
-        :param str content: The content that is to be analyzed. The service supports up to 20 MB of content for all `ContentItem` objects combined.
+        :param str content: The content that is to be analyzed. The service supports up to
+        20 MB of content for all `ContentItem` objects combined.
         :param str id: (optional) A unique identifier for this content item.
-        :param int created: (optional) A timestamp that identifies when this content was created. Specify a value in milliseconds since the UNIX Epoch (January 1, 1970, at 0:00 UTC). Required only for results that include temporal behavior data.
-        :param int updated: (optional) A timestamp that identifies when this content was last updated. Specify a value in milliseconds since the UNIX Epoch (January 1, 1970, at 0:00 UTC). Required only for results that include temporal behavior data.
-        :param str contenttype: (optional) The MIME type of the content. The default is plain text. The tags are stripped from HTML content before it is analyzed; plain text is processed as submitted.
-        :param str language: (optional) The language identifier (two-letter ISO 639-1 identifier) for the language of the content item. The default is `en` (English). Regional variants are treated as their parent language; for example, `en-US` is interpreted as `en`. A language specified with the **Content-Type** parameter overrides the value of this parameter; any content items that specify a different language are ignored. Omit the **Content-Type** parameter to base the language on the most prevalent specification among the content items; again, content items that specify a different language are ignored. You can specify any combination of languages for the input and response content.
-        :param str parentid: (optional) The unique ID of the parent content item for this item. Used to identify hierarchical relationships between posts/replies, messages/replies, and so on.
-        :param bool reply: (optional) Indicates whether this content item is a reply to another content item.
-        :param bool forward: (optional) Indicates whether this content item is a forwarded/copied version of another content item.
+        :param int created: (optional) A timestamp that identifies when this content was
+        created. Specify a value in milliseconds since the UNIX Epoch (January 1, 1970, at
+        0:00 UTC). Required only for results that include temporal behavior data.
+        :param int updated: (optional) A timestamp that identifies when this content was
+        last updated. Specify a value in milliseconds since the UNIX Epoch (January 1,
+        1970, at 0:00 UTC). Required only for results that include temporal behavior data.
+        :param str contenttype: (optional) The MIME type of the content. The default is
+        plain text. The tags are stripped from HTML content before it is analyzed; plain
+        text is processed as submitted.
+        :param str language: (optional) The language identifier (two-letter ISO 639-1
+        identifier) for the language of the content item. The default is `en` (English).
+        Regional variants are treated as their parent language; for example, `en-US` is
+        interpreted as `en`. A language specified with the **Content-Type** parameter
+        overrides the value of this parameter; any content items that specify a different
+        language are ignored. Omit the **Content-Type** parameter to base the language on
+        the most prevalent specification among the content items; again, content items
+        that specify a different language are ignored. You can specify any combination of
+        languages for the input and response content.
+        :param str parentid: (optional) The unique ID of the parent content item for this
+        item. Used to identify hierarchical relationships between posts/replies,
+        messages/replies, and so on.
+        :param bool reply: (optional) Indicates whether this content item is a reply to
+        another content item.
+        :param bool forward: (optional) Indicates whether this content item is a
+        forwarded/copied version of another content item.
         """
         self.content = content
         self.id = id
@@ -591,14 +701,28 @@ class Profile(object):
     Profile.
 
     :attr str processed_language: The language model that was used to process the input.
-    :attr int word_count: The number of words from the input that were used to produce the profile.
-    :attr str word_count_message: (optional) When guidance is appropriate, a string that provides a message that indicates the number of words found and where that value falls in the range of required or suggested number of words.
-    :attr list[Trait] personality: A recursive array of `Trait` objects that provides detailed results for the Big Five personality characteristics (dimensions and facets) inferred from the input text.
-    :attr list[Trait] needs: Detailed results for the Needs characteristics inferred from the input text.
-    :attr list[Trait] values: Detailed results for the Values characteristics inferred from the input text.
-    :attr list[Behavior] behavior: (optional) For JSON content that is timestamped, detailed results about the social behavior disclosed by the input in terms of temporal characteristics. The results include information about the distribution of the content over the days of the week and the hours of the day.
-    :attr list[ConsumptionPreferencesCategory] consumption_preferences: (optional) If the **consumption_preferences** parameter is `true`, detailed results for each category of consumption preferences. Each element of the array provides information inferred from the input text for the individual preferences of that category.
-    :attr list[Warning] warnings: Warning messages associated with the input text submitted with the request. The array is empty if the input generated no warnings.
+    :attr int word_count: The number of words from the input that were used to produce the
+    profile.
+    :attr str word_count_message: (optional) When guidance is appropriate, a string that
+    provides a message that indicates the number of words found and where that value falls
+    in the range of required or suggested number of words.
+    :attr list[Trait] personality: A recursive array of `Trait` objects that provides
+    detailed results for the Big Five personality characteristics (dimensions and facets)
+    inferred from the input text.
+    :attr list[Trait] needs: Detailed results for the Needs characteristics inferred from
+    the input text.
+    :attr list[Trait] values: Detailed results for the Values characteristics inferred
+    from the input text.
+    :attr list[Behavior] behavior: (optional) For JSON content that is timestamped,
+    detailed results about the social behavior disclosed by the input in terms of temporal
+    characteristics. The results include information about the distribution of the content
+    over the days of the week and the hours of the day.
+    :attr list[ConsumptionPreferencesCategory] consumption_preferences: (optional) If the
+    **consumption_preferences** parameter is `true`, detailed results for each category of
+    consumption preferences. Each element of the array provides information inferred from
+    the input text for the individual preferences of that category.
+    :attr list[Warning] warnings: Warning messages associated with the input text
+    submitted with the request. The array is empty if the input generated no warnings.
     """
 
     def __init__(self,
@@ -614,15 +738,31 @@ class Profile(object):
         """
         Initialize a Profile object.
 
-        :param str processed_language: The language model that was used to process the input.
-        :param int word_count: The number of words from the input that were used to produce the profile.
-        :param list[Trait] personality: A recursive array of `Trait` objects that provides detailed results for the Big Five personality characteristics (dimensions and facets) inferred from the input text.
-        :param list[Trait] needs: Detailed results for the Needs characteristics inferred from the input text.
-        :param list[Trait] values: Detailed results for the Values characteristics inferred from the input text.
-        :param list[Warning] warnings: Warning messages associated with the input text submitted with the request. The array is empty if the input generated no warnings.
-        :param str word_count_message: (optional) When guidance is appropriate, a string that provides a message that indicates the number of words found and where that value falls in the range of required or suggested number of words.
-        :param list[Behavior] behavior: (optional) For JSON content that is timestamped, detailed results about the social behavior disclosed by the input in terms of temporal characteristics. The results include information about the distribution of the content over the days of the week and the hours of the day.
-        :param list[ConsumptionPreferencesCategory] consumption_preferences: (optional) If the **consumption_preferences** parameter is `true`, detailed results for each category of consumption preferences. Each element of the array provides information inferred from the input text for the individual preferences of that category.
+        :param str processed_language: The language model that was used to process the
+        input.
+        :param int word_count: The number of words from the input that were used to
+        produce the profile.
+        :param list[Trait] personality: A recursive array of `Trait` objects that provides
+        detailed results for the Big Five personality characteristics (dimensions and
+        facets) inferred from the input text.
+        :param list[Trait] needs: Detailed results for the Needs characteristics inferred
+        from the input text.
+        :param list[Trait] values: Detailed results for the Values characteristics
+        inferred from the input text.
+        :param list[Warning] warnings: Warning messages associated with the input text
+        submitted with the request. The array is empty if the input generated no warnings.
+        :param str word_count_message: (optional) When guidance is appropriate, a string
+        that provides a message that indicates the number of words found and where that
+        value falls in the range of required or suggested number of words.
+        :param list[Behavior] behavior: (optional) For JSON content that is timestamped,
+        detailed results about the social behavior disclosed by the input in terms of
+        temporal characteristics. The results include information about the distribution
+        of the content over the days of the week and the hours of the day.
+        :param list[ConsumptionPreferencesCategory] consumption_preferences: (optional) If
+        the **consumption_preferences** parameter is `true`, detailed results for each
+        category of consumption preferences. Each element of the array provides
+        information inferred from the input text for the individual preferences of that
+        category.
         """
         self.processed_language = processed_language
         self.word_count = word_count
@@ -660,7 +800,7 @@ class Profile(object):
                 'Required property \'personality\' not present in Profile JSON'
             )
         if 'needs' in _dict:
-            args['needs'] = [Trait._from_dict(x) for x in _dict.get('needs')]
+            args['needs'] = [Trait._from_dict(x) for x in (_dict.get('needs'))]
         else:
             raise ValueError(
                 'Required property \'needs\' not present in Profile JSON')
@@ -711,7 +851,7 @@ class Profile(object):
         if hasattr(self, 'behavior') and self.behavior is not None:
             _dict['behavior'] = [x._to_dict() for x in self.behavior]
         if hasattr(self, 'consumption_preferences'
-                  ) and self.consumption_preferences is not None:
+                   ) and self.consumption_preferences is not None:
             _dict['consumption_preferences'] = [
                 x._to_dict() for x in self.consumption_preferences
             ]
@@ -738,13 +878,35 @@ class Trait(object):
     """
     Trait.
 
-    :attr str trait_id: The unique, non-localized identifier of the characteristic to which the results pertain. IDs have the form * `big5_{characteristic}` for Big Five personality dimensions * `facet_{characteristic}` for Big Five personality facets * `need_{characteristic}` for Needs  *`value_{characteristic}` for Values.
+    :attr str trait_id: The unique, non-localized identifier of the characteristic to
+    which the results pertain. IDs have the form
+    * `big5_{characteristic}` for Big Five personality dimensions
+    * `facet_{characteristic}` for Big Five personality facets
+    * `need_{characteristic}` for Needs
+     *`value_{characteristic}` for Values.
     :attr str name: The user-visible, localized name of the characteristic.
-    :attr str category: The category of the characteristic: `personality` for Big Five personality characteristics, `needs` for Needs, and `values` for Values.
-    :attr float percentile: The normalized percentile score for the characteristic. The range is 0 to 1. For example, if the percentage for Openness is 0.60, the author scored in the 60th percentile; the author is more open than 59 percent of the population and less open than 39 percent of the population.
-    :attr float raw_score: (optional) The raw score for the characteristic. The range is 0 to 1. A higher score generally indicates a greater likelihood that the author has that characteristic, but raw scores must be considered in aggregate: The range of values in practice might be much smaller than 0 to 1, so an individual score must be considered in the context of the overall scores and their range.   The raw score is computed based on the input and the service model; it is not normalized or compared with a sample population. The raw score enables comparison of the results against a different sampling population and with a custom normalization approach.
-    :attr bool significant: (optional) **`2017-10-13`**: Indicates whether the characteristic is meaningful for the input language. The field is always `true` for all characteristics of English, Spanish, and Japanese input. The field is `false` for the subset of characteristics of Arabic and Korean input for which the service's models are unable to generate meaningful results. **`2016-10-19`**: Not returned.
-    :attr list[Trait] children: (optional) For `personality` (Big Five) dimensions, more detailed results for the facets of each dimension as inferred from the input text.
+    :attr str category: The category of the characteristic: `personality` for Big Five
+    personality characteristics, `needs` for Needs, and `values` for Values.
+    :attr float percentile: The normalized percentile score for the characteristic. The
+    range is 0 to 1. For example, if the percentage for Openness is 0.60, the author
+    scored in the 60th percentile; the author is more open than 59 percent of the
+    population and less open than 39 percent of the population.
+    :attr float raw_score: (optional) The raw score for the characteristic. The range is 0
+    to 1. A higher score generally indicates a greater likelihood that the author has that
+    characteristic, but raw scores must be considered in aggregate: The range of values in
+    practice might be much smaller than 0 to 1, so an individual score must be considered
+    in the context of the overall scores and their range.
+    The raw score is computed based on the input and the service model; it is not
+    normalized or compared with a sample population. The raw score enables comparison of
+    the results against a different sampling population and with a custom normalization
+    approach.
+    :attr bool significant: (optional) **`2017-10-13`**: Indicates whether the
+    characteristic is meaningful for the input language. The field is always `true` for
+    all characteristics of English, Spanish, and Japanese input. The field is `false` for
+    the subset of characteristics of Arabic and Korean input for which the service's
+    models are unable to generate meaningful results. **`2016-10-19`**: Not returned.
+    :attr list[Trait] children: (optional) For `personality` (Big Five) dimensions, more
+    detailed results for the facets of each dimension as inferred from the input text.
     """
 
     def __init__(self,
@@ -758,13 +920,37 @@ class Trait(object):
         """
         Initialize a Trait object.
 
-        :param str trait_id: The unique, non-localized identifier of the characteristic to which the results pertain. IDs have the form * `big5_{characteristic}` for Big Five personality dimensions * `facet_{characteristic}` for Big Five personality facets * `need_{characteristic}` for Needs  *`value_{characteristic}` for Values.
+        :param str trait_id: The unique, non-localized identifier of the characteristic to
+        which the results pertain. IDs have the form
+        * `big5_{characteristic}` for Big Five personality dimensions
+        * `facet_{characteristic}` for Big Five personality facets
+        * `need_{characteristic}` for Needs
+         *`value_{characteristic}` for Values.
         :param str name: The user-visible, localized name of the characteristic.
-        :param str category: The category of the characteristic: `personality` for Big Five personality characteristics, `needs` for Needs, and `values` for Values.
-        :param float percentile: The normalized percentile score for the characteristic. The range is 0 to 1. For example, if the percentage for Openness is 0.60, the author scored in the 60th percentile; the author is more open than 59 percent of the population and less open than 39 percent of the population.
-        :param float raw_score: (optional) The raw score for the characteristic. The range is 0 to 1. A higher score generally indicates a greater likelihood that the author has that characteristic, but raw scores must be considered in aggregate: The range of values in practice might be much smaller than 0 to 1, so an individual score must be considered in the context of the overall scores and their range.   The raw score is computed based on the input and the service model; it is not normalized or compared with a sample population. The raw score enables comparison of the results against a different sampling population and with a custom normalization approach.
-        :param bool significant: (optional) **`2017-10-13`**: Indicates whether the characteristic is meaningful for the input language. The field is always `true` for all characteristics of English, Spanish, and Japanese input. The field is `false` for the subset of characteristics of Arabic and Korean input for which the service's models are unable to generate meaningful results. **`2016-10-19`**: Not returned.
-        :param list[Trait] children: (optional) For `personality` (Big Five) dimensions, more detailed results for the facets of each dimension as inferred from the input text.
+        :param str category: The category of the characteristic: `personality` for Big
+        Five personality characteristics, `needs` for Needs, and `values` for Values.
+        :param float percentile: The normalized percentile score for the characteristic.
+        The range is 0 to 1. For example, if the percentage for Openness is 0.60, the
+        author scored in the 60th percentile; the author is more open than 59 percent of
+        the population and less open than 39 percent of the population.
+        :param float raw_score: (optional) The raw score for the characteristic. The range
+        is 0 to 1. A higher score generally indicates a greater likelihood that the author
+        has that characteristic, but raw scores must be considered in aggregate: The range
+        of values in practice might be much smaller than 0 to 1, so an individual score
+        must be considered in the context of the overall scores and their range.
+        The raw score is computed based on the input and the service model; it is not
+        normalized or compared with a sample population. The raw score enables comparison
+        of the results against a different sampling population and with a custom
+        normalization approach.
+        :param bool significant: (optional) **`2017-10-13`**: Indicates whether the
+        characteristic is meaningful for the input language. The field is always `true`
+        for all characteristics of English, Spanish, and Japanese input. The field is
+        `false` for the subset of characteristics of Arabic and Korean input for which the
+        service's models are unable to generate meaningful results. **`2016-10-19`**: Not
+        returned.
+        :param list[Trait] children: (optional) For `personality` (Big Five) dimensions,
+        more detailed results for the facets of each dimension as inferred from the input
+        text.
         """
         self.trait_id = trait_id
         self.name = name
@@ -847,7 +1033,18 @@ class Warning(object):
     Warning.
 
     :attr str warning_id: The identifier of the warning message.
-    :attr str message: The message associated with the `warning_id`: * `WORD_COUNT_MESSAGE`: "There were {number} words in the input. We need a minimum of 600, preferably 1,200 or more, to compute statistically significant estimates." * `JSON_AS_TEXT`: "Request input was processed as text/plain as indicated, however detected a JSON input. Did you mean application/json?" * `CONTENT_TRUNCATED`: "For maximum accuracy while also optimizing processing time, only the first 250KB of input text (excluding markup) was analyzed. Accuracy levels off at approximately 3,000 words so this did not affect the accuracy of the profile." * `PARTIAL_TEXT_USED`, "The text provided to compute the profile was trimmed for performance reasons. This action does not affect the accuracy of the output, as not all of the input text was required." Applies only when Arabic input text exceeds a threshold at which additional words do not contribute to the accuracy of the profile.
+    :attr str message: The message associated with the `warning_id`:
+    * `WORD_COUNT_MESSAGE`: "There were {number} words in the input. We need a minimum of
+    600, preferably 1,200 or more, to compute statistically significant estimates."
+    * `JSON_AS_TEXT`: "Request input was processed as text/plain as indicated, however
+    detected a JSON input. Did you mean application/json?"
+    * `CONTENT_TRUNCATED`: "For maximum accuracy while also optimizing processing time,
+    only the first 250KB of input text (excluding markup) was analyzed. Accuracy levels
+    off at approximately 3,000 words so this did not affect the accuracy of the profile."
+    * `PARTIAL_TEXT_USED`, "The text provided to compute the profile was trimmed for
+    performance reasons. This action does not affect the accuracy of the output, as not
+    all of the input text was required." Applies only when Arabic input text exceeds a
+    threshold at which additional words do not contribute to the accuracy of the profile.
     """
 
     def __init__(self, warning_id, message):
@@ -855,7 +1052,20 @@ class Warning(object):
         Initialize a Warning object.
 
         :param str warning_id: The identifier of the warning message.
-        :param str message: The message associated with the `warning_id`: * `WORD_COUNT_MESSAGE`: "There were {number} words in the input. We need a minimum of 600, preferably 1,200 or more, to compute statistically significant estimates." * `JSON_AS_TEXT`: "Request input was processed as text/plain as indicated, however detected a JSON input. Did you mean application/json?" * `CONTENT_TRUNCATED`: "For maximum accuracy while also optimizing processing time, only the first 250KB of input text (excluding markup) was analyzed. Accuracy levels off at approximately 3,000 words so this did not affect the accuracy of the profile." * `PARTIAL_TEXT_USED`, "The text provided to compute the profile was trimmed for performance reasons. This action does not affect the accuracy of the output, as not all of the input text was required." Applies only when Arabic input text exceeds a threshold at which additional words do not contribute to the accuracy of the profile.
+        :param str message: The message associated with the `warning_id`:
+        * `WORD_COUNT_MESSAGE`: "There were {number} words in the input. We need a minimum
+        of 600, preferably 1,200 or more, to compute statistically significant estimates."
+        * `JSON_AS_TEXT`: "Request input was processed as text/plain as indicated, however
+        detected a JSON input. Did you mean application/json?"
+        * `CONTENT_TRUNCATED`: "For maximum accuracy while also optimizing processing
+        time, only the first 250KB of input text (excluding markup) was analyzed. Accuracy
+        levels off at approximately 3,000 words so this did not affect the accuracy of the
+        profile."
+        * `PARTIAL_TEXT_USED`, "The text provided to compute the profile was trimmed for
+        performance reasons. This action does not affect the accuracy of the output, as
+        not all of the input text was required." Applies only when Arabic input text
+        exceeds a threshold at which additional words do not contribute to the accuracy of
+        the profile.
         """
         self.warning_id = warning_id
         self.message = message

--- a/watson_developer_cloud/speech_to_text_v1.py
+++ b/watson_developer_cloud/speech_to_text_v1.py
@@ -69,14 +69,7 @@ security](https://console.bluemix.net/docs/services/speech-to-text/information-s
 from __future__ import absolute_import
 
 import json
-from .watson_service import WatsonService, _remove_null_values
-from .utils import deprecated
-from watson_developer_cloud.websocket import RecognizeCallback, RecognizeListener
-import base64
-try:
-    from urllib.parse import urlencode
-except ImportError:
-    from urllib import urlencode
+from .watson_service import WatsonService
 
 ##############################################################################
 # Service
@@ -152,7 +145,8 @@ class SpeechToTextV1(WatsonService):
         for use with the service. The information includes the name of the model and its
         minimum sampling rate in Hertz, among other things.
 
-        :param str model_id: The identifier of the model in the form of its name from the output of the **Get models** method.
+        :param str model_id: The identifier of the model in the form of its name from the
+        output of the **Get models** method.
         :param dict headers: A `dict` containing the request headers
         :return: A `dict` containing the `SpeechModel` response.
         :rtype: dict
@@ -169,7 +163,7 @@ class SpeechToTextV1(WatsonService):
 
     def list_models(self, **kwargs):
         """
-        Get models.
+        List models.
 
         Retrieves a list of all language models that are available for use with the
         service. The information includes the name of the model and its minimum sampling
@@ -187,57 +181,173 @@ class SpeechToTextV1(WatsonService):
             method='GET', url=url, headers=headers, accept_json=True)
         return response
 
-    @deprecated('Use list_models instead.')
-    def models(self):
-        return self.list_models()
-
     #########################
     # Sessionless
     #########################
 
-    def recognize(self,
-                  model=None,
-                  customization_id=None,
-                  acoustic_customization_id=None,
-                  customization_weight=None,
-                  version=None,
-                  audio=None,
-                  content_type=None,
-                  inactivity_timeout=None,
-                  keywords=None,
-                  keywords_threshold=None,
-                  max_alternatives=None,
-                  word_alternatives_threshold=None,
-                  word_confidence=None,
-                  timestamps=None,
-                  profanity_filter=None,
-                  smart_formatting=None,
-                  speaker_labels=None,
-                  **kwargs):
+    def recognize_sessionless(self,
+                              audio,
+                              content_type,
+                              model=None,
+                              customization_id=None,
+                              acoustic_customization_id=None,
+                              base_model_version=None,
+                              customization_weight=None,
+                              inactivity_timeout=None,
+                              keywords=None,
+                              keywords_threshold=None,
+                              max_alternatives=None,
+                              word_alternatives_threshold=None,
+                              word_confidence=None,
+                              timestamps=None,
+                              profanity_filter=None,
+                              smart_formatting=None,
+                              speaker_labels=None,
+                              **kwargs):
         """
-        Sends audio for speech recognition in sessionless mode.
+        Recognize audio (sessionless).
 
-        :param str model: The identifier of the model that is to be used for the recognition request.
-        :param str customization_id: The GUID of a custom language model that is to be used with the request. The base model of the specified custom language model must match the model specified with the `model` parameter. You must make the request with service credentials created for the instance of the service that owns the custom model. By default, no custom language model is used.
-        :param str acoustic_customization_id: The GUID of a custom acoustic model that is to be used with the request. The base model of the specified custom acoustic model must match the model specified with the `model` parameter. You must make the request with service credentials created for the instance of the service that owns the custom model. By default, no custom acoustic model is used.
-        :param float customization_weight: NON-MULTIPART ONLY: If you specify a customization ID with the request, you can use the customization weight to tell the service how much weight to give to words from the custom language model compared to those from the base model for speech recognition.   Specify a value between 0.0 and 1.0. Unless a different customization weight was specified for the custom model when it was trained, the default value is 0.3. A customization weight that you specify overrides a weight that was specified when the custom model was trained.   The default value yields the best performance in general. Assign a higher value if your audio makes frequent use of OOV words from the custom model. Use caution when setting the weight: a higher value can improve the accuracy of phrases from the custom model's domain, but it can negatively affect performance on non-domain phrases.
-        :param str version: The version of the specified base `model` that is to be used for speech recognition. Multiple versions of a base model can exist when a model is updated for internal improvements. The parameter is intended primarily for use with custom models that have been upgraded for a new base model. The default value depends on whether the parameter is used with or without a custom model. For more information, see [Base model version](https://console.bluemix.net/docs/services/speech-to-text/input.html#version).
-        :param str audio: NON-MULTIPART ONLY: Audio to transcribe in the format specified by the `Content-Type` header. **Required for a non-multipart request.**.
-        :param str content_type: The type of the input: audio/basic, audio/flac, audio/l16, audio/mp3, audio/mpeg, audio/mulaw, audio/ogg, audio/ogg;codecs=opus, audio/ogg;codecs=vorbis, audio/wav, audio/webm, audio/webm;codecs=opus, audio/webm;codecs=vorbis, or multipart/form-data.
-        :param int inactivity_timeout: NON-MULTIPART ONLY: The time in seconds after which, if only silence (no speech) is detected in submitted audio, the connection is closed with a 400 error. Useful for stopping audio submission from a live microphone when a user simply walks away. Use `-1` for infinity.
-        :param list[str] keywords: NON-MULTIPART ONLY: Array of keyword strings to spot in the audio. Each keyword string can include one or more tokens. Keywords are spotted only in the final hypothesis, not in interim results. If you specify any keywords, you must also specify a keywords threshold. You can spot a maximum of 1000 keywords. Omit the parameter or specify an empty array if you do not need to spot keywords.
-        :param float keywords_threshold: NON-MULTIPART ONLY: Confidence value that is the lower bound for spotting a keyword. A word is considered to match a keyword if its confidence is greater than or equal to the threshold. Specify a probability between 0 and 1 inclusive. No keyword spotting is performed if you omit the parameter. If you specify a threshold, you must also specify one or more keywords.
-        :param int max_alternatives: NON-MULTIPART ONLY: Maximum number of alternative transcripts to be returned. By default, a single transcription is returned.
-        :param float word_alternatives_threshold: NON-MULTIPART ONLY: Confidence value that is the lower bound for identifying a hypothesis as a possible word alternative (also known as \"Confusion Networks\"). An alternative word is considered if its confidence is greater than or equal to the threshold. Specify a probability between 0 and 1 inclusive. No alternative words are computed if you omit the parameter.
-        :param bool word_confidence: NON-MULTIPART ONLY: If `true`, confidence measure per word is returned.
-        :param bool timestamps: NON-MULTIPART ONLY: If `true`, time alignment for each word is returned.
-        :param bool profanity_filter: NON-MULTIPART ONLY: If `true` (the default), filters profanity from all output except for keyword results by replacing inappropriate words with a series of asterisks. Set the parameter to `false` to return results with no censoring. Applies to US English transcription only.
-        :param bool smart_formatting: NON-MULTIPART ONLY: If `true`, converts dates, times, series of digits and numbers, phone numbers, currency values, and Internet addresses into more readable, conventional representations in the final transcript of a recognition request. If `false` (the default), no formatting is performed. Applies to US English transcription only.
-        :param bool speaker_labels: NON-MULTIPART ONLY: Indicates whether labels that identify which words were spoken by which participants in a multi-person exchange are to be included in the response. The default is `false`; no speaker labels are returned. Setting `speaker_labels` to `true` forces the `timestamps` parameter to be `true`, regardless of whether you specify `false` for the parameter.   To determine whether a language model supports speaker labels, use the **Get models** method and check that the attribute `speaker_labels` is set to `true`. You can also refer to [Speaker labels](https://console.bluemix.net/docs/services/speech-to-text/output.html#speaker_labels).
+        Sends audio and returns transcription results for a sessionless recognition
+        request. Returns only the final results; to enable interim results, use
+        session-based requests or the WebSocket API. The service imposes a data size limit
+        of 100 MB. It automatically detects the endianness of the incoming audio and, for
+        audio that includes multiple channels, downmixes the audio to one-channel mono
+        during transcoding. (For the `audio/l16` format, you can specify the endianness.)
+        ### Streaming mode
+         For requests to transcribe live audio as it becomes available, you must set the
+        `Transfer-Encoding` header to `chunked` to use streaming mode. In streaming mode,
+        the server closes the connection (status code 408) if the service receives no data
+        chunk for 30 seconds and the service has no audio to transcribe for 30 seconds.
+        The server also closes the connection (status code 400) if no speech is detected
+        for `inactivity_timeout` seconds of audio (not processing time); use the
+        `inactivity_timeout` parameter to change the default of 30 seconds.
+        ### Audio formats (content types)
+         Use the `Content-Type` header to specify the audio format (MIME type) of the
+        audio. The service accepts the following formats:
+        * `audio/basic` (Use only with narrowband models.)
+        * `audio/flac`
+        * `audio/l16` (Specify the sampling rate (`rate`) and optionally the number of
+        channels (`channels`) and endianness (`endianness`) of the audio.)
+        * `audio/mp3`
+        * `audio/mpeg`
+        * `audio/mulaw` (Specify the sampling rate (`rate`) of the audio.)
+        * `audio/ogg` (The service automatically detects the codec of the input audio.)
+        * `audio/ogg;codecs=opus`
+        * `audio/ogg;codecs=vorbis`
+        * `audio/wav` (Provide audio with a maximum of nine channels.)
+        * `audio/webm` (The service automatically detects the codec of the input audio.)
+        * `audio/webm;codecs=opus`
+        * `audio/webm;codecs=vorbis`
+        For information about the supported audio formats, including specifying the
+        sampling rate, channels, and endianness for the indicated formats, see [Audio
+        formats](https://console.bluemix.net/docs/services/speech-to-text/audio-formats.html).
+        ### Multipart speech recognition
+         The method also supports multipart recognition requests. With multipart requests,
+        you pass all audio data as multipart form data. You specify some parameters as
+        request headers and query parameters, but you pass JSON metadata as form data to
+        control most aspects of the transcription.
+        The multipart approach is intended for use with browsers for which JavaScript is
+        disabled or when the parameters used with the request are greater than the 8 KB
+        limit imposed by most HTTP servers and proxies. You can encounter this limit, for
+        example, if you want to spot a very large number of keywords.
+        For information about submitting a multipart request, see [Submitting multipart
+        requests as form
+        data](https://console.bluemix.net/docs/services/speech-to-text/http.html#HTTP-multi).
+
+        :param str audio: The audio to transcribe in the format specified by the
+        `Content-Type` header.
+        :param str content_type: The type of the input: audio/basic, audio/flac,
+        audio/l16, audio/mp3, audio/mpeg, audio/mulaw, audio/ogg, audio/ogg;codecs=opus,
+        audio/ogg;codecs=vorbis, audio/wav, audio/webm, audio/webm;codecs=opus, or
+        audio/webm;codecs=vorbis.
+        :param str model: The identifier of the model that is to be used for the
+        recognition request or, for the **Create a session** method, with the new session.
+        :param str customization_id: The customization ID (GUID) of a custom language
+        model that is to be used with the recognition request or, for the **Create a
+        session** method, with the new session. The base model of the specified custom
+        language model must match the model specified with the `model` parameter. You must
+        make the request with service credentials created for the instance of the service
+        that owns the custom model. By default, no custom language model is used.
+        :param str acoustic_customization_id: The customization ID (GUID) of a custom
+        acoustic model that is to be used with the recognition request or, for the
+        **Create a session** method, with the new session. The base model of the specified
+        custom acoustic model must match the model specified with the `model` parameter.
+        You must make the request with service credentials created for the instance of the
+        service that owns the custom model. By default, no custom acoustic model is used.
+        :param str base_model_version: The version of the specified base model that is to
+        be used with recognition request or, for the **Create a session** method, with the
+        new session. Multiple versions of a base model can exist when a model is updated
+        for internal improvements. The parameter is intended primarily for use with custom
+        models that have been upgraded for a new base model. The default value depends on
+        whether the parameter is used with or without a custom model. For more
+        information, see [Base model
+        version](https://console.bluemix.net/docs/services/speech-to-text/input.html#version).
+        :param float customization_weight: If you specify the customization ID (GUID) of a
+        custom language model with the recognition request or, for sessions, with the
+        **Create a session** method, the customization weight tells the service how much
+        weight to give to words from the custom language model compared to those from the
+        base model for the current request.
+        Specify a value between 0.0 and 1.0. Unless a different customization weight was
+        specified for the custom model when it was trained, the default value is 0.3. A
+        customization weight that you specify overrides a weight that was specified when
+        the custom model was trained.
+        The default value yields the best performance in general. Assign a higher value if
+        your audio makes frequent use of OOV words from the custom model. Use caution when
+        setting the weight: a higher value can improve the accuracy of phrases from the
+        custom model's domain, but it can negatively affect performance on non-domain
+        phrases.
+        :param int inactivity_timeout: The time in seconds after which, if only silence
+        (no speech) is detected in submitted audio, the connection is closed with a 400
+        error. Useful for stopping audio submission from a live microphone when a user
+        simply walks away. Use `-1` for infinity.
+        :param list[str] keywords: An array of keyword strings to spot in the audio. Each
+        keyword string can include one or more tokens. Keywords are spotted only in the
+        final hypothesis, not in interim results. If you specify any keywords, you must
+        also specify a keywords threshold. You can spot a maximum of 1000 keywords. Omit
+        the parameter or specify an empty array if you do not need to spot keywords.
+        :param float keywords_threshold: A confidence value that is the lower bound for
+        spotting a keyword. A word is considered to match a keyword if its confidence is
+        greater than or equal to the threshold. Specify a probability between 0 and 1
+        inclusive. No keyword spotting is performed if you omit the parameter. If you
+        specify a threshold, you must also specify one or more keywords.
+        :param int max_alternatives: The maximum number of alternative transcripts to be
+        returned. By default, a single transcription is returned.
+        :param float word_alternatives_threshold: A confidence value that is the lower
+        bound for identifying a hypothesis as a possible word alternative (also known as
+        \"Confusion Networks\"). An alternative word is considered if its confidence is
+        greater than or equal to the threshold. Specify a probability between 0 and 1
+        inclusive. No alternative words are computed if you omit the parameter.
+        :param bool word_confidence: If `true`, a confidence measure in the range of 0 to
+        1 is returned for each word. By default, no word confidence measures are returned.
+        :param bool timestamps: If `true`, time alignment is returned for each word. By
+        default, no timestamps are returned.
+        :param bool profanity_filter: If `true` (the default), filters profanity from all
+        output except for keyword results by replacing inappropriate words with a series
+        of asterisks. Set the parameter to `false` to return results with no censoring.
+        Applies to US English transcription only.
+        :param bool smart_formatting: If `true`, converts dates, times, series of digits
+        and numbers, phone numbers, currency values, and internet addresses into more
+        readable, conventional representations in the final transcript of a recognition
+        request. For US English, also converts certain keyword strings to punctuation
+        symbols. By default, no smart formatting is performed. Applies to US English and
+        Spanish transcription only.
+        :param bool speaker_labels: If `true`, the response includes labels that identify
+        which words were spoken by which participants in a multi-person exchange. By
+        default, no speaker labels are returned. Setting `speaker_labels` to `true` forces
+        the `timestamps` parameter to be `true`, regardless of whether you specify `false`
+        for the parameter.
+         To determine whether a language model supports speaker labels, use the **Get
+        models** method and check that the attribute `speaker_labels` is set to `true`.
+        You can also refer to [Speaker
+        labels](https://console.bluemix.net/docs/services/speech-to-text/output.html#speaker_labels).
         :param dict headers: A `dict` containing the request headers
         :return: A `dict` containing the `SpeechRecognitionResults` response.
         :rtype: dict
         """
+        if audio is None:
+            raise ValueError('audio must be provided')
+        if content_type is None:
+            raise ValueError('content_type must be provided')
         headers = {'Content-Type': content_type}
         if 'headers' in kwargs:
             headers.update(kwargs.get('headers'))
@@ -245,9 +355,8 @@ class SpeechToTextV1(WatsonService):
             'model': model,
             'customization_id': customization_id,
             'acoustic_customization_id': acoustic_customization_id,
+            'base_model_version': base_model_version,
             'customization_weight': customization_weight,
-            'version': version,
-            'base_model_version': version,
             'inactivity_timeout': inactivity_timeout,
             'keywords': self._convert_list(keywords),
             'keywords_threshold': keywords_threshold,
@@ -270,100 +379,6 @@ class SpeechToTextV1(WatsonService):
             accept_json=True)
         return response
 
-
-    def recognize_with_websocket(self,
-                                 audio=None,
-                                 content_type='audio/l16; rate=44100',
-                                 model='en-US_BroadbandModel',
-                                 recognize_callback=None,
-                                 customization_id=None,
-                                 acoustic_customization_id=None,
-                                 customization_weight=None,
-                                 version=None,
-                                 inactivity_timeout=None,
-                                 interim_results=True,
-                                 keywords=None,
-                                 keywords_threshold=None,
-                                 max_alternatives=1,
-                                 word_alternatives_threshold=None,
-                                 word_confidence=False,
-                                 timestamps=False,
-                                 profanity_filter=None,
-                                 smart_formatting=False,
-                                 speaker_labels=None,
-                                 **kwargs):
-        """
-        Sends audio for speech recognition using web sockets.
-
-        :param str audio: Audio to transcribe in the format specified by the `Content-Type` header.
-        :param str content_type: The type of the input: audio/basic, audio/flac, audio/l16, audio/mp3, audio/mpeg, audio/mulaw, audio/ogg, audio/ogg;codecs=opus, audio/ogg;codecs=vorbis, audio/wav, audio/webm, audio/webm;codecs=opus, audio/webm;codecs=vorbis, or multipart/form-data.
-        :param str model: The identifier of the model to be used for the recognition request.
-        :param RecognizeCallback recognize_callback: The instance handling events returned from the service.
-        :param str customization_id: The GUID of a custom language model that is to be used with the request. The base model of the specified custom language model must match the model specified with the `model` parameter. You must make the request with service credentials created for the instance of the service that owns the custom model. By default, no custom language model is used.
-        :param str acoustic_customization_id: The GUID of a custom acoustic model that is to be used with the request. The base model of the specified custom acoustic model must match the model specified with the `model` parameter. You must make the request with service credentials created for the instance of the service that owns the custom model. By default, no custom acoustic model is used.
-        :param float customization_weight: If you specify a `customization_id` with the request, you can use the `customization_weight` parameter to tell the service how much weight to give to words from the custom language model compared to those from the base model for speech recognition.   Specify a value between 0.0 and 1.0. Unless a different customization weight was specified for the custom model when it was trained, the default value is 0.3. A customization weight that you specify overrides a weight that was specified when the custom model was trained.   The default value yields the best performance in general. Assign a higher value if your audio makes frequent use of OOV words from the custom model. Use caution when setting the weight: a higher value can improve the accuracy of phrases from the custom model's domain, but it can negatively affect performance on non-domain phrases.
-        :param str version: The version of the specified base `model` that is to be used for speech recognition. Multiple versions of a base model can exist when a model is updated for internal improvements. The parameter is intended primarily for use with custom models that have been upgraded for a new base model. The default value depends on whether the parameter is used with or without a custom model. For more information, see [Base model version](https://console.bluemix.net/docs/services/speech-to-text/input.html#version).
-        :param int inactivity_timeout: The time in seconds after which, if only silence (no speech) is detected in submitted audio, the connection is closed with a 400 error. Useful for stopping audio submission from a live microphone when a user simply walks away. Use `-1` for infinity.
-        :param bool interim_results: Send back non-final previews of each "sentence" as it is being processed. These results are ignored in text mode.
-        :param list[str] keywords: Array of keyword strings to spot in the audio. Each keyword string can include one or more tokens. Keywords are spotted only in the final hypothesis, not in interim results. If you specify any keywords, you must also specify a keywords threshold. Omit the parameter or specify an empty array if you do not need to spot keywords.
-        :param float keywords_threshold: Confidence value that is the lower bound for spotting a keyword. A word is considered to match a keyword if its confidence is greater than or equal to the threshold. Specify a probability between 0 and 1 inclusive. No keyword spotting is performed if you omit the parameter. If you specify a threshold, you must also specify one or more keywords.
-        :param int max_alternatives: Maximum number of alternative transcripts to be returned. By default, a single transcription is returned.
-        :param float word_alternatives_threshold: Confidence value that is the lower bound for identifying a hypothesis as a possible word alternative (also known as \"Confusion Networks\"). An alternative word is considered if its confidence is greater than or equal to the threshold. Specify a probability between 0 and 1 inclusive. No alternative words are computed if you omit the parameter.
-        :param bool word_confidence: If `true`, confidence measure per word is returned.
-        :param bool timestamps: If `true`, time alignment for each word is returned.
-        :param bool profanity_filter: If `true` (the default), filters profanity from all output except for keyword results by replacing inappropriate words with a series of asterisks. Set the parameter to `false` to return results with no censoring. Applies to US English transcription only.
-        :param bool smart_formatting: If `true`, converts dates, times, series of digits and numbers, phone numbers, currency values, and Internet addresses into more readable, conventional representations in the final transcript of a recognition request. If `false` (the default), no formatting is performed. Applies to US English transcription only.
-        :param bool speaker_labels: Indicates whether labels that identify which words were spoken by which participants in a multi-person exchange are to be included in the response. The default is `false`; no speaker labels are returned. Setting `speaker_labels` to `true` forces the `timestamps` parameter to be `true`, regardless of whether you specify `false` for the parameter.   To determine whether a language model supports speaker labels, use the `GET /v1/models` method and check that the attribute `speaker_labels` is set to `true`. You can also refer to [Speaker labels](https://console.bluemix.net/docs/services/speech-to-text/output.html#speaker_labels).
-        :param dict headers: A `dict` containing the request headers
-        :return:
-        """
-        if audio is None:
-            raise ValueError('Audio must be provided')
-        if recognize_callback is None:
-            raise ValueError('Recognize callback must be provided')
-        if not isinstance(recognize_callback, RecognizeCallback):
-            raise Exception(
-                'Callback is not a derived class of RecognizeCallback')
-
-        headers = {}
-        if self.default_headers is not None:
-            headers = self.default_headers.copy()
-        if 'headers' in kwargs:
-            headers.update(kwargs.get('headers'))
-
-        authstring = "{0}:{1}".format(self.username, self.password)
-        base64_authorization = base64.b64encode(authstring.encode('utf-8')).decode('utf-8')
-        headers['Authorization'] = 'Basic {0}'.format(base64_authorization)
-
-        url = self.url.replace('https:', 'wss:')
-        params = {
-            'model': model,
-            'customization_id': customization_id,
-            'acoustic_customization_id': acoustic_customization_id,
-            'customization_weight': customization_weight,
-            'version': version
-        }
-        params = _remove_null_values(params)
-        url = url + '/v1/recognize?{0}'.format(urlencode(params))
-
-        options = {
-            'content_type': content_type,
-            'inactivity_timeout': inactivity_timeout,
-            'interim_results': interim_results,
-            'keywords': keywords,
-            'keywords_threshold': keywords_threshold,
-            'max_alternatives': max_alternatives,
-            'word_alternatives_threshold': word_alternatives_threshold,
-            'word_confidence': word_confidence,
-            'timestamps': timestamps,
-            'profanity_filter': profanity_filter,
-            'smart_formatting': smart_formatting,
-            'speaker_labels': speaker_labels
-        }
-        options = _remove_null_values(options)
-
-        RecognizeListener(audio, options, recognize_callback, url, headers)
-
     #########################
     # Asynchronous
     #########################
@@ -375,10 +390,10 @@ class SpeechToTextV1(WatsonService):
         Returns information about the specified job. The response always includes the
         status of the job and its creation and update times. If the status is `completed`,
         the response includes the results of the recognition request. You must submit the
-        request with the service credentials of the user who created the job.   You can
-        use the method to retrieve the results of any job, regardless of whether it was
-        submitted with a callback URL and the `recognitions.completed_with_results` event,
-        and you can retrieve the results multiple times for as long as they remain
+        request with the service credentials of the user who created the job.
+        You can use the method to retrieve the results of any job, regardless of whether
+        it was submitted with a callback URL and the `recognitions.completed_with_results`
+        event, and you can retrieve the results multiple times for as long as they remain
         available. Use the **Check jobs** method to request information about the most
         recent jobs associated with the calling user.
 
@@ -432,8 +447,8 @@ class SpeechToTextV1(WatsonService):
                    results_ttl=None,
                    customization_id=None,
                    acoustic_customization_id=None,
+                   base_model_version=None,
                    customization_weight=None,
-                   version=None,
                    inactivity_timeout=None,
                    keywords=None,
                    keywords_threshold=None,
@@ -451,64 +466,167 @@ class SpeechToTextV1(WatsonService):
         Creates a job for a new asynchronous recognition request. The job is owned by the
         user whose service credentials are used to create it. How you learn the status and
         results of a job depends on the parameters you include with the job creation
-        request: * By callback notification: Include the `callback_url` parameter to
-        specify a URL to which the service is to send callback notifications when the
-        status of the job changes. Optionally, you can also include the `events` and
-        `user_token` parameters to subscribe to specific events and to specify a string
-        that is to be included with each notification for the job. * By polling the
-        service: Omit the `callback_url`, `events`, and `user_token` parameters. You must
-        then use the **Check jobs** or **Check a job** methods to check the status of the
-        job, using the latter to retrieve the results when the job is complete.  The two
-        approaches are not mutually exclusive. You can poll the service for job status or
-        obtain results from the service manually even if you include a callback URL. In
-        both cases, you can include the `results_ttl` parameter to specify how long the
-        results are to remain available after the job is complete. For detailed usage
-        information about the two approaches, including callback notifications, see
+        request:
+        * By callback notification: Include the `callback_url` parameter to specify a URL
+        to which the service is to send callback notifications when the status of the job
+        changes. Optionally, you can also include the `events` and `user_token` parameters
+        to subscribe to specific events and to specify a string that is to be included
+        with each notification for the job.
+        * By polling the service: Omit the `callback_url`, `events`, and `user_token`
+        parameters. You must then use the **Check jobs** or **Check a job** methods to
+        check the status of the job, using the latter to retrieve the results when the job
+        is complete.
+        The two approaches are not mutually exclusive. You can poll the service for job
+        status or obtain results from the service manually even if you include a callback
+        URL. In both cases, you can include the `results_ttl` parameter to specify how
+        long the results are to remain available after the job is complete. For detailed
+        usage information about the two approaches, including callback notifications, see
         [Creating a
         job](https://console.bluemix.net/docs/services/speech-to-text/async.html#create).
         Using the HTTPS **Check a job** method to retrieve results is more secure than
         receiving them via callback notification over HTTP because it provides
-        confidentiality in addition to authentication and data integrity.   The method
-        supports the same basic parameters as other HTTP and WebSocket recognition
-        requests. The service imposes a data size limit of 100 MB. It automatically
-        detects the endianness of the incoming audio and, for audio that includes multiple
-        channels, downmixes the audio to one-channel mono during transcoding. (For the
-        `audio/l16` format, you can specify the endianness.)   ### Audio formats (content
-        types)   Use the `Content-Type` parameter to specify the audio format (MIME type)
-        of the audio: * `audio/basic` (Use only with narrowband models.) * `audio/flac` *
-        `audio/l16` (Specify the sampling rate (`rate`) and optionally the number of
-        channels (`channels`) and endianness (`endianness`) of the audio.) * `audio/mp3` *
-        `audio/mpeg` * `audio/mulaw` (Specify the sampling rate (`rate`) of the audio.) *
-        `audio/ogg` (The service automatically detects the codec of the input audio.) *
-        `audio/ogg;codecs=opus` * `audio/ogg;codecs=vorbis` * `audio/wav` (Provide audio
-        with a maximum of nine channels.) * `audio/webm` (The service automatically
-        detects the codec of the input audio.) * `audio/webm;codecs=opus` *
-        `audio/webm;codecs=vorbis`   For information about the supported audio formats,
-        including specifying the sampling rate, channels, and endianness for the indicated
-        formats, see [Audio
+        confidentiality in addition to authentication and data integrity.
+        The method supports the same basic parameters as other HTTP and WebSocket
+        recognition requests. The service imposes a data size limit of 100 MB. It
+        automatically detects the endianness of the incoming audio and, for audio that
+        includes multiple channels, downmixes the audio to one-channel mono during
+        transcoding. (For the `audio/l16` format, you can specify the endianness.)
+        ### Audio formats (content types)
+         Use the `Content-Type` parameter to specify the audio format (MIME type) of the
+        audio:
+        * `audio/basic` (Use only with narrowband models.)
+        * `audio/flac`
+        * `audio/l16` (Specify the sampling rate (`rate`) and optionally the number of
+        channels (`channels`) and endianness (`endianness`) of the audio.)
+        * `audio/mp3`
+        * `audio/mpeg`
+        * `audio/mulaw` (Specify the sampling rate (`rate`) of the audio.)
+        * `audio/ogg` (The service automatically detects the codec of the input audio.)
+        * `audio/ogg;codecs=opus`
+        * `audio/ogg;codecs=vorbis`
+        * `audio/wav` (Provide audio with a maximum of nine channels.)
+        * `audio/webm` (The service automatically detects the codec of the input audio.)
+        * `audio/webm;codecs=opus`
+        * `audio/webm;codecs=vorbis`
+        For information about the supported audio formats, including specifying the
+        sampling rate, channels, and endianness for the indicated formats, see [Audio
         formats](https://console.bluemix.net/docs/services/speech-to-text/audio-formats.html).
 
-        :param str audio: The audio to transcribe in the format specified by the `Content-Type` header.
-        :param str content_type: The type of the input: audio/basic, audio/flac, audio/l16, audio/mp3, audio/mpeg, audio/mulaw, audio/ogg, audio/ogg;codecs=opus, audio/ogg;codecs=vorbis, audio/wav, audio/webm, audio/webm;codecs=opus, or audio/webm;codecs=vorbis.
-        :param str model: The identifier of the model that is to be used for the recognition request or, for the **Create a session** method, with the new session.
-        :param str callback_url: A URL to which callback notifications are to be sent. The URL must already be successfully white-listed by using the **Register a callback** method. Omit the parameter to poll the service for job completion and results. You can include the same callback URL with any number of job creation requests. Use the `user_token` parameter to specify a unique user-specified string with each job to differentiate the callback notifications for the jobs.
-        :param str events: If the job includes a callback URL, a comma-separated list of notification events to which to subscribe. Valid events are: `recognitions.started` generates a callback notification when the service begins to process the job. `recognitions.completed` generates a callback notification when the job is complete; you must use the **Check a job** method to retrieve the results before they time out or are deleted. `recognitions.completed_with_results` generates a callback notification when the job is complete; the notification includes the results of the request. `recognitions.failed` generates a callback notification if the service experiences an error while processing the job. Omit the parameter to subscribe to the default events: `recognitions.started`, `recognitions.completed`, and `recognitions.failed`. The `recognitions.completed` and `recognitions.completed_with_results` events are incompatible; you can specify only of the two events. If the job does not include a callback URL, omit the parameter.
-        :param str user_token: If the job includes a callback URL, a user-specified string that the service is to include with each callback notification for the job; the token allows the user to maintain an internal mapping between jobs and notification events. If the job does not include a callback URL, omit the parameter.
-        :param int results_ttl: The number of minutes for which the results are to be available after the job has finished. If not delivered via a callback, the results must be retrieved within this time. Omit the parameter to use a time to live of one week. The parameter is valid with or without a callback URL.
-        :param str customization_id: The customization ID (GUID) of a custom language model that is to be used with the recognition request or, for the **Create a session** method, with the new session. The base model of the specified custom language model must match the model specified with the `model` parameter. You must make the request with service credentials created for the instance of the service that owns the custom model. By default, no custom language model is used.
-        :param str acoustic_customization_id: The customization ID (GUID) of a custom acoustic model that is to be used with the recognition request or, for the **Create a session** method, with the new session. The base model of the specified custom acoustic model must match the model specified with the `model` parameter. You must make the request with service credentials created for the instance of the service that owns the custom model. By default, no custom acoustic model is used.
-        :param str version: The version of the specified base model that is to be used with recognition request or, for the **Create a session** method, with the new session. Multiple versions of a base model can exist when a model is updated for internal improvements. The parameter is intended primarily for use with custom models that have been upgraded for a new base model. The default value depends on whether the parameter is used with or without a custom model. For more information, see [Base model version](https://console.bluemix.net/docs/services/speech-to-text/input.html#version).
-        :param float customization_weight: If you specify the customization ID (GUID) of a custom language model with the recognition request or, for sessions, with the **Create a session** method, the customization weight tells the service how much weight to give to words from the custom language model compared to those from the base model for the current request.   Specify a value between 0.0 and 1.0. Unless a different customization weight was specified for the custom model when it was trained, the default value is 0.3. A customization weight that you specify overrides a weight that was specified when the custom model was trained.   The default value yields the best performance in general. Assign a higher value if your audio makes frequent use of OOV words from the custom model. Use caution when setting the weight: a higher value can improve the accuracy of phrases from the custom model's domain, but it can negatively affect performance on non-domain phrases.
-        :param int inactivity_timeout: The time in seconds after which, if only silence (no speech) is detected in submitted audio, the connection is closed with a 400 error. Useful for stopping audio submission from a live microphone when a user simply walks away. Use `-1` for infinity.
-        :param list[str] keywords: An array of keyword strings to spot in the audio. Each keyword string can include one or more tokens. Keywords are spotted only in the final hypothesis, not in interim results. If you specify any keywords, you must also specify a keywords threshold. You can spot a maximum of 1000 keywords. Omit the parameter or specify an empty array if you do not need to spot keywords.
-        :param float keywords_threshold: A confidence value that is the lower bound for spotting a keyword. A word is considered to match a keyword if its confidence is greater than or equal to the threshold. Specify a probability between 0 and 1 inclusive. No keyword spotting is performed if you omit the parameter. If you specify a threshold, you must also specify one or more keywords.
-        :param int max_alternatives: The maximum number of alternative transcripts to be returned. By default, a single transcription is returned.
-        :param float word_alternatives_threshold: A confidence value that is the lower bound for identifying a hypothesis as a possible word alternative (also known as \"Confusion Networks\"). An alternative word is considered if its confidence is greater than or equal to the threshold. Specify a probability between 0 and 1 inclusive. No alternative words are computed if you omit the parameter.
-        :param bool word_confidence: If `true`, a confidence measure in the range of 0 to 1 is returned for each word. By default, no word confidence measures are returned.
-        :param bool timestamps: If `true`, time alignment is returned for each word. By default, no timestamps are returned.
-        :param bool profanity_filter: If `true` (the default), filters profanity from all output except for keyword results by replacing inappropriate words with a series of asterisks. Set the parameter to `false` to return results with no censoring. Applies to US English transcription only.
-        :param bool smart_formatting: If `true`, converts dates, times, series of digits and numbers, phone numbers, currency values, and internet addresses into more readable, conventional representations in the final transcript of a recognition request. For US English, also converts certain keyword strings to punctuation symbols. By default, no smart formatting is performed. Applies to US English and Spanish transcription only.
-        :param bool speaker_labels: If `true`, the response includes labels that identify which words were spoken by which participants in a multi-person exchange. By default, no speaker labels are returned. Setting `speaker_labels` to `true` forces the `timestamps` parameter to be `true`, regardless of whether you specify `false` for the parameter.   To determine whether a language model supports speaker labels, use the **Get models** method and check that the attribute `speaker_labels` is set to `true`. You can also refer to [Speaker labels](https://console.bluemix.net/docs/services/speech-to-text/output.html#speaker_labels).
+        :param str audio: The audio to transcribe in the format specified by the
+        `Content-Type` header.
+        :param str content_type: The type of the input: audio/basic, audio/flac,
+        audio/l16, audio/mp3, audio/mpeg, audio/mulaw, audio/ogg, audio/ogg;codecs=opus,
+        audio/ogg;codecs=vorbis, audio/wav, audio/webm, audio/webm;codecs=opus, or
+        audio/webm;codecs=vorbis.
+        :param str model: The identifier of the model that is to be used for the
+        recognition request or, for the **Create a session** method, with the new session.
+        :param str callback_url: A URL to which callback notifications are to be sent. The
+        URL must already be successfully white-listed by using the **Register a callback**
+        method. Omit the parameter to poll the service for job completion and results. You
+        can include the same callback URL with any number of job creation requests. Use
+        the `user_token` parameter to specify a unique user-specified string with each job
+        to differentiate the callback notifications for the jobs.
+        :param str events: If the job includes a callback URL, a comma-separated list of
+        notification events to which to subscribe. Valid events are:
+        `recognitions.started` generates a callback notification when the service begins
+        to process the job. `recognitions.completed` generates a callback notification
+        when the job is complete; you must use the **Check a job** method to retrieve the
+        results before they time out or are deleted. `recognitions.completed_with_results`
+        generates a callback notification when the job is complete; the notification
+        includes the results of the request. `recognitions.failed` generates a callback
+        notification if the service experiences an error while processing the job. Omit
+        the parameter to subscribe to the default events: `recognitions.started`,
+        `recognitions.completed`, and `recognitions.failed`. The `recognitions.completed`
+        and `recognitions.completed_with_results` events are incompatible; you can specify
+        only of the two events. If the job does not include a callback URL, omit the
+        parameter.
+        :param str user_token: If the job includes a callback URL, a user-specified string
+        that the service is to include with each callback notification for the job; the
+        token allows the user to maintain an internal mapping between jobs and
+        notification events. If the job does not include a callback URL, omit the
+        parameter.
+        :param int results_ttl: The number of minutes for which the results are to be
+        available after the job has finished. If not delivered via a callback, the results
+        must be retrieved within this time. Omit the parameter to use a time to live of
+        one week. The parameter is valid with or without a callback URL.
+        :param str customization_id: The customization ID (GUID) of a custom language
+        model that is to be used with the recognition request or, for the **Create a
+        session** method, with the new session. The base model of the specified custom
+        language model must match the model specified with the `model` parameter. You must
+        make the request with service credentials created for the instance of the service
+        that owns the custom model. By default, no custom language model is used.
+        :param str acoustic_customization_id: The customization ID (GUID) of a custom
+        acoustic model that is to be used with the recognition request or, for the
+        **Create a session** method, with the new session. The base model of the specified
+        custom acoustic model must match the model specified with the `model` parameter.
+        You must make the request with service credentials created for the instance of the
+        service that owns the custom model. By default, no custom acoustic model is used.
+        :param str base_model_version: The version of the specified base model that is to
+        be used with recognition request or, for the **Create a session** method, with the
+        new session. Multiple versions of a base model can exist when a model is updated
+        for internal improvements. The parameter is intended primarily for use with custom
+        models that have been upgraded for a new base model. The default value depends on
+        whether the parameter is used with or without a custom model. For more
+        information, see [Base model
+        version](https://console.bluemix.net/docs/services/speech-to-text/input.html#version).
+        :param float customization_weight: If you specify the customization ID (GUID) of a
+        custom language model with the recognition request or, for sessions, with the
+        **Create a session** method, the customization weight tells the service how much
+        weight to give to words from the custom language model compared to those from the
+        base model for the current request.
+        Specify a value between 0.0 and 1.0. Unless a different customization weight was
+        specified for the custom model when it was trained, the default value is 0.3. A
+        customization weight that you specify overrides a weight that was specified when
+        the custom model was trained.
+        The default value yields the best performance in general. Assign a higher value if
+        your audio makes frequent use of OOV words from the custom model. Use caution when
+        setting the weight: a higher value can improve the accuracy of phrases from the
+        custom model's domain, but it can negatively affect performance on non-domain
+        phrases.
+        :param int inactivity_timeout: The time in seconds after which, if only silence
+        (no speech) is detected in submitted audio, the connection is closed with a 400
+        error. Useful for stopping audio submission from a live microphone when a user
+        simply walks away. Use `-1` for infinity.
+        :param list[str] keywords: An array of keyword strings to spot in the audio. Each
+        keyword string can include one or more tokens. Keywords are spotted only in the
+        final hypothesis, not in interim results. If you specify any keywords, you must
+        also specify a keywords threshold. You can spot a maximum of 1000 keywords. Omit
+        the parameter or specify an empty array if you do not need to spot keywords.
+        :param float keywords_threshold: A confidence value that is the lower bound for
+        spotting a keyword. A word is considered to match a keyword if its confidence is
+        greater than or equal to the threshold. Specify a probability between 0 and 1
+        inclusive. No keyword spotting is performed if you omit the parameter. If you
+        specify a threshold, you must also specify one or more keywords.
+        :param int max_alternatives: The maximum number of alternative transcripts to be
+        returned. By default, a single transcription is returned.
+        :param float word_alternatives_threshold: A confidence value that is the lower
+        bound for identifying a hypothesis as a possible word alternative (also known as
+        \"Confusion Networks\"). An alternative word is considered if its confidence is
+        greater than or equal to the threshold. Specify a probability between 0 and 1
+        inclusive. No alternative words are computed if you omit the parameter.
+        :param bool word_confidence: If `true`, a confidence measure in the range of 0 to
+        1 is returned for each word. By default, no word confidence measures are returned.
+        :param bool timestamps: If `true`, time alignment is returned for each word. By
+        default, no timestamps are returned.
+        :param bool profanity_filter: If `true` (the default), filters profanity from all
+        output except for keyword results by replacing inappropriate words with a series
+        of asterisks. Set the parameter to `false` to return results with no censoring.
+        Applies to US English transcription only.
+        :param bool smart_formatting: If `true`, converts dates, times, series of digits
+        and numbers, phone numbers, currency values, and internet addresses into more
+        readable, conventional representations in the final transcript of a recognition
+        request. For US English, also converts certain keyword strings to punctuation
+        symbols. By default, no smart formatting is performed. Applies to US English and
+        Spanish transcription only.
+        :param bool speaker_labels: If `true`, the response includes labels that identify
+        which words were spoken by which participants in a multi-person exchange. By
+        default, no speaker labels are returned. Setting `speaker_labels` to `true` forces
+        the `timestamps` parameter to be `true`, regardless of whether you specify `false`
+        for the parameter.
+         To determine whether a language model supports speaker labels, use the **Get
+        models** method and check that the attribute `speaker_labels` is set to `true`.
+        You can also refer to [Speaker
+        labels](https://console.bluemix.net/docs/services/speech-to-text/output.html#speaker_labels).
         :param dict headers: A `dict` containing the request headers
         :return: A `dict` containing the `RecognitionJob` response.
         :rtype: dict
@@ -528,8 +646,7 @@ class SpeechToTextV1(WatsonService):
             'results_ttl': results_ttl,
             'customization_id': customization_id,
             'acoustic_customization_id': acoustic_customization_id,
-            'version': version,
-            'base_model_version': version,
+            'base_model_version': base_model_version,
             'customization_weight': customization_weight,
             'inactivity_timeout': inactivity_timeout,
             'keywords': self._convert_list(keywords),
@@ -586,31 +703,40 @@ class SpeechToTextV1(WatsonService):
         callback URL if it is not already registered by sending a `GET` request to the
         callback URL. The service passes a random alphanumeric challenge string via the
         `challenge_string` parameter of the request. The request includes an `Accept`
-        header that specifies `text/plain` as the required response type.   To be
-        registered successfully, the callback URL must respond to the `GET` request from
-        the service. The response must send status code 200 and must include the challenge
-        string in its body. Set the `Content-Type` response header to `text/plain`. Upon
-        receiving this response, the service responds to the original registration request
-        with response code 201.   The service sends only a single `GET` request to the
-        callback URL. If the service does not receive a reply with a response code of 200
-        and a body that echoes the challenge string sent by the service within five
-        seconds, it does not white-list the URL; it instead sends status code 400 in
-        response to the **Register a callback** request. If the requested callback URL is
-        already white-listed, the service responds to the initial registration request
-        with response code 200.   If you specify a user secret with the request, the
-        service uses it as a key to calculate an HMAC-SHA1 signature of the challenge
-        string in its response to the `POST` request. It sends this signature in the
-        `X-Callback-Signature` header of its `GET` request to the URL during registration.
-        It also uses the secret to calculate a signature over the payload of every
-        callback notification that uses the URL. The signature provides authentication and
-        data integrity for HTTP communications.   After you successfully register a
-        callback URL, you can use it with an indefinite number of recognition requests.
-        You can register a maximum of 20 callback URLS in a one-hour span of time. For
-        more information, see [Registering a callback
+        header that specifies `text/plain` as the required response type.
+        To be registered successfully, the callback URL must respond to the `GET` request
+        from the service. The response must send status code 200 and must include the
+        challenge string in its body. Set the `Content-Type` response header to
+        `text/plain`. Upon receiving this response, the service responds to the original
+        registration request with response code 201.
+        The service sends only a single `GET` request to the callback URL. If the service
+        does not receive a reply with a response code of 200 and a body that echoes the
+        challenge string sent by the service within five seconds, it does not white-list
+        the URL; it instead sends status code 400 in response to the **Register a
+        callback** request. If the requested callback URL is already white-listed, the
+        service responds to the initial registration request with response code 200.
+        If you specify a user secret with the request, the service uses it as a key to
+        calculate an HMAC-SHA1 signature of the challenge string in its response to the
+        `POST` request. It sends this signature in the `X-Callback-Signature` header of
+        its `GET` request to the URL during registration. It also uses the secret to
+        calculate a signature over the payload of every callback notification that uses
+        the URL. The signature provides authentication and data integrity for HTTP
+        communications.
+        After you successfully register a callback URL, you can use it with an indefinite
+        number of recognition requests. You can register a maximum of 20 callback URLS in
+        a one-hour span of time. For more information, see [Registering a callback
         URL](https://console.bluemix.net/docs/services/speech-to-text/async.html#register).
 
-        :param str callback_url: An HTTP or HTTPS URL to which callback notifications are to be sent. To be white-listed, the URL must successfully echo the challenge string during URL verification. During verification, the client can also check the signature that the service sends in the `X-Callback-Signature` header to verify the origin of the request.
-        :param str user_secret: A user-specified string that the service uses to generate the HMAC-SHA1 signature that it sends via the `X-Callback-Signature` header. The service includes the header during URL verification and with every notification sent to the callback URL. It calculates the signature over the payload of the notification. If you omit the parameter, the service does not send the header.
+        :param str callback_url: An HTTP or HTTPS URL to which callback notifications are
+        to be sent. To be white-listed, the URL must successfully echo the challenge
+        string during URL verification. During verification, the client can also check the
+        signature that the service sends in the `X-Callback-Signature` header to verify
+        the origin of the request.
+        :param str user_secret: A user-specified string that the service uses to generate
+        the HMAC-SHA1 signature that it sends via the `X-Callback-Signature` header. The
+        service includes the header during URL verification and with every notification
+        sent to the callback URL. It calculates the signature over the payload of the
+        notification. If you omit the parameter, the service does not send the header.
         :param dict headers: A `dict` containing the request headers
         :return: A `dict` containing the `RegisterStatus` response.
         :rtype: dict
@@ -673,12 +799,32 @@ class SpeechToTextV1(WatsonService):
         Creates a new custom language model for a specified base model. The custom
         language model can be used only with the base model for which it is created. The
         model is owned by the instance of the service whose credentials are used to create
-        it. You must pass a value of `application/json` with the `Content-Type` header.
+        it.
 
-        :param str name: A user-defined name for the new custom language model. Use a name that is unique among all custom language models that you own. Use a localized name that matches the language of the custom model. Use a name that describes the domain of the custom model, such as `Medical custom model` or `Legal custom model`.
-        :param str base_model_name: The name of the base language model that is to be customized by the new custom language model. The new custom model can be used only with the base model that it customizes. To determine whether a base model supports language model customization, request information about the base model and check that the attribute `custom_language_model` is set to `true`, or refer to [Language support for customization](https://console.bluemix.net/docs/services/speech-to-text/custom.html#languageSupport).
-        :param str dialect: The dialect of the specified language that is to be used with the custom language model. The parameter is meaningful only for Spanish models, for which the service creates a custom language model that is suited for speech in one of the following dialects: * `es-ES` for Castilian Spanish (the default) * `es-LA` for Latin American Spanish * `es-US` for North American (Mexican) Spanish   A specified dialect must be valid for the base model. By default, the dialect matches the language of the base model; for example, `en-US` for either of the US English language models.
-        :param str description: A description of the new custom language model. Use a localized description that matches the language of the custom model.
+        :param str name: A user-defined name for the new custom language model. Use a name
+        that is unique among all custom language models that you own. Use a localized name
+        that matches the language of the custom model. Use a name that describes the
+        domain of the custom model, such as `Medical custom model` or `Legal custom
+        model`.
+        :param str base_model_name: The name of the base language model that is to be
+        customized by the new custom language model. The new custom model can be used only
+        with the base model that it customizes. To determine whether a base model supports
+        language model customization, request information about the base model and check
+        that the attribute `custom_language_model` is set to `true`, or refer to [Language
+        support for
+        customization](https://console.bluemix.net/docs/services/speech-to-text/custom.html#languageSupport).
+        :param str dialect: The dialect of the specified language that is to be used with
+        the custom language model. The parameter is meaningful only for Spanish models,
+        for which the service creates a custom language model that is suited for speech in
+        one of the following dialects:
+        * `es-ES` for Castilian Spanish (the default)
+        * `es-LA` for Latin American Spanish
+        * `es-US` for North American (Mexican) Spanish
+        A specified dialect must be valid for the base model. By default, the dialect
+        matches the language of the base model; for example, `en-US` for either of the US
+        English language models.
+        :param str description: A description of the new custom language model. Use a
+        localized description that matches the language of the custom model.
         :param dict headers: A `dict` containing the request headers
         :return: A `dict` containing the `LanguageModel` response.
         :rtype: dict
@@ -705,14 +851,6 @@ class SpeechToTextV1(WatsonService):
             accept_json=True)
         return response
 
-    @deprecated('Use create_language_model() instead.')
-    def create_custom_model(self,
-                            name,
-                            description="",
-                            base_model="en-US_BroadbandModel"):
-        return self.create_language_model(
-            name, base_model, description=description)
-
     def delete_language_model(self, customization_id, **kwargs):
         """
         Delete a custom language model.
@@ -722,7 +860,9 @@ class SpeechToTextV1(WatsonService):
         processed. You must use credentials for the instance of the service that owns a
         model to delete it.
 
-        :param str customization_id: The customization ID (GUID) of the custom language model. You must make the request with service credentials created for the instance of the service that owns the custom model.
+        :param str customization_id: The customization ID (GUID) of the custom language
+        model. You must make the request with service credentials created for the instance
+        of the service that owns the custom model.
         :param dict headers: A `dict` containing the request headers
         :rtype: None
         """
@@ -737,19 +877,16 @@ class SpeechToTextV1(WatsonService):
             method='DELETE', url=url, headers=headers, accept_json=True)
         return None
 
-    @deprecated('Use delete_language_model() instead.')
-    def delete_custom_model(self, modelid):
-        return self.delete_language_model(modelid)
-
     def get_language_model(self, customization_id, **kwargs):
         """
-        List a custom language model.
+        Get a custom language model.
 
-        Lists information about a specified custom language model. You must use
-        credentials for the instance of the service that owns a model to list information
-        about it.
+        Gets information about a specified custom language model. You must use credentials
+        for the instance of the service that owns a model to list information about it.
 
-        :param str customization_id: The customization ID (GUID) of the custom language model. You must make the request with service credentials created for the instance of the service that owns the custom model.
+        :param str customization_id: The customization ID (GUID) of the custom language
+        model. You must make the request with service credentials created for the instance
+        of the service that owns the custom model.
         :param dict headers: A `dict` containing the request headers
         :return: A `dict` containing the `LanguageModel` response.
         :rtype: dict
@@ -765,10 +902,6 @@ class SpeechToTextV1(WatsonService):
             method='GET', url=url, headers=headers, accept_json=True)
         return response
 
-    @deprecated('Use get_language_model() instead.')
-    def get_custom_model(self, modelid):
-        return self.get_language_model(modelid)
-
     def list_language_models(self, language=None, **kwargs):
         """
         List custom language models.
@@ -779,7 +912,10 @@ class SpeechToTextV1(WatsonService):
         all languages. You must use credentials for the instance of the service that owns
         a model to list information about it.
 
-        :param str language: The identifier of the language for which custom language or custom acoustic models are to be returned (for example, `en-US`). Omit the parameter to see all custom language or custom acoustic models owned by the requesting service credentials.
+        :param str language: The identifier of the language for which custom language or
+        custom acoustic models are to be returned (for example, `en-US`). Omit the
+        parameter to see all custom language or custom acoustic models owned by the
+        requesting service credentials.
         :param dict headers: A `dict` containing the request headers
         :return: A `dict` containing the `LanguageModels` response.
         :rtype: dict
@@ -797,10 +933,6 @@ class SpeechToTextV1(WatsonService):
             accept_json=True)
         return response
 
-    @deprecated('Use list_language_models() instead.')
-    def list_custom_models(self):
-        return self.list_language_models()
-
     def reset_language_model(self, customization_id, **kwargs):
         """
         Reset a custom language model.
@@ -811,7 +943,9 @@ class SpeechToTextV1(WatsonService):
         but the model's words resource is removed and must be re-created. You must use
         credentials for the instance of the service that owns a model to reset it.
 
-        :param str customization_id: The customization ID (GUID) of the custom language model. You must make the request with service credentials created for the instance of the service that owns the custom model.
+        :param str customization_id: The customization ID (GUID) of the custom language
+        model. You must make the request with service credentials created for the instance
+        of the service that owns the custom model.
         :param dict headers: A `dict` containing the request headers
         :rtype: None
         """
@@ -839,25 +973,45 @@ class SpeechToTextV1(WatsonService):
         latest data. You can specify whether the custom language model is to be trained
         with all words from its words resource or only with words that were added or
         modified by the user. You must use credentials for the instance of the service
-        that owns a model to train it.   The training method is asynchronous. It can take
-        on the order of minutes to complete depending on the amount of data on which the
-        service is being trained and the current load on the service. The method returns
-        an HTTP 200 response code to indicate that the training process has begun.   You
-        can monitor the status of the training by using the **List a custom language
+        that owns a model to train it.
+        The training method is asynchronous. It can take on the order of minutes to
+        complete depending on the amount of data on which the service is being trained and
+        the current load on the service. The method returns an HTTP 200 response code to
+        indicate that the training process has begun.
+        You can monitor the status of the training by using the **List a custom language
         model** method to poll the model's status. Use a loop to check the status every 10
         seconds. The method returns a `Customization` object that includes `status` and
         `progress` fields. A status of `available` means that the custom model is trained
         and ready to use. The service cannot accept subsequent training requests, or
         requests to add new corpora or words, until the existing request completes.
-        Training can fail to start for the following reasons: * The service is currently
-        handling another request for the custom model, such as another training request or
-        a request to add a corpus or words to the model. * No training data (corpora or
-        words) have been added to the custom model. * One or more words that were added to
-        the custom model have invalid sounds-like pronunciations that you must fix.
+        Training can fail to start for the following reasons:
+        * The service is currently handling another request for the custom model, such as
+        another training request or a request to add a corpus or words to the model.
+        * No training data (corpora or words) have been added to the custom model.
+        * One or more words that were added to the custom model have invalid sounds-like
+        pronunciations that you must fix.
 
-        :param str customization_id: The customization ID (GUID) of the custom language model. You must make the request with service credentials created for the instance of the service that owns the custom model.
-        :param str word_type_to_add: The type of words from the custom language model's words resource on which to train the model: * `all` (the default) trains the model on all new words, regardless of whether they were extracted from corpora or were added or modified by the user. * `user` trains the model only on new words that were added or modified by the user; the model is not trained on new words extracted from corpora.
-        :param float customization_weight: Specifies a customization weight for the custom language model. The customization weight tells the service how much weight to give to words from the custom language model compared to those from the base model for speech recognition. Specify a value between 0.0 and 1.0; the default is 0.3.   The default value yields the best performance in general. Assign a higher value if your audio makes frequent use of OOV words from the custom model. Use caution when setting the weight: a higher value can improve the accuracy of phrases from the custom model's domain, but it can negatively affect performance on non-domain phrases.   The value that you assign is used for all recognition requests that use the model. You can override it for any recognition request by specifying a customization weight for that request.
+        :param str customization_id: The customization ID (GUID) of the custom language
+        model. You must make the request with service credentials created for the instance
+        of the service that owns the custom model.
+        :param str word_type_to_add: The type of words from the custom language model's
+        words resource on which to train the model:
+        * `all` (the default) trains the model on all new words, regardless of whether
+        they were extracted from corpora or were added or modified by the user.
+        * `user` trains the model only on new words that were added or modified by the
+        user; the model is not trained on new words extracted from corpora.
+        :param float customization_weight: Specifies a customization weight for the custom
+        language model. The customization weight tells the service how much weight to give
+        to words from the custom language model compared to those from the base model for
+        speech recognition. Specify a value between 0.0 and 1.0; the default is 0.3.
+        The default value yields the best performance in general. Assign a higher value if
+        your audio makes frequent use of OOV words from the custom model. Use caution when
+        setting the weight: a higher value can improve the accuracy of phrases from the
+        custom model's domain, but it can negatively affect performance on non-domain
+        phrases.
+        The value that you assign is used for all recognition requests that use the model.
+        You can override it for any recognition request by specifying a customization
+        weight for that request.
         :param dict headers: A `dict` containing the request headers
         :rtype: None
         """
@@ -880,14 +1034,6 @@ class SpeechToTextV1(WatsonService):
             accept_json=True)
         return None
 
-    @deprecated('Use train_language_model() instead.')
-    def train_custom_model(self,
-                           customization_id,
-                           customization_weight=None,
-                           word_type=None):
-        self.train_language_model(customization_id, word_type,
-                                  customization_weight)
-
     def upgrade_language_model(self, customization_id, **kwargs):
         """
         Upgrade a custom language model.
@@ -897,17 +1043,20 @@ class SpeechToTextV1(WatsonService):
         minutes to complete depending on the amount of data in the custom model and the
         current load on the service. A custom model must be in the `ready` or `available`
         state to be upgraded. You must use credentials for the instance of the service
-        that owns a model to upgrade it.   The method returns an HTTP 200 response code to
-        indicate that the upgrade process has begun successfully. You can monitor the
-        status of the upgrade by using the **List a custom language model** method to poll
-        the model's status. Use a loop to check the status every 10 seconds. While it is
-        being upgraded, the custom model has the status `upgrading`. When the upgrade is
-        complete, the model resumes the status that it had prior to upgrade. The service
-        cannot accept subsequent requests for the model until the upgrade completes.   For
-        more information, see [Upgrading custom
+        that owns a model to upgrade it.
+        The method returns an HTTP 200 response code to indicate that the upgrade process
+        has begun successfully. You can monitor the status of the upgrade by using the
+        **List a custom language model** method to poll the model's status. Use a loop to
+        check the status every 10 seconds. While it is being upgraded, the custom model
+        has the status `upgrading`. When the upgrade is complete, the model resumes the
+        status that it had prior to upgrade. The service cannot accept subsequent requests
+        for the model until the upgrade completes.
+        For more information, see [Upgrading custom
         models](https://console.bluemix.net/docs/services/speech-to-text/custom-upgrade.html).
 
-        :param str customization_id: The customization ID (GUID) of the custom language model. You must make the request with service credentials created for the instance of the service that owns the custom model.
+        :param str customization_id: The customization ID (GUID) of the custom language
+        model. You must make the request with service credentials created for the instance
+        of the service that owns the custom model.
         :param dict headers: A `dict` containing the request headers
         :rtype: None
         """
@@ -930,7 +1079,6 @@ class SpeechToTextV1(WatsonService):
                    corpus_name,
                    corpus_file,
                    allow_overwrite=None,
-                   corpus_file_content_type=None,
                    corpus_filename=None,
                    **kwargs):
         """
@@ -948,35 +1096,47 @@ class SpeechToTextV1(WatsonService):
         text file and for information about how the service parses a corpus file, see
         [Preparing a corpus text
         file](https://console.bluemix.net/docs/services/speech-to-text/language-resource.html#prepareCorpus).
-          The call returns an HTTP 201 response code if the corpus is valid. The service
+        The call returns an HTTP 201 response code if the corpus is valid. The service
         then asynchronously processes the contents of the corpus and automatically
         extracts new words that it finds. This can take on the order of a minute or two to
         complete depending on the total number of words and the number of new words in the
         corpus, as well as the current load on the service. You cannot submit requests to
         add additional corpora or words to the custom model, or to train the model, until
         the service's analysis of the corpus for the current request completes. Use the
-        **List a corpus** method to check the status of the analysis.   The service
-        auto-populates the model's words resource with any word that is not found in its
-        base vocabulary; these are referred to as out-of-vocabulary (OOV) words. You can
-        use the **List custom words** method to examine the words resource, using other
-        words method to eliminate typos and modify how words are pronounced as needed.
+        **List a corpus** method to check the status of the analysis.
+        The service auto-populates the model's words resource with any word that is not
+        found in its base vocabulary; these are referred to as out-of-vocabulary (OOV)
+        words. You can use the **List custom words** method to examine the words resource,
+        using other words method to eliminate typos and modify how words are pronounced as
+        needed.
         To add a corpus file that has the same name as an existing corpus, set the
         `allow_overwrite` parameter to `true`; otherwise, the request fails. Overwriting
         an existing corpus causes the service to process the corpus text file and extract
         OOV words anew. Before doing so, it removes any OOV words associated with the
         existing corpus from the model's words resource unless they were also added by
         another corpus or they have been modified in some way with the **Add custom
-        words** or **Add a custom word** method.   The service limits the overall amount
-        of data that you can add to a custom model to a maximum of 10 million total words
-        from all corpora combined. Also, you can add no more than 30 thousand custom (OOV)
-        words to a model; this includes words that the service extracts from corpora and
-        words that you add directly.
+        words** or **Add a custom word** method.
+        The service limits the overall amount of data that you can add to a custom model
+        to a maximum of 10 million total words from all corpora combined. Also, you can
+        add no more than 30 thousand custom (OOV) words to a model; this includes words
+        that the service extracts from corpora and words that you add directly.
 
-        :param str customization_id: The customization ID (GUID) of the custom language model. You must make the request with service credentials created for the instance of the service that owns the custom model.
-        :param str corpus_name: The name of the corpus for the custom language model. When adding a corpus, do not include spaces in the name; use a localized name that matches the language of the custom model; and do not use the name `user`, which is reserved by the service to denote custom words added or modified by the user.
-        :param file corpus_file: A plain text file that contains the training data for the corpus. Encode the file in UTF-8 if it contains non-ASCII characters; the service assumes UTF-8 encoding if it encounters non-ASCII characters. With cURL, use the `--data-binary` option to upload the file for the request.
-        :param bool allow_overwrite: If `true`, the specified corpus or audio resource overwrites an existing corpus or audio resource with the same name. If `false` (the default), the request fails if a corpus or audio resource with the same name already exists. The parameter has no effect if a corpus or audio resource with the same name does not already exist.
-        :param str corpus_file_content_type: The content type of corpus_file.
+        :param str customization_id: The customization ID (GUID) of the custom language
+        model. You must make the request with service credentials created for the instance
+        of the service that owns the custom model.
+        :param str corpus_name: The name of the corpus for the custom language model. When
+        adding a corpus, do not include spaces in the name; use a localized name that
+        matches the language of the custom model; and do not use the name `user`, which is
+        reserved by the service to denote custom words added or modified by the user.
+        :param file corpus_file: A plain text file that contains the training data for the
+        corpus. Encode the file in UTF-8 if it contains non-ASCII characters; the service
+        assumes UTF-8 encoding if it encounters non-ASCII characters. With cURL, use the
+        `--data-binary` option to upload the file for the request.
+        :param bool allow_overwrite: If `true`, the specified corpus or audio resource
+        overwrites an existing corpus or audio resource with the same name. If `false`
+        (the default), the request fails if a corpus or audio resource with the same name
+        already exists. The parameter has no effect if a corpus or audio resource with the
+        same name does not already exist.
         :param str corpus_filename: The filename for corpus_file.
         :param dict headers: A `dict` containing the request headers
         :rtype: None
@@ -993,7 +1153,7 @@ class SpeechToTextV1(WatsonService):
         params = {'allow_overwrite': allow_overwrite}
         if not corpus_filename and hasattr(corpus_file, 'name'):
             corpus_filename = corpus_file.name
-        mime_type = corpus_file_content_type or 'application/octet-stream'
+        mime_type = 'text/plain'
         corpus_file_tuple = (corpus_filename, corpus_file, mime_type)
         url = '/v1/customizations/{0}/corpora/{1}'.format(
             *self._encode_path_vars(customization_id, corpus_name))
@@ -1018,8 +1178,13 @@ class SpeechToTextV1(WatsonService):
         model with the **Train a custom language model** method. You must use credentials
         for the instance of the service that owns a model to delete its corpora.
 
-        :param str customization_id: The customization ID (GUID) of the custom language model. You must make the request with service credentials created for the instance of the service that owns the custom model.
-        :param str corpus_name: The name of the corpus for the custom language model. When adding a corpus, do not include spaces in the name; use a localized name that matches the language of the custom model; and do not use the name `user`, which is reserved by the service to denote custom words added or modified by the user.
+        :param str customization_id: The customization ID (GUID) of the custom language
+        model. You must make the request with service credentials created for the instance
+        of the service that owns the custom model.
+        :param str corpus_name: The name of the corpus for the custom language model. When
+        adding a corpus, do not include spaces in the name; use a localized name that
+        matches the language of the custom model; and do not use the name `user`, which is
+        reserved by the service to denote custom words added or modified by the user.
         :param dict headers: A `dict` containing the request headers
         :rtype: None
         """
@@ -1038,15 +1203,20 @@ class SpeechToTextV1(WatsonService):
 
     def get_corpus(self, customization_id, corpus_name, **kwargs):
         """
-        List a corpus.
+        Get a corpus.
 
-        Lists information about a corpus from a custom language model. The information
+        Gets information about a corpus from a custom language model. The information
         includes the total number of words and out-of-vocabulary (OOV) words, name, and
         status of the corpus. You must use credentials for the instance of the service
         that owns a model to list its corpora.
 
-        :param str customization_id: The customization ID (GUID) of the custom language model. You must make the request with service credentials created for the instance of the service that owns the custom model.
-        :param str corpus_name: The name of the corpus for the custom language model. When adding a corpus, do not include spaces in the name; use a localized name that matches the language of the custom model; and do not use the name `user`, which is reserved by the service to denote custom words added or modified by the user.
+        :param str customization_id: The customization ID (GUID) of the custom language
+        model. You must make the request with service credentials created for the instance
+        of the service that owns the custom model.
+        :param str corpus_name: The name of the corpus for the custom language model. When
+        adding a corpus, do not include spaces in the name; use a localized name that
+        matches the language of the custom model; and do not use the name `user`, which is
+        reserved by the service to denote custom words added or modified by the user.
         :param dict headers: A `dict` containing the request headers
         :return: A `dict` containing the `Corpus` response.
         :rtype: dict
@@ -1073,7 +1243,9 @@ class SpeechToTextV1(WatsonService):
         status of each corpus. You must use credentials for the instance of the service
         that owns a model to list its corpora.
 
-        :param str customization_id: The customization ID (GUID) of the custom language model. You must make the request with service credentials created for the instance of the service that owns the custom model.
+        :param str customization_id: The customization ID (GUID) of the custom language
+        model. You must make the request with service credentials created for the instance
+        of the service that owns the custom model.
         :param dict headers: A `dict` containing the request headers
         :return: A `dict` containing the `Corpora` response.
         :rtype: dict
@@ -1096,6 +1268,7 @@ class SpeechToTextV1(WatsonService):
     def add_word(self,
                  customization_id,
                  word_name,
+                 word=None,
                  sounds_like=None,
                  display_as=None,
                  **kwargs):
@@ -1107,36 +1280,58 @@ class SpeechToTextV1(WatsonService):
         corpus added to the model. You can use this method to add a word or to modify an
         existing word in the words resource. The words resource for a model can contain a
         maximum of 30 thousand custom (OOV) words, including words that the service
-        extracts from corpora and words that you add directly.   You must use credentials
-        for the instance of the service that owns a model to add or modify a custom word
-        for the model. You must pass a value of `application/json` with the `Content-Type`
-        header. Adding or modifying a custom word does not affect the custom model until
-        you train the model for the new data by using the **Train a custom language
-        model** method.   Use the `word_name` parameter to specify the custom word that is
-        to be added or modified. Use the `CustomWord` object to provide one or both of the
-        optional `sounds_like` and `display_as` fields for the word. * The `sounds_like`
-        field provides an array of one or more pronunciations for the word. Use the
-        parameter to specify how the word can be pronounced by users. Use the parameter
-        for words that are difficult to pronounce, foreign words, acronyms, and so on. For
-        example, you might specify that the word `IEEE` can sound like `i triple e`. You
-        can specify a maximum of five sounds-like pronunciations for a word. For
-        information about pronunciation rules, see [Using the sounds_like
+        extracts from corpora and words that you add directly.
+        You must use credentials for the instance of the service that owns a model to add
+        or modify a custom word for the model. Adding or modifying a custom word does not
+        affect the custom model until you train the model for the new data by using the
+        **Train a custom language model** method.
+        Use the `word_name` parameter to specify the custom word that is to be added or
+        modified. Use the `CustomWord` object to provide one or both of the optional
+        `sounds_like` and `display_as` fields for the word.
+        * The `sounds_like` field provides an array of one or more pronunciations for the
+        word. Use the parameter to specify how the word can be pronounced by users. Use
+        the parameter for words that are difficult to pronounce, foreign words, acronyms,
+        and so on. For example, you might specify that the word `IEEE` can sound like `i
+        triple e`. You can specify a maximum of five sounds-like pronunciations for a
+        word. For information about pronunciation rules, see [Using the sounds_like
         field](https://console.bluemix.net/docs/services/speech-to-text/language-resource.html#soundsLike).
         * The `display_as` field provides a different way of spelling the word in a
         transcript. Use the parameter when you want the word to appear different from its
         usual representation or from its spelling in corpora training data. For example,
-        you might indicate that the word `IBM(trademark)` is to be displayed as `IBM`. For
-        more information, see [Using the display_as
+        you might indicate that the word `IBM(trademark)` is to be displayed as
+        `IBM&trade;`. For more information, see [Using the display_as
         field](https://console.bluemix.net/docs/services/speech-to-text/language-resource.html#displayAs).
-           If you add a custom word that already exists in the words resource for the
-        custom model, the new definition overwrites the existing data for the word. If the
+        If you add a custom word that already exists in the words resource for the custom
+        model, the new definition overwrites the existing data for the word. If the
         service encounters an error, it does not add the word to the words resource. Use
         the **List a custom word** method to review the word that you add.
 
-        :param str customization_id: The customization ID (GUID) of the custom language model. You must make the request with service credentials created for the instance of the service that owns the custom model.
-        :param str word_name: The custom word for the custom language model. When you add or update a custom word with the **Add a custom word** method, do not include spaces in the word. Use a `-` (dash) or `_` (underscore) to connect the tokens of compound words.
-        :param list[str] sounds_like: An array of sounds-like pronunciations for the custom word. Specify how words that are difficult to pronounce, foreign words, acronyms, and so on can be pronounced by users. For a word that is not in the service's base vocabulary, omit the parameter to have the service automatically generate a sounds-like pronunciation for the word. For a word that is in the service's base vocabulary, use the parameter to specify additional pronunciations for the word. You cannot override the default pronunciation of a word; pronunciations you add augment the pronunciation from the base vocabulary. A word can have at most five sounds-like pronunciations, and a pronunciation can include at most 40 characters not including spaces.
-        :param str display_as: An alternative spelling for the custom word when it appears in a transcript. Use the parameter when you want the word to have a spelling that is different from its usual representation or from its spelling in corpora training data.
+        :param str customization_id: The customization ID (GUID) of the custom language
+        model. You must make the request with service credentials created for the instance
+        of the service that owns the custom model.
+        :param str word_name: The custom word for the custom language model. When you add
+        or update a custom word with the **Add a custom word** method, do not include
+        spaces in the word. Use a `-` (dash) or `_` (underscore) to connect the tokens of
+        compound words.
+        :param str word: For the **Add custom words** method, you must specify the custom
+        word that is to be added to or updated in the custom model. Do not include spaces
+        in the word. Use a `-` (dash) or `_` (underscore) to connect the tokens of
+        compound words.
+        Omit this field for the **Add a custom word** method.
+        :param list[str] sounds_like: An array of sounds-like pronunciations for the
+        custom word. Specify how words that are difficult to pronounce, foreign words,
+        acronyms, and so on can be pronounced by users. For a word that is not in the
+        service's base vocabulary, omit the parameter to have the service automatically
+        generate a sounds-like pronunciation for the word. For a word that is in the
+        service's base vocabulary, use the parameter to specify additional pronunciations
+        for the word. You cannot override the default pronunciation of a word;
+        pronunciations you add augment the pronunciation from the base vocabulary. A word
+        can have at most five sounds-like pronunciations, and a pronunciation can include
+        at most 40 characters not including spaces.
+        :param str display_as: An alternative spelling for the custom word when it appears
+        in a transcript. Use the parameter when you want the word to have a spelling that
+        is different from its usual representation or from its spelling in corpora
+        training data.
         :param dict headers: A `dict` containing the request headers
         :rtype: None
         """
@@ -1148,7 +1343,7 @@ class SpeechToTextV1(WatsonService):
         if 'headers' in kwargs:
             headers.update(kwargs.get('headers'))
         data = {
-            'word': word_name,
+            'word': word,
             'sounds_like': sounds_like,
             'display_as': display_as
         }
@@ -1157,10 +1352,6 @@ class SpeechToTextV1(WatsonService):
         self.request(
             method='PUT', url=url, headers=headers, json=data, accept_json=True)
         return None
-
-    @deprecated('Use add_word instead.')
-    def add_custom_word(self, customization_id, custom_word):
-        return self.add_word(customization_id, custom_word)
 
     def add_words(self, customization_id, words, **kwargs):
         """
@@ -1171,49 +1362,52 @@ class SpeechToTextV1(WatsonService):
         each corpus added to the model. You can use this method to add additional words or
         to modify existing words in the words resource. The words resource for a model can
         contain a maximum of 30 thousand custom (OOV) words, including words that the
-        service extracts from corpora and words that you add directly.   You must use
-        credentials for the instance of the service that owns a model to add or modify
-        custom words for the model. You must pass a value of `application/json` with the
-        `Content-Type` header. Adding or modifying custom words does not affect the custom
-        model until you train the model for the new data by using the **Train a custom
-        language model** method.   You add custom words by providing a `Words` object,
-        which is an array of `Word` objects, one per word. You must use the object's word
-        parameter to identify the word that is to be added. You can also provide one or
-        both of the optional `sounds_like` and `display_as` fields for each word. * The
-        `sounds_like` field provides an array of one or more pronunciations for the word.
-        Use the parameter to specify how the word can be pronounced by users. Use the
-        parameter for words that are difficult to pronounce, foreign words, acronyms, and
-        so on. For example, you might specify that the word `IEEE` can sound like `i
+        service extracts from corpora and words that you add directly.
+        You must use credentials for the instance of the service that owns a model to add
+        or modify custom words for the model. Adding or modifying custom words does not
+        affect the custom model until you train the model for the new data by using the
+        **Train a custom language model** method.
+        You add custom words by providing a `Words` object, which is an array of `Word`
+        objects, one per word. You must use the object's word parameter to identify the
+        word that is to be added. You can also provide one or both of the optional
+        `sounds_like` and `display_as` fields for each word.
+        * The `sounds_like` field provides an array of one or more pronunciations for the
+        word. Use the parameter to specify how the word can be pronounced by users. Use
+        the parameter for words that are difficult to pronounce, foreign words, acronyms,
+        and so on. For example, you might specify that the word `IEEE` can sound like `i
         triple e`. You can specify a maximum of five sounds-like pronunciations for a
         word. For information about pronunciation rules, see [Using the sounds_like
         field](https://console.bluemix.net/docs/services/speech-to-text/language-resource.html#soundsLike).
         * The `display_as` field provides a different way of spelling the word in a
         transcript. Use the parameter when you want the word to appear different from its
         usual representation or from its spelling in corpora training data. For example,
-        you might indicate that the word `IBM(trademark)` is to be displayed as `IBM`. For
-        more information, see [Using the display_as
+        you might indicate that the word `IBM(trademark)` is to be displayed as
+        `IBM&trade;`. For more information, see [Using the display_as
         field](https://console.bluemix.net/docs/services/speech-to-text/language-resource.html#displayAs).
-           If you add a custom word that already exists in the words resource for the
-        custom model, the new definition overwrites the existing data for the word. If the
+        If you add a custom word that already exists in the words resource for the custom
+        model, the new definition overwrites the existing data for the word. If the
         service encounters an error with the input data, it returns a failure code and
-        does not add any of the words to the words resource.   The call returns an HTTP
-        201 response code if the input data is valid. It then asynchronously processes the
-        words to add them to the model's words resource. The time that it takes for the
-        analysis to complete depends on the number of new words that you add but is
-        generally faster than adding a corpus or training a model.   You can monitor the
-        status of the request by using the **List a custom language model** method to poll
-        the model's status. Use a loop to check the status every 10 seconds. The method
-        returns a `Customization` object that includes a `status` field. A status of
-        `ready` means that the words have been added to the custom model. The service
-        cannot accept requests to add new corpora or words or to train the model until the
-        existing request completes.   You can use the **List custom words** or **List a
-        custom word** method to review the words that you add. Words with an invalid
-        `sounds_like` field include an `error` field that describes the problem. You can
-        use other words-related methods to correct errors, eliminate typos, and modify how
-        words are pronounced as needed.
+        does not add any of the words to the words resource.
+        The call returns an HTTP 201 response code if the input data is valid. It then
+        asynchronously processes the words to add them to the model's words resource. The
+        time that it takes for the analysis to complete depends on the number of new words
+        that you add but is generally faster than adding a corpus or training a model.
+        You can monitor the status of the request by using the **List a custom language
+        model** method to poll the model's status. Use a loop to check the status every 10
+        seconds. The method returns a `Customization` object that includes a `status`
+        field. A status of `ready` means that the words have been added to the custom
+        model. The service cannot accept requests to add new corpora or words or to train
+        the model until the existing request completes.
+        You can use the **List custom words** or **List a custom word** method to review
+        the words that you add. Words with an invalid `sounds_like` field include an
+        `error` field that describes the problem. You can use other words-related methods
+        to correct errors, eliminate typos, and modify how words are pronounced as needed.
 
-        :param str customization_id: The customization ID (GUID) of the custom language model. You must make the request with service credentials created for the instance of the service that owns the custom model.
-        :param list[CustomWord] words: An array of objects that provides information about each custom word that is to be added to or updated in the custom language model.
+        :param str customization_id: The customization ID (GUID) of the custom language
+        model. You must make the request with service credentials created for the instance
+        of the service that owns the custom model.
+        :param list[CustomWord] words: An array of objects that provides information about
+        each custom word that is to be added to or updated in the custom language model.
         :param dict headers: A `dict` containing the request headers
         :rtype: None
         """
@@ -1236,10 +1430,6 @@ class SpeechToTextV1(WatsonService):
             accept_json=True)
         return None
 
-    @deprecated('Use add_words() instead.')
-    def add_custom_words(self, customization_id, custom_words):
-        return self.add_words(customization_id, custom_words)
-
     def delete_word(self, customization_id, word_name, **kwargs):
         """
         Delete a custom word.
@@ -1252,8 +1442,13 @@ class SpeechToTextV1(WatsonService):
         **Train a custom language model** method. You must use credentials for the
         instance of the service that owns a model to delete its words.
 
-        :param str customization_id: The customization ID (GUID) of the custom language model. You must make the request with service credentials created for the instance of the service that owns the custom model.
-        :param str word_name: The custom word for the custom language model. When you add or update a custom word with the **Add a custom word** method, do not include spaces in the word. Use a `-` (dash) or `_` (underscore) to connect the tokens of compound words.
+        :param str customization_id: The customization ID (GUID) of the custom language
+        model. You must make the request with service credentials created for the instance
+        of the service that owns the custom model.
+        :param str word_name: The custom word for the custom language model. When you add
+        or update a custom word with the **Add a custom word** method, do not include
+        spaces in the word. Use a `-` (dash) or `_` (underscore) to connect the tokens of
+        compound words.
         :param dict headers: A `dict` containing the request headers
         :rtype: None
         """
@@ -1270,20 +1465,21 @@ class SpeechToTextV1(WatsonService):
             method='DELETE', url=url, headers=headers, accept_json=True)
         return None
 
-    @deprecated('Use delete_word() instead.')
-    def delete_custom_word(self, customization_id, custom_word):
-        return self.delete_word(customization_id, custom_word)
-
     def get_word(self, customization_id, word_name, **kwargs):
         """
-        List a custom word.
+        Get a custom word.
 
-        Lists information about a custom word from a custom language model. You must use
+        Gets information about a custom word from a custom language model. You must use
         credentials for the instance of the service that owns a model to query information
         about its words.
 
-        :param str customization_id: The customization ID (GUID) of the custom language model. You must make the request with service credentials created for the instance of the service that owns the custom model.
-        :param str word_name: The custom word for the custom language model. When you add or update a custom word with the **Add a custom word** method, do not include spaces in the word. Use a `-` (dash) or `_` (underscore) to connect the tokens of compound words.
+        :param str customization_id: The customization ID (GUID) of the custom language
+        model. You must make the request with service credentials created for the instance
+        of the service that owns the custom model.
+        :param str word_name: The custom word for the custom language model. When you add
+        or update a custom word with the **Add a custom word** method, do not include
+        spaces in the word. Use a `-` (dash) or `_` (underscore) to connect the tokens of
+        compound words.
         :param dict headers: A `dict` containing the request headers
         :return: A `dict` containing the `Word` response.
         :rtype: dict
@@ -1301,10 +1497,6 @@ class SpeechToTextV1(WatsonService):
             method='GET', url=url, headers=headers, accept_json=True)
         return response
 
-    @deprecated('Use get_word() instead.')
-    def get_custom_word(self, customization_id, custom_word):
-        return self.get_word(customization_id, custom_word)
-
     def list_words(self, customization_id, word_type=None, sort=None, **kwargs):
         """
         List custom words.
@@ -1317,9 +1509,21 @@ class SpeechToTextV1(WatsonService):
         must use credentials for the instance of the service that owns a model to query
         information about its words.
 
-        :param str customization_id: The customization ID (GUID) of the custom language model. You must make the request with service credentials created for the instance of the service that owns the custom model.
-        :param str word_type: The type of words to be listed from the custom language model's words resource: * `all` (the default) shows all words. * `user` shows only custom words that were added or modified by the user. * `corpora` shows only OOV that were extracted from corpora.
-        :param str sort: Indicates the order in which the words are to be listed, `alphabetical` or by `count`. You can prepend an optional `+` or `-` to an argument to indicate whether the results are to be sorted in ascending or descending order. By default, words are sorted in ascending alphabetical order. For alphabetical ordering, the lexicographical precedence is numeric values, uppercase letters, and lowercase letters. For count ordering, values with the same count are ordered alphabetically. With cURL, URL encode the `+` symbol as `%2B`.
+        :param str customization_id: The customization ID (GUID) of the custom language
+        model. You must make the request with service credentials created for the instance
+        of the service that owns the custom model.
+        :param str word_type: The type of words to be listed from the custom language
+        model's words resource:
+        * `all` (the default) shows all words.
+        * `user` shows only custom words that were added or modified by the user.
+        * `corpora` shows only OOV that were extracted from corpora.
+        :param str sort: Indicates the order in which the words are to be listed,
+        `alphabetical` or by `count`. You can prepend an optional `+` or `-` to an
+        argument to indicate whether the results are to be sorted in ascending or
+        descending order. By default, words are sorted in ascending alphabetical order.
+        For alphabetical ordering, the lexicographical precedence is numeric values,
+        uppercase letters, and lowercase letters. For count ordering, values with the same
+        count are ordered alphabetically. With cURL, URL encode the `+` symbol as `%2B`.
         :param dict headers: A `dict` containing the request headers
         :return: A `dict` containing the `Words` response.
         :rtype: dict
@@ -1340,10 +1544,6 @@ class SpeechToTextV1(WatsonService):
             accept_json=True)
         return response
 
-    @deprecated('Use list_words() instead.')
-    def list_custom_words(self, customization_id, word_type=None, sort=None):
-        return self.list_words(customization_id, word_type, sort)
-
     #########################
     # Custom acoustic models
     #########################
@@ -1359,11 +1559,20 @@ class SpeechToTextV1(WatsonService):
         Creates a new custom acoustic model for a specified base model. The custom
         acoustic model can be used only with the base model for which it is created. The
         model is owned by the instance of the service whose credentials are used to create
-        it. You must pass a value of `application/json` with the `Content-Type` header.
+        it.
 
-        :param str name: A user-defined name for the new custom acoustic model. Use a name that is unique among all custom acoustic models that you own. Use a localized name that matches the language of the custom model. Use a name that describes the acoustic environment of the custom model, such as `Mobile custom model` or `Noisy car custom model`.
-        :param str base_model_name: The name of the base language model that is to be customized by the new custom acoustic model. The new custom model can be used only with the base model that it customizes. To determine whether a base model supports acoustic model customization, refer to [Language support for customization](https://console.bluemix.net/docs/services/speech-to-text/custom.html#languageSupport).
-        :param str description: A description of the new custom acoustic model. Use a localized description that matches the language of the custom model.
+        :param str name: A user-defined name for the new custom acoustic model. Use a name
+        that is unique among all custom acoustic models that you own. Use a localized name
+        that matches the language of the custom model. Use a name that describes the
+        acoustic environment of the custom model, such as `Mobile custom model` or `Noisy
+        car custom model`.
+        :param str base_model_name: The name of the base language model that is to be
+        customized by the new custom acoustic model. The new custom model can be used only
+        with the base model that it customizes. To determine whether a base model supports
+        acoustic model customization, refer to [Language support for
+        customization](https://console.bluemix.net/docs/services/speech-to-text/custom.html#languageSupport).
+        :param str description: A description of the new custom acoustic model. Use a
+        localized description that matches the language of the custom model.
         :param dict headers: A `dict` containing the request headers
         :return: A `dict` containing the `AcousticModel` response.
         :rtype: dict
@@ -1398,7 +1607,9 @@ class SpeechToTextV1(WatsonService):
         processed. You must use credentials for the instance of the service that owns a
         model to delete it.
 
-        :param str customization_id: The customization ID (GUID) of the custom acoustic model. You must make the request with service credentials created for the instance of the service that owns the custom model.
+        :param str customization_id: The customization ID (GUID) of the custom acoustic
+        model. You must make the request with service credentials created for the instance
+        of the service that owns the custom model.
         :param dict headers: A `dict` containing the request headers
         :rtype: None
         """
@@ -1415,13 +1626,14 @@ class SpeechToTextV1(WatsonService):
 
     def get_acoustic_model(self, customization_id, **kwargs):
         """
-        List a custom acoustic model.
+        Get a custom acoustic model.
 
-        Lists information about a specified custom acoustic model. You must use
-        credentials for the instance of the service that owns a model to list information
-        about it.
+        Gets information about a specified custom acoustic model. You must use credentials
+        for the instance of the service that owns a model to list information about it.
 
-        :param str customization_id: The customization ID (GUID) of the custom acoustic model. You must make the request with service credentials created for the instance of the service that owns the custom model.
+        :param str customization_id: The customization ID (GUID) of the custom acoustic
+        model. You must make the request with service credentials created for the instance
+        of the service that owns the custom model.
         :param dict headers: A `dict` containing the request headers
         :return: A `dict` containing the `AcousticModel` response.
         :rtype: dict
@@ -1447,7 +1659,10 @@ class SpeechToTextV1(WatsonService):
         all languages. You must use credentials for the instance of the service that owns
         a model to list information about it.
 
-        :param str language: The identifier of the language for which custom language or custom acoustic models are to be returned (for example, `en-US`). Omit the parameter to see all custom language or custom acoustic models owned by the requesting service credentials.
+        :param str language: The identifier of the language for which custom language or
+        custom acoustic models are to be returned (for example, `en-US`). Omit the
+        parameter to see all custom language or custom acoustic models owned by the
+        requesting service credentials.
         :param dict headers: A `dict` containing the request headers
         :return: A `dict` containing the `AcousticModels` response.
         :rtype: dict
@@ -1475,7 +1690,9 @@ class SpeechToTextV1(WatsonService):
         but the model's audio resources are removed and must be re-created. You must use
         credentials for the instance of the service that owns a model to reset it.
 
-        :param str customization_id: The customization ID (GUID) of the custom acoustic model. You must make the request with service credentials created for the instance of the service that owns the custom model.
+        :param str customization_id: The customization ID (GUID) of the custom acoustic
+        model. You must make the request with service credentials created for the instance
+        of the service that owns the custom model.
         :param dict headers: A `dict` containing the request headers
         :rtype: None
         """
@@ -1501,17 +1718,18 @@ class SpeechToTextV1(WatsonService):
         use this method to begin the actual training of the model on the latest audio
         data. The custom acoustic model does not reflect its changed data until you train
         it. You must use credentials for the instance of the service that owns a model to
-        train it.   The training method is asynchronous. It can take on the order of
-        minutes or hours to complete depending on the total amount of audio data on which
-        the custom acoustic model is being trained and the current load on the service.
-        Typically, training a custom acoustic model takes approximately two to four times
-        the length of its audio data. The range of time depends on the model being trained
-        and the nature of the audio, such as whether the audio is clean or noisy. The
-        method returns an HTTP 200 response code to indicate that the training process has
-        begun.   You can monitor the status of the training by using the **List a custom
-        acoustic model** method to poll the model's status. Use a loop to check the status
-        once a minute. The method returns an `Customization` object that includes `status`
-        and `progress` fields. A status of `available` indicates that the custom model is
+        train it.
+        The training method is asynchronous. It can take on the order of minutes or hours
+        to complete depending on the total amount of audio data on which the custom
+        acoustic model is being trained and the current load on the service. Typically,
+        training a custom acoustic model takes approximately two to four times the length
+        of its audio data. The range of time depends on the model being trained and the
+        nature of the audio, such as whether the audio is clean or noisy. The method
+        returns an HTTP 200 response code to indicate that the training process has begun.
+        You can monitor the status of the training by using the **List a custom acoustic
+        model** method to poll the model's status. Use a loop to check the status once a
+        minute. The method returns an `Customization` object that includes `status` and
+        `progress` fields. A status of `available` indicates that the custom model is
         trained and ready to use. The service cannot accept subsequent training requests,
         or requests to add new audio resources, until the existing request completes.
         You can use the optional `custom_language_model_id` parameter to specify the GUID
@@ -1522,14 +1740,21 @@ class SpeechToTextV1(WatsonService):
         For information about creating a separate custom language model, see [Creating a
         custom language
         model](https://console.bluemix.net/docs/services/speech-to-text/language-create.html).
-          Training can fail to start for the following reasons: * The service is currently
-        handling another request for the custom model, such as another training request or
-        a request to add audio resources to the model. * The custom model contains less
-        than 10 minutes or more than 50 hours of audio data. * One or more of the custom
-        model's audio resources is invalid.
+        Training can fail to start for the following reasons:
+        * The service is currently handling another request for the custom model, such as
+        another training request or a request to add audio resources to the model.
+        * The custom model contains less than 10 minutes or more than 50 hours of audio
+        data.
+        * One or more of the custom model's audio resources is invalid.
 
-        :param str customization_id: The customization ID (GUID) of the custom acoustic model. You must make the request with service credentials created for the instance of the service that owns the custom model.
-        :param str custom_language_model_id: The customization ID (GUID) of a custom language model that is to be used during training of the custom acoustic model. Specify a custom language model that has been trained with verbatim transcriptions of the audio resources or that contains words that are relevant to the contents of the audio resources.
+        :param str customization_id: The customization ID (GUID) of the custom acoustic
+        model. You must make the request with service credentials created for the instance
+        of the service that owns the custom model.
+        :param str custom_language_model_id: The customization ID (GUID) of a custom
+        language model that is to be used during training of the custom acoustic model.
+        Specify a custom language model that has been trained with verbatim transcriptions
+        of the audio resources or that contains words that are relevant to the contents of
+        the audio resources.
         :param dict headers: A `dict` containing the request headers
         :rtype: None
         """
@@ -1562,23 +1787,29 @@ class SpeechToTextV1(WatsonService):
         and the current load on the service; typically, upgrade takes approximately twice
         the length of the total audio contained in the custom model. A custom model must
         be in the `ready` or `available` state to be upgraded. You must use credentials
-        for the instance of the service that owns a model to upgrade it.   The method
-        returns an HTTP 200 response code to indicate that the upgrade process has begun
-        successfully. You can monitor the status of the upgrade by using the **List a
-        custom acoustic model** method to poll the model's status. Use a loop to check the
-        status once a minute. While it is being upgraded, the custom model has the status
-        `upgrading`. When the upgrade is complete, the model resumes the status that it
-        had prior to upgrade. The service cannot accept subsequent requests for the model
-        until the upgrade completes.   If the custom acoustic model was trained with a
-        separately created custom language model, you must use the
-        `custom_language_model_id` parameter to specify the GUID of that custom language
-        model. The custom language model must be upgraded before the custom acoustic model
-        can be upgraded. Omit the parameter if the custom acoustic model was not trained
-        with a custom language model.   For more information, see [Upgrading custom
+        for the instance of the service that owns a model to upgrade it.
+        The method returns an HTTP 200 response code to indicate that the upgrade process
+        has begun successfully. You can monitor the status of the upgrade by using the
+        **List a custom acoustic model** method to poll the model's status. Use a loop to
+        check the status once a minute. While it is being upgraded, the custom model has
+        the status `upgrading`. When the upgrade is complete, the model resumes the status
+        that it had prior to upgrade. The service cannot accept subsequent requests for
+        the model until the upgrade completes.
+        If the custom acoustic model was trained with a separately created custom language
+        model, you must use the `custom_language_model_id` parameter to specify the GUID
+        of that custom language model. The custom language model must be upgraded before
+        the custom acoustic model can be upgraded. Omit the parameter if the custom
+        acoustic model was not trained with a custom language model.
+        For more information, see [Upgrading custom
         models](https://console.bluemix.net/docs/services/speech-to-text/custom-upgrade.html).
 
-        :param str customization_id: The customization ID (GUID) of the custom acoustic model. You must make the request with service credentials created for the instance of the service that owns the custom model.
-        :param str custom_language_model_id: If the custom acoustic model was trained with a custom language model, the customization ID (GUID) of that custom language model. The custom language model must be upgraded before the custom acoustic model can be upgraded.
+        :param str customization_id: The customization ID (GUID) of the custom acoustic
+        model. You must make the request with service credentials created for the instance
+        of the service that owns the custom model.
+        :param str custom_language_model_id: If the custom acoustic model was trained with
+        a custom language model, the customization ID (GUID) of that custom language
+        model. The custom language model must be upgraded before the custom acoustic model
+        can be upgraded.
         :param dict headers: A `dict` containing the request headers
         :rtype: None
         """
@@ -1618,69 +1849,96 @@ class SpeechToTextV1(WatsonService):
         use credentials for the instance of the service that owns a model to add an audio
         resource to it. Adding audio data does not affect the custom acoustic model until
         you train the model for the new data by using the **Train a custom acoustic
-        model** method.   You can add individual audio files or an archive file that
-        contains multiple audio files. Adding multiple audio files via a single archive
-        file is significantly more efficient than adding each file individually. You can
-        add audio resources in any format that the service supports for speech
-        recognition.   You can use this method to add any number of audio resources to a
-        custom model by calling the method once for each audio or archive file. But the
-        addition of one audio resource must be fully complete before you can add another.
-        You must add a minimum of 10 minutes and a maximum of 50 hours of audio that
-        includes speech, not just silence, to a custom acoustic model before you can train
-        it. No audio resource, audio- or archive-type, can be larger than 100 MB. To add
-        an audio resource that has the same name as an existing audio resource, set the
-        `allow_overwrite` parameter to `true`; otherwise, the request fails.   The method
-        is asynchronous. It can take several seconds to complete depending on the duration
-        of the audio and, in the case of an archive file, the total number of audio files
-        being processed. The service returns a 201 response code if the audio is valid. It
-        then asynchronously analyzes the contents of the audio file or files and
-        automatically extracts information about the audio such as its length, sampling
-        rate, and encoding. You cannot submit requests to add additional audio resources
-        to a custom acoustic model, or to train the model, until the service's analysis of
-        all audio files for the current request completes.   To determine the status of
-        the service's analysis of the audio, use the **List an audio resource** method to
-        poll the status of the audio. The method accepts the GUID of the custom model and
-        the name of the audio resource, and it returns the status of the resource. Use a
-        loop to check the status of the audio every few seconds until it becomes `ok`.
-        ### Content types for audio-type resources   You can add an individual audio file
-        in any format that the service supports for speech recognition. For an audio-type
-        resource, use the `Content-Type` parameter to specify the audio format (MIME type)
-        of the audio file: * `audio/basic` (Use only with narrowband models.) *
-        `audio/flac` * `audio/l16` (Specify the sampling rate (`rate`) and optionally the
-        number of channels (`channels`) and endianness (`endianness`) of the audio.) *
-        `audio/mp3` * `audio/mpeg` * `audio/mulaw` (Specify the sampling rate (`rate`) of
-        the audio.) * `audio/ogg` (The service automatically detects the codec of the
-        input audio.) * `audio/ogg;codecs=opus` * `audio/ogg;codecs=vorbis` * `audio/wav`
-        (Provide audio with a maximum of nine channels.) * `audio/webm` (The service
-        automatically detects the codec of the input audio.) * `audio/webm;codecs=opus` *
-        `audio/webm;codecs=vorbis`   For information about the supported audio formats,
-        including specifying the sampling rate, channels, and endianness for the indicated
-        formats, see [Audio
+        model** method.
+        You can add individual audio files or an archive file that contains multiple audio
+        files. Adding multiple audio files via a single archive file is significantly more
+        efficient than adding each file individually. You can add audio resources in any
+        format that the service supports for speech recognition.
+        You can use this method to add any number of audio resources to a custom model by
+        calling the method once for each audio or archive file. But the addition of one
+        audio resource must be fully complete before you can add another. You must add a
+        minimum of 10 minutes and a maximum of 50 hours of audio that includes speech, not
+        just silence, to a custom acoustic model before you can train it. No audio
+        resource, audio- or archive-type, can be larger than 100 MB. To add an audio
+        resource that has the same name as an existing audio resource, set the
+        `allow_overwrite` parameter to `true`; otherwise, the request fails.
+        The method is asynchronous. It can take several seconds to complete depending on
+        the duration of the audio and, in the case of an archive file, the total number of
+        audio files being processed. The service returns a 201 response code if the audio
+        is valid. It then asynchronously analyzes the contents of the audio file or files
+        and automatically extracts information about the audio such as its length,
+        sampling rate, and encoding. You cannot submit requests to add additional audio
+        resources to a custom acoustic model, or to train the model, until the service's
+        analysis of all audio files for the current request completes.
+        To determine the status of the service's analysis of the audio, use the **List an
+        audio resource** method to poll the status of the audio. The method accepts the
+        GUID of the custom model and the name of the audio resource, and it returns the
+        status of the resource. Use a loop to check the status of the audio every few
+        seconds until it becomes `ok`.
+        ### Content types for audio-type resources
+         You can add an individual audio file in any format that the service supports for
+        speech recognition. For an audio-type resource, use the `Content-Type` parameter
+        to specify the audio format (MIME type) of the audio file:
+        * `audio/basic` (Use only with narrowband models.)
+        * `audio/flac`
+        * `audio/l16` (Specify the sampling rate (`rate`) and optionally the number of
+        channels (`channels`) and endianness (`endianness`) of the audio.)
+        * `audio/mp3`
+        * `audio/mpeg`
+        * `audio/mulaw` (Specify the sampling rate (`rate`) of the audio.)
+        * `audio/ogg` (The service automatically detects the codec of the input audio.)
+        * `audio/ogg;codecs=opus`
+        * `audio/ogg;codecs=vorbis`
+        * `audio/wav` (Provide audio with a maximum of nine channels.)
+        * `audio/webm` (The service automatically detects the codec of the input audio.)
+        * `audio/webm;codecs=opus`
+        * `audio/webm;codecs=vorbis`
+        For information about the supported audio formats, including specifying the
+        sampling rate, channels, and endianness for the indicated formats, see [Audio
         formats](https://console.bluemix.net/docs/services/speech-to-text/audio-formats.html).
-          **Note:** The sampling rate of an audio file must match the sampling rate of the
+        **Note:** The sampling rate of an audio file must match the sampling rate of the
         base model for the custom model: for broadband models, at least 16 kHz; for
         narrowband models, at least 8 kHz. If the sampling rate of the audio is higher
         than the minimum required rate, the service down-samples the audio to the
         appropriate rate. If the sampling rate of the audio is lower than the minimum
-        required rate, the service labels the audio file as `invalid`.   ### Content types
-        for archive-type resources   You can add an archive file (**.zip** or **.tar.gz**
-        file) that contains audio files in any format that the service supports for speech
-        recognition. For an archive-type resource, use the `Content-Type` parameter to
-        specify the media type of the archive file: * `application/zip` for a **.zip**
-        file * `application/gzip` for a **.tar.gz** file.   All audio files contained in
-        the archive must have the same audio format. Use the `Contained-Content-Type`
-        parameter to specify the format of the contained audio files. The parameter
-        accepts all of the audio formats supported for use with speech recognition and
-        with the `Content-Type` header, including the `rate`, `channels`, and `endianness`
-        parameters that are used with some formats. The default contained audio format is
-        `audio/wav`.
+        required rate, the service labels the audio file as `invalid`.
+        ### Content types for archive-type resources
+         You can add an archive file (**.zip** or **.tar.gz** file) that contains audio
+        files in any format that the service supports for speech recognition. For an
+        archive-type resource, use the `Content-Type` parameter to specify the media type
+        of the archive file:
+        * `application/zip` for a **.zip** file
+        * `application/gzip` for a **.tar.gz** file.
+        All audio files contained in the archive must have the same audio format. Use the
+        `Contained-Content-Type` parameter to specify the format of the contained audio
+        files. The parameter accepts all of the audio formats supported for use with
+        speech recognition and with the `Content-Type` header, including the `rate`,
+        `channels`, and `endianness` parameters that are used with some formats. The
+        default contained audio format is `audio/wav`.
 
-        :param str customization_id: The customization ID (GUID) of the custom acoustic model. You must make the request with service credentials created for the instance of the service that owns the custom model.
-        :param str audio_name: The name of the audio resource for the custom acoustic model. When adding an audio resource, do not include spaces in the name; use a localized name that matches the language of the custom model.
-        :param list[str] audio_resource: The audio resource that is to be added to the custom acoustic model, an individual audio file or an archive file.
-        :param str content_type: The type of the input: application/zip, application/gzip, audio/basic, audio/flac, audio/l16, audio/mp3, audio/mpeg, audio/mulaw, audio/ogg, audio/ogg;codecs=opus, audio/ogg;codecs=vorbis, audio/wav, audio/webm, audio/webm;codecs=opus, or audio/webm;codecs=vorbis.
-        :param str contained_content_type: For an archive-type resource, specifies the format of the audio files contained in the archive file. The parameter accepts all of the audio formats supported for use with speech recognition, including the `rate`, `channels`, and `endianness` parameters that are used with some formats. For a complete list of supported audio formats, see [Audio formats](/docs/services/speech-to-text/input.html#formats).
-        :param bool allow_overwrite: If `true`, the specified corpus or audio resource overwrites an existing corpus or audio resource with the same name. If `false` (the default), the request fails if a corpus or audio resource with the same name already exists. The parameter has no effect if a corpus or audio resource with the same name does not already exist.
+        :param str customization_id: The customization ID (GUID) of the custom acoustic
+        model. You must make the request with service credentials created for the instance
+        of the service that owns the custom model.
+        :param str audio_name: The name of the audio resource for the custom acoustic
+        model. When adding an audio resource, do not include spaces in the name; use a
+        localized name that matches the language of the custom model.
+        :param list[str] audio_resource: The audio resource that is to be added to the
+        custom acoustic model, an individual audio file or an archive file.
+        :param str content_type: The type of the input: application/zip, application/gzip,
+        audio/basic, audio/flac, audio/l16, audio/mp3, audio/mpeg, audio/mulaw, audio/ogg,
+        audio/ogg;codecs=opus, audio/ogg;codecs=vorbis, audio/wav, audio/webm,
+        audio/webm;codecs=opus, or audio/webm;codecs=vorbis.
+        :param str contained_content_type: For an archive-type resource, specifies the
+        format of the audio files contained in the archive file. The parameter accepts all
+        of the audio formats supported for use with speech recognition, including the
+        `rate`, `channels`, and `endianness` parameters that are used with some formats.
+        For a complete list of supported audio formats, see [Audio
+        formats](/docs/services/speech-to-text/input.html#formats).
+        :param bool allow_overwrite: If `true`, the specified corpus or audio resource
+        overwrites an existing corpus or audio resource with the same name. If `false`
+        (the default), the request fails if a corpus or audio resource with the same name
+        already exists. The parameter has no effect if a corpus or audio resource with the
+        same name does not already exist.
         :param dict headers: A `dict` containing the request headers
         :rtype: None
         """
@@ -1723,8 +1981,12 @@ class SpeechToTextV1(WatsonService):
         You must use credentials for the instance of the service that owns a model to
         delete its audio resources.
 
-        :param str customization_id: The customization ID (GUID) of the custom acoustic model. You must make the request with service credentials created for the instance of the service that owns the custom model.
-        :param str audio_name: The name of the audio resource for the custom acoustic model. When adding an audio resource, do not include spaces in the name; use a localized name that matches the language of the custom model.
+        :param str customization_id: The customization ID (GUID) of the custom acoustic
+        model. You must make the request with service credentials created for the instance
+        of the service that owns the custom model.
+        :param str audio_name: The name of the audio resource for the custom acoustic
+        model. When adding an audio resource, do not include spaces in the name; use a
+        localized name that matches the language of the custom model.
         :param dict headers: A `dict` containing the request headers
         :rtype: None
         """
@@ -1743,24 +2005,28 @@ class SpeechToTextV1(WatsonService):
 
     def get_audio(self, customization_id, audio_name, **kwargs):
         """
-        List an audio resource.
+        Get an audio resource.
 
-        Lists information about an audio resource from a custom acoustic model. The method
+        gets information about an audio resource from a custom acoustic model. The method
         returns an `AudioListing` object whose fields depend on the type of audio resource
-        you specify with the method's `audio_name` parameter: * **For an audio-type
-        resource,** the object's fields match those of an `AudioResource` object:
-        `duration`, `name`, `details`, and `status`. * **For an archive-type resource,**
-        the object includes a `container` field whose fields match those of an
-        `AudioResource` object. It also includes an `audio` field, which contains an array
-        of `AudioResource` objects that provides information about the audio files that
-        are contained in the archive.   The information includes the status of the
-        specified audio resource, which is important for checking the service's analysis
-        of the resource in response to a request to add it to the custom model. You must
-        use credentials for the instance of the service that owns a model to list its
-        audio resources.
+        you specify with the method's `audio_name` parameter:
+        * **For an audio-type resource,** the object's fields match those of an
+        `AudioResource` object: `duration`, `name`, `details`, and `status`.
+        * **For an archive-type resource,** the object includes a `container` field whose
+        fields match those of an `AudioResource` object. It also includes an `audio`
+        field, which contains an array of `AudioResource` objects that provides
+        information about the audio files that are contained in the archive.
+        The information includes the status of the specified audio resource, which is
+        important for checking the service's analysis of the resource in response to a
+        request to add it to the custom model. You must use credentials for the instance
+        of the service that owns a model to list its audio resources.
 
-        :param str customization_id: The customization ID (GUID) of the custom acoustic model. You must make the request with service credentials created for the instance of the service that owns the custom model.
-        :param str audio_name: The name of the audio resource for the custom acoustic model. When adding an audio resource, do not include spaces in the name; use a localized name that matches the language of the custom model.
+        :param str customization_id: The customization ID (GUID) of the custom acoustic
+        model. You must make the request with service credentials created for the instance
+        of the service that owns the custom model.
+        :param str audio_name: The name of the audio resource for the custom acoustic
+        model. When adding an audio resource, do not include spaces in the name; use a
+        localized name that matches the language of the custom model.
         :param dict headers: A `dict` containing the request headers
         :return: A `dict` containing the `AudioListing` response.
         :rtype: dict
@@ -1789,7 +2055,9 @@ class SpeechToTextV1(WatsonService):
         to a request to add it to the custom acoustic model. You must use credentials for
         the instance of the service that owns a model to list its audio resources.
 
-        :param str customization_id: The customization ID (GUID) of the custom acoustic model. You must make the request with service credentials created for the instance of the service that owns the custom model.
+        :param str customization_id: The customization ID (GUID) of the custom acoustic
+        model. You must make the request with service credentials created for the instance
+        of the service that owns the custom model.
         :param dict headers: A `dict` containing the request headers
         :return: A `dict` containing the `AudioResources` response.
         :rtype: dict
@@ -1817,10 +2085,10 @@ class SpeechToTextV1(WatsonService):
         deletes all data for the customer ID, regardless of the method by which the
         information was added. The method has no effect if no data is associated with the
         customer ID. You must issue the request with credentials for the same instance of
-        the service that was used to associate the customer ID with the data.   You
-        associate a customer ID with data by passing the `X-Watson-Metadata` header with a
-        request that passes the data. For more information about customer IDs and about
-        using this method, see [Information
+        the service that was used to associate the customer ID with the data.
+        You associate a customer ID with data by passing the `X-Watson-Metadata` header
+        with a request that passes the data. For more information about customer IDs and
+        about using this method, see [Information
         security](https://console.bluemix.net/docs/services/speech-to-text/information-security.html).
 
         :param str customer_id: The customer ID for which all data is to be deleted.
@@ -1852,17 +2120,39 @@ class AcousticModel(object):
     """
     AcousticModel.
 
-    :attr str customization_id: The customization ID (GUID) of the custom acoustic model. The **Create a custom acoustic model** method returns only this field of the object; it does not return the other fields.
-    :attr str created: (optional) The date and time in Coordinated Universal Time (UTC) at which the custom acoustic model was created. The value is provided in full ISO 8601 format (`YYYY-MM-DDThh:mm:ss.sTZD`).
-    :attr str language: (optional) The language identifier of the custom acoustic model (for example, `en-US`).
-    :attr list[str] versions: (optional) A list of the available versions of the custom acoustic model. Each element of the array indicates a version of the base model with which the custom model can be used. Multiple versions exist only if the custom model has been upgraded; otherwise, only a single version is shown.
-    :attr str owner: (optional) The GUID of the service credentials for the instance of the service that owns the custom acoustic model.
+    :attr str customization_id: The customization ID (GUID) of the custom acoustic model.
+    The **Create a custom acoustic model** method returns only this field of the object;
+    it does not return the other fields.
+    :attr str created: (optional) The date and time in Coordinated Universal Time (UTC) at
+    which the custom acoustic model was created. The value is provided in full ISO 8601
+    format (`YYYY-MM-DDThh:mm:ss.sTZD`).
+    :attr str language: (optional) The language identifier of the custom acoustic model
+    (for example, `en-US`).
+    :attr list[str] versions: (optional) A list of the available versions of the custom
+    acoustic model. Each element of the array indicates a version of the base model with
+    which the custom model can be used. Multiple versions exist only if the custom model
+    has been upgraded; otherwise, only a single version is shown.
+    :attr str owner: (optional) The GUID of the service credentials for the instance of
+    the service that owns the custom acoustic model.
     :attr str name: (optional) The name of the custom acoustic model.
     :attr str description: (optional) The description of the custom acoustic model.
-    :attr str base_model_name: (optional) The name of the language model for which the custom acoustic model was created.
-    :attr str status: (optional) The current status of the custom acoustic model: * `pending` indicates that the model was created but is waiting either for training data to be added or for the service to finish analyzing added data. * `ready` indicates that the model contains data and is ready to be trained. * `training` indicates that the model is currently being trained. * `available` indicates that the model is trained and ready to use. * `upgrading` indicates that the model is currently being upgraded. * `failed` indicates that training of the model failed.
-    :attr int progress: (optional) A percentage that indicates the progress of the custom acoustic model's current training. A value of `100` means that the model is fully trained. **Note:** The `progress` field does not currently reflect the progress of the training. The field changes from `0` to `100` when training is complete.
-    :attr str warnings: (optional) If the request included unknown parameters, the following message: `Unexpected query parameter(s) ['parameters'] detected`, where `parameters` is a list that includes a quoted string for each unknown parameter.
+    :attr str base_model_name: (optional) The name of the language model for which the
+    custom acoustic model was created.
+    :attr str status: (optional) The current status of the custom acoustic model:
+    * `pending` indicates that the model was created but is waiting either for training
+    data to be added or for the service to finish analyzing added data.
+    * `ready` indicates that the model contains data and is ready to be trained.
+    * `training` indicates that the model is currently being trained.
+    * `available` indicates that the model is trained and ready to use.
+    * `upgrading` indicates that the model is currently being upgraded.
+    * `failed` indicates that training of the model failed.
+    :attr int progress: (optional) A percentage that indicates the progress of the custom
+    acoustic model's current training. A value of `100` means that the model is fully
+    trained. **Note:** The `progress` field does not currently reflect the progress of the
+    training. The field changes from `0` to `100` when training is complete.
+    :attr str warnings: (optional) If the request included unknown parameters, the
+    following message: `Unexpected query parameter(s) ['parameters'] detected`, where
+    `parameters` is a list that includes a quoted string for each unknown parameter.
     """
 
     def __init__(self,
@@ -1880,17 +2170,40 @@ class AcousticModel(object):
         """
         Initialize a AcousticModel object.
 
-        :param str customization_id: The customization ID (GUID) of the custom acoustic model. The **Create a custom acoustic model** method returns only this field of the object; it does not return the other fields.
-        :param str created: (optional) The date and time in Coordinated Universal Time (UTC) at which the custom acoustic model was created. The value is provided in full ISO 8601 format (`YYYY-MM-DDThh:mm:ss.sTZD`).
-        :param str language: (optional) The language identifier of the custom acoustic model (for example, `en-US`).
-        :param list[str] versions: (optional) A list of the available versions of the custom acoustic model. Each element of the array indicates a version of the base model with which the custom model can be used. Multiple versions exist only if the custom model has been upgraded; otherwise, only a single version is shown.
-        :param str owner: (optional) The GUID of the service credentials for the instance of the service that owns the custom acoustic model.
+        :param str customization_id: The customization ID (GUID) of the custom acoustic
+        model. The **Create a custom acoustic model** method returns only this field of
+        the object; it does not return the other fields.
+        :param str created: (optional) The date and time in Coordinated Universal Time
+        (UTC) at which the custom acoustic model was created. The value is provided in
+        full ISO 8601 format (`YYYY-MM-DDThh:mm:ss.sTZD`).
+        :param str language: (optional) The language identifier of the custom acoustic
+        model (for example, `en-US`).
+        :param list[str] versions: (optional) A list of the available versions of the
+        custom acoustic model. Each element of the array indicates a version of the base
+        model with which the custom model can be used. Multiple versions exist only if the
+        custom model has been upgraded; otherwise, only a single version is shown.
+        :param str owner: (optional) The GUID of the service credentials for the instance
+        of the service that owns the custom acoustic model.
         :param str name: (optional) The name of the custom acoustic model.
         :param str description: (optional) The description of the custom acoustic model.
-        :param str base_model_name: (optional) The name of the language model for which the custom acoustic model was created.
-        :param str status: (optional) The current status of the custom acoustic model: * `pending` indicates that the model was created but is waiting either for training data to be added or for the service to finish analyzing added data. * `ready` indicates that the model contains data and is ready to be trained. * `training` indicates that the model is currently being trained. * `available` indicates that the model is trained and ready to use. * `upgrading` indicates that the model is currently being upgraded. * `failed` indicates that training of the model failed.
-        :param int progress: (optional) A percentage that indicates the progress of the custom acoustic model's current training. A value of `100` means that the model is fully trained. **Note:** The `progress` field does not currently reflect the progress of the training. The field changes from `0` to `100` when training is complete.
-        :param str warnings: (optional) If the request included unknown parameters, the following message: `Unexpected query parameter(s) ['parameters'] detected`, where `parameters` is a list that includes a quoted string for each unknown parameter.
+        :param str base_model_name: (optional) The name of the language model for which
+        the custom acoustic model was created.
+        :param str status: (optional) The current status of the custom acoustic model:
+        * `pending` indicates that the model was created but is waiting either for
+        training data to be added or for the service to finish analyzing added data.
+        * `ready` indicates that the model contains data and is ready to be trained.
+        * `training` indicates that the model is currently being trained.
+        * `available` indicates that the model is trained and ready to use.
+        * `upgrading` indicates that the model is currently being upgraded.
+        * `failed` indicates that training of the model failed.
+        :param int progress: (optional) A percentage that indicates the progress of the
+        custom acoustic model's current training. A value of `100` means that the model is
+        fully trained. **Note:** The `progress` field does not currently reflect the
+        progress of the training. The field changes from `0` to `100` when training is
+        complete.
+        :param str warnings: (optional) If the request included unknown parameters, the
+        following message: `Unexpected query parameter(s) ['parameters'] detected`, where
+        `parameters` is a list that includes a quoted string for each unknown parameter.
         """
         self.customization_id = customization_id
         self.created = created
@@ -1984,14 +2297,20 @@ class AcousticModels(object):
     """
     AcousticModels.
 
-    :attr list[AcousticModel] customizations: An array of objects that provides information about each available custom acoustic model. The array is empty if the requesting service credentials own no custom acoustic models (if no language is specified) or own no custom acoustic models for the specified language.
+    :attr list[AcousticModel] customizations: An array of objects that provides
+    information about each available custom acoustic model. The array is empty if the
+    requesting service credentials own no custom acoustic models (if no language is
+    specified) or own no custom acoustic models for the specified language.
     """
 
     def __init__(self, customizations):
         """
         Initialize a AcousticModels object.
 
-        :param list[AcousticModel] customizations: An array of objects that provides information about each available custom acoustic model. The array is empty if the requesting service credentials own no custom acoustic models (if no language is specified) or own no custom acoustic models for the specified language.
+        :param list[AcousticModel] customizations: An array of objects that provides
+        information about each available custom acoustic model. The array is empty if the
+        requesting service credentials own no custom acoustic models (if no language is
+        specified) or own no custom acoustic models for the specified language.
         """
         self.customizations = customizations
 
@@ -2038,20 +2357,42 @@ class AudioDetails(object):
     """
     AudioDetails.
 
-    :attr str type: (optional) The type of the audio resource: * `audio` for an individual audio file * `archive` for an archive (**.zip** or **.tar.gz**) file that contains audio files.
-    :attr str codec: (optional) **For an audio-type resource,** the codec in which the audio is encoded. Omitted for an archive-type resource.
-    :attr int frequency: (optional) **For an audio-type resource,** the sampling rate of the audio in Hertz (samples per second). Omitted for an archive-type resource.
-    :attr str compression: (optional) **For an archive-type resource,** the format of the compressed archive: * `zip` for a **.zip** file * `gzip` for a **.tar.gz** file   Omitted for an audio-type resource.
+    :attr str type: (optional) The type of the audio resource:
+    * `audio` for an individual audio file
+    * `archive` for an archive (**.zip** or **.tar.gz**) file that contains audio files
+    * `undetermined` for a resource that the service cannot validate (for example, if the
+    user mistakenly passes a file that does not contain audio, such as a JPEG file).
+    :attr str codec: (optional) **For an audio-type resource,** the codec in which the
+    audio is encoded. Omitted for an archive-type resource.
+    :attr int frequency: (optional) **For an audio-type resource,** the sampling rate of
+    the audio in Hertz (samples per second). Omitted for an archive-type resource.
+    :attr str compression: (optional) **For an archive-type resource,** the format of the
+    compressed archive:
+    * `zip` for a **.zip** file
+    * `gzip` for a **.tar.gz** file
+    Omitted for an audio-type resource.
     """
 
     def __init__(self, type=None, codec=None, frequency=None, compression=None):
         """
         Initialize a AudioDetails object.
 
-        :param str type: (optional) The type of the audio resource: * `audio` for an individual audio file * `archive` for an archive (**.zip** or **.tar.gz**) file that contains audio files.
-        :param str codec: (optional) **For an audio-type resource,** the codec in which the audio is encoded. Omitted for an archive-type resource.
-        :param int frequency: (optional) **For an audio-type resource,** the sampling rate of the audio in Hertz (samples per second). Omitted for an archive-type resource.
-        :param str compression: (optional) **For an archive-type resource,** the format of the compressed archive: * `zip` for a **.zip** file * `gzip` for a **.tar.gz** file   Omitted for an audio-type resource.
+        :param str type: (optional) The type of the audio resource:
+        * `audio` for an individual audio file
+        * `archive` for an archive (**.zip** or **.tar.gz**) file that contains audio
+        files
+        * `undetermined` for a resource that the service cannot validate (for example, if
+        the user mistakenly passes a file that does not contain audio, such as a JPEG
+        file).
+        :param str codec: (optional) **For an audio-type resource,** the codec in which
+        the audio is encoded. Omitted for an archive-type resource.
+        :param int frequency: (optional) **For an audio-type resource,** the sampling rate
+        of the audio in Hertz (samples per second). Omitted for an archive-type resource.
+        :param str compression: (optional) **For an archive-type resource,** the format of
+        the compressed archive:
+        * `zip` for a **.zip** file
+        * `gzip` for a **.tar.gz** file
+        Omitted for an audio-type resource.
         """
         self.type = type
         self.codec = codec
@@ -2104,12 +2445,32 @@ class AudioListing(object):
     """
     AudioListing.
 
-    :attr float duration: (optional) **For an audio-type resource,**  the total seconds of audio in the resource. Omitted for an archive-type resource.
-    :attr str name: (optional) **For an audio-type resource,** the name of the resource. Omitted for an archive-type resource.
-    :attr AudioDetails details: (optional) **For an audio-type resource,** an `AudioDetails` object that provides detailed information about the resource. The object is empty until the service finishes processing the audio. Omitted for an archive-type resource.
-    :attr str status: (optional) **For an audio-type resource,** the status of the resource: * `ok` indicates that the service has successfully analyzed the audio data. The data can be used to train the custom model. * `being_processed` indicates that the service is still analyzing the audio data. The service cannot accept requests to add new audio resources or to train the custom model until its analysis is complete. * `invalid` indicates that the audio data is not valid for training the custom model (possibly because it has the wrong format or sampling rate, or because it is corrupted).   Omitted for an archive-type resource.
-    :attr AudioResource container: (optional) **For an archive-type resource,** an object of type `AudioResource` that provides information about the resource. Omitted for an audio-type resource.
-    :attr list[AudioResource] audio: (optional) **For an archive-type resource,** an array of `AudioResource` objects that provides information about the audio-type resources that are contained in the resource. Omitted for an audio-type resource.
+    :attr float duration: (optional) **For an audio-type resource,**  the total seconds of
+    audio in the resource. The value is always a whole number. Omitted for an archive-type
+    resource.
+    :attr str name: (optional) **For an audio-type resource,** the user-specified name of
+    the resource. Omitted for an archive-type resource.
+    :attr AudioDetails details: (optional) **For an audio-type resource,** an
+    `AudioDetails` object that provides detailed information about the resource. The
+    object is empty until the service finishes processing the audio. Omitted for an
+    archive-type resource.
+    :attr str status: (optional) **For an audio-type resource,** the status of the
+    resource:
+    * `ok` indicates that the service has successfully analyzed the audio data. The data
+    can be used to train the custom model.
+    * `being_processed` indicates that the service is still analyzing the audio data. The
+    service cannot accept requests to add new audio resources or to train the custom model
+    until its analysis is complete.
+    * `invalid` indicates that the audio data is not valid for training the custom model
+    (possibly because it has the wrong format or sampling rate, or because it is
+    corrupted).
+    Omitted for an archive-type resource.
+    :attr AudioResource container: (optional) **For an archive-type resource,** an object
+    of type `AudioResource` that provides information about the resource. Omitted for an
+    audio-type resource.
+    :attr list[AudioResource] audio: (optional) **For an archive-type resource,** an array
+    of `AudioResource` objects that provides information about the audio-type resources
+    that are contained in the resource. Omitted for an audio-type resource.
     """
 
     def __init__(self,
@@ -2122,12 +2483,32 @@ class AudioListing(object):
         """
         Initialize a AudioListing object.
 
-        :param float duration: (optional) **For an audio-type resource,**  the total seconds of audio in the resource. Omitted for an archive-type resource.
-        :param str name: (optional) **For an audio-type resource,** the name of the resource. Omitted for an archive-type resource.
-        :param AudioDetails details: (optional) **For an audio-type resource,** an `AudioDetails` object that provides detailed information about the resource. The object is empty until the service finishes processing the audio. Omitted for an archive-type resource.
-        :param str status: (optional) **For an audio-type resource,** the status of the resource: * `ok` indicates that the service has successfully analyzed the audio data. The data can be used to train the custom model. * `being_processed` indicates that the service is still analyzing the audio data. The service cannot accept requests to add new audio resources or to train the custom model until its analysis is complete. * `invalid` indicates that the audio data is not valid for training the custom model (possibly because it has the wrong format or sampling rate, or because it is corrupted).   Omitted for an archive-type resource.
-        :param AudioResource container: (optional) **For an archive-type resource,** an object of type `AudioResource` that provides information about the resource. Omitted for an audio-type resource.
-        :param list[AudioResource] audio: (optional) **For an archive-type resource,** an array of `AudioResource` objects that provides information about the audio-type resources that are contained in the resource. Omitted for an audio-type resource.
+        :param float duration: (optional) **For an audio-type resource,**  the total
+        seconds of audio in the resource. The value is always a whole number. Omitted for
+        an archive-type resource.
+        :param str name: (optional) **For an audio-type resource,** the user-specified
+        name of the resource. Omitted for an archive-type resource.
+        :param AudioDetails details: (optional) **For an audio-type resource,** an
+        `AudioDetails` object that provides detailed information about the resource. The
+        object is empty until the service finishes processing the audio. Omitted for an
+        archive-type resource.
+        :param str status: (optional) **For an audio-type resource,** the status of the
+        resource:
+        * `ok` indicates that the service has successfully analyzed the audio data. The
+        data can be used to train the custom model.
+        * `being_processed` indicates that the service is still analyzing the audio data.
+        The service cannot accept requests to add new audio resources or to train the
+        custom model until its analysis is complete.
+        * `invalid` indicates that the audio data is not valid for training the custom
+        model (possibly because it has the wrong format or sampling rate, or because it is
+        corrupted).
+        Omitted for an archive-type resource.
+        :param AudioResource container: (optional) **For an archive-type resource,** an
+        object of type `AudioResource` that provides information about the resource.
+        Omitted for an audio-type resource.
+        :param list[AudioResource] audio: (optional) **For an archive-type resource,** an
+        array of `AudioResource` objects that provides information about the audio-type
+        resources that are contained in the resource. Omitted for an audio-type resource.
         """
         self.duration = duration
         self.name = name
@@ -2192,20 +2573,52 @@ class AudioResource(object):
     """
     AudioResource.
 
-    :attr float duration: The total seconds of audio in the audio resource.
-    :attr str name: The name of the audio resource.
-    :attr AudioDetails details: An `AudioDetails` object that provides detailed information about the audio resource. The object is empty until the service finishes processing the audio.
-    :attr str status: The status of the audio resource: * `ok` indicates that the service has successfully analyzed the audio data. The data can be used to train the custom model. * `being_processed` indicates that the service is still analyzing the audio data. The service cannot accept requests to add new audio resources or to train the custom model until its analysis is complete. * `invalid` indicates that the audio data is not valid for training the custom model (possibly because it has the wrong format or sampling rate, or because it is corrupted). For an archive file, the entire archive is invalid if any of its audio files are invalid.
+    :attr float duration: The total seconds of audio in the audio resource. The value is
+    always a whole number.
+    :attr str name: **For an archive-type resource,** the user-specified name of the
+    resource.
+    **For an audio-type resource,** the user-specified name of the resource or the name of
+    the audio file that the user added for the resource. The value depends on the method
+    that is called.
+    :attr AudioDetails details: An `AudioDetails` object that provides detailed
+    information about the audio resource. The object is empty until the service finishes
+    processing the audio.
+    :attr str status: The status of the audio resource:
+    * `ok` indicates that the service has successfully analyzed the audio data. The data
+    can be used to train the custom model.
+    * `being_processed` indicates that the service is still analyzing the audio data. The
+    service cannot accept requests to add new audio resources or to train the custom model
+    until its analysis is complete.
+    * `invalid` indicates that the audio data is not valid for training the custom model
+    (possibly because it has the wrong format or sampling rate, or because it is
+    corrupted). For an archive file, the entire archive is invalid if any of its audio
+    files are invalid.
     """
 
     def __init__(self, duration, name, details, status):
         """
         Initialize a AudioResource object.
 
-        :param float duration: The total seconds of audio in the audio resource.
-        :param str name: The name of the audio resource.
-        :param AudioDetails details: An `AudioDetails` object that provides detailed information about the audio resource. The object is empty until the service finishes processing the audio.
-        :param str status: The status of the audio resource: * `ok` indicates that the service has successfully analyzed the audio data. The data can be used to train the custom model. * `being_processed` indicates that the service is still analyzing the audio data. The service cannot accept requests to add new audio resources or to train the custom model until its analysis is complete. * `invalid` indicates that the audio data is not valid for training the custom model (possibly because it has the wrong format or sampling rate, or because it is corrupted). For an archive file, the entire archive is invalid if any of its audio files are invalid.
+        :param float duration: The total seconds of audio in the audio resource. The value
+        is always a whole number.
+        :param str name: **For an archive-type resource,** the user-specified name of the
+        resource.
+        **For an audio-type resource,** the user-specified name of the resource or the
+        name of the audio file that the user added for the resource. The value depends on
+        the method that is called.
+        :param AudioDetails details: An `AudioDetails` object that provides detailed
+        information about the audio resource. The object is empty until the service
+        finishes processing the audio.
+        :param str status: The status of the audio resource:
+        * `ok` indicates that the service has successfully analyzed the audio data. The
+        data can be used to train the custom model.
+        * `being_processed` indicates that the service is still analyzing the audio data.
+        The service cannot accept requests to add new audio resources or to train the
+        custom model until its analysis is complete.
+        * `invalid` indicates that the audio data is not valid for training the custom
+        model (possibly because it has the wrong format or sampling rate, or because it is
+        corrupted). For an archive file, the entire archive is invalid if any of its audio
+        files are invalid.
         """
         self.duration = duration
         self.name = name
@@ -2273,16 +2686,26 @@ class AudioResources(object):
     """
     AudioResources.
 
-    :attr float total_minutes_of_audio: The total minutes of accumulated audio summed over all of the valid audio resources for the custom acoustic model. You can use this value to determine whether the custom model has too little or too much audio to begin training.
-    :attr list[AudioResource] audio: An array of `AudioResource` objects that provides information about the audio resources of the custom acoustic model. The array is empty if the custom model has no audio resources.
+    :attr float total_minutes_of_audio: The total minutes of accumulated audio summed over
+    all of the valid audio resources for the custom acoustic model. You can use this value
+    to determine whether the custom model has too little or too much audio to begin
+    training.
+    :attr list[AudioResource] audio: An array of `AudioResource` objects that provides
+    information about the audio resources of the custom acoustic model. The array is empty
+    if the custom model has no audio resources.
     """
 
     def __init__(self, total_minutes_of_audio, audio):
         """
         Initialize a AudioResources object.
 
-        :param float total_minutes_of_audio: The total minutes of accumulated audio summed over all of the valid audio resources for the custom acoustic model. You can use this value to determine whether the custom model has too little or too much audio to begin training.
-        :param list[AudioResource] audio: An array of `AudioResource` objects that provides information about the audio resources of the custom acoustic model. The array is empty if the custom model has no audio resources.
+        :param float total_minutes_of_audio: The total minutes of accumulated audio summed
+        over all of the valid audio resources for the custom acoustic model. You can use
+        this value to determine whether the custom model has too little or too much audio
+        to begin training.
+        :param list[AudioResource] audio: An array of `AudioResource` objects that
+        provides information about the audio resources of the custom acoustic model. The
+        array is empty if the custom model has no audio resources.
         """
         self.total_minutes_of_audio = total_minutes_of_audio
         self.audio = audio
@@ -2336,14 +2759,17 @@ class Corpora(object):
     """
     Corpora.
 
-    :attr list[Corpus] corpora: Information about corpora of the custom model. The array is empty if the custom model has no corpora.
+    :attr list[Corpus] corpora: An array of objects that provides information about the
+    corpora for the custom model. The array is empty if the custom model has no corpora.
     """
 
     def __init__(self, corpora):
         """
         Initialize a Corpora object.
 
-        :param list[Corpus] corpora: Information about corpora of the custom model. The array is empty if the custom model has no corpora.
+        :param list[Corpus] corpora: An array of objects that provides information about
+        the corpora for the custom model. The array is empty if the custom model has no
+        corpora.
         """
         self.corpora = corpora
 
@@ -2387,10 +2813,21 @@ class Corpus(object):
     Corpus.
 
     :attr str name: The name of the corpus.
-    :attr int total_words: The total number of words in the corpus. The value is `0` while the corpus is being processed.
-    :attr int out_of_vocabulary_words: The number of OOV words in the corpus. The value is `0` while the corpus is being processed.
-    :attr str status: The status of the corpus: * `analyzed` indicates that the service has successfully analyzed the corpus; the custom model can be trained with data from the corpus. * `being_processed` indicates that the service is still analyzing the corpus; the service cannot accept requests to add new corpora or words, or to train the custom model. * `undetermined` indicates that the service encountered an error while processing the corpus.
-    :attr str error: (optional) If the status of the corpus is `undetermined`, the following message: `Analysis of corpus 'name' failed. Please try adding the corpus again by setting the 'allow_overwrite' flag to 'true'`.
+    :attr int total_words: The total number of words in the corpus. The value is `0` while
+    the corpus is being processed.
+    :attr int out_of_vocabulary_words: The number of OOV words in the corpus. The value is
+    `0` while the corpus is being processed.
+    :attr str status: The status of the corpus:
+    * `analyzed` indicates that the service has successfully analyzed the corpus; the
+    custom model can be trained with data from the corpus.
+    * `being_processed` indicates that the service is still analyzing the corpus; the
+    service cannot accept requests to add new corpora or words, or to train the custom
+    model.
+    * `undetermined` indicates that the service encountered an error while processing the
+    corpus.
+    :attr str error: (optional) If the status of the corpus is `undetermined`, the
+    following message: `Analysis of corpus 'name' failed. Please try adding the corpus
+    again by setting the 'allow_overwrite' flag to 'true'`.
     """
 
     def __init__(self,
@@ -2403,10 +2840,21 @@ class Corpus(object):
         Initialize a Corpus object.
 
         :param str name: The name of the corpus.
-        :param int total_words: The total number of words in the corpus. The value is `0` while the corpus is being processed.
-        :param int out_of_vocabulary_words: The number of OOV words in the corpus. The value is `0` while the corpus is being processed.
-        :param str status: The status of the corpus: * `analyzed` indicates that the service has successfully analyzed the corpus; the custom model can be trained with data from the corpus. * `being_processed` indicates that the service is still analyzing the corpus; the service cannot accept requests to add new corpora or words, or to train the custom model. * `undetermined` indicates that the service encountered an error while processing the corpus.
-        :param str error: (optional) If the status of the corpus is `undetermined`, the following message: `Analysis of corpus 'name' failed. Please try adding the corpus again by setting the 'allow_overwrite' flag to 'true'`.
+        :param int total_words: The total number of words in the corpus. The value is `0`
+        while the corpus is being processed.
+        :param int out_of_vocabulary_words: The number of OOV words in the corpus. The
+        value is `0` while the corpus is being processed.
+        :param str status: The status of the corpus:
+        * `analyzed` indicates that the service has successfully analyzed the corpus; the
+        custom model can be trained with data from the corpus.
+        * `being_processed` indicates that the service is still analyzing the corpus; the
+        service cannot accept requests to add new corpora or words, or to train the custom
+        model.
+        * `undetermined` indicates that the service encountered an error while processing
+        the corpus.
+        :param str error: (optional) If the status of the corpus is `undetermined`, the
+        following message: `Analysis of corpus 'name' failed. Please try adding the corpus
+        again by setting the 'allow_overwrite' flag to 'true'`.
         """
         self.name = name
         self.total_words = total_words
@@ -2479,18 +2927,50 @@ class CustomWord(object):
     """
     CustomWord.
 
-    :attr str word: (optional) For the **Add custom words** method, you must specify the custom word that is to be added to or updated in the custom model. Do not include spaces in the word. Use a `-` (dash) or `_` (underscore) to connect the tokens of compound words.   Omit this field for the **Add a custom word** method.
-    :attr list[str] sounds_like: (optional) An array of sounds-like pronunciations for the custom word. Specify how words that are difficult to pronounce, foreign words, acronyms, and so on can be pronounced by users. For a word that is not in the service's base vocabulary, omit the parameter to have the service automatically generate a sounds-like pronunciation for the word. For a word that is in the service's base vocabulary, use the parameter to specify additional pronunciations for the word. You cannot override the default pronunciation of a word; pronunciations you add augment the pronunciation from the base vocabulary. A word can have at most five sounds-like pronunciations, and a pronunciation can include at most 40 characters not including spaces.
-    :attr str display_as: (optional) An alternative spelling for the custom word when it appears in a transcript. Use the parameter when you want the word to have a spelling that is different from its usual representation or from its spelling in corpora training data.
+    :attr str word: (optional) For the **Add custom words** method, you must specify the
+    custom word that is to be added to or updated in the custom model. Do not include
+    spaces in the word. Use a `-` (dash) or `_` (underscore) to connect the tokens of
+    compound words.
+    Omit this field for the **Add a custom word** method.
+    :attr list[str] sounds_like: (optional) An array of sounds-like pronunciations for the
+    custom word. Specify how words that are difficult to pronounce, foreign words,
+    acronyms, and so on can be pronounced by users. For a word that is not in the
+    service's base vocabulary, omit the parameter to have the service automatically
+    generate a sounds-like pronunciation for the word. For a word that is in the service's
+    base vocabulary, use the parameter to specify additional pronunciations for the word.
+    You cannot override the default pronunciation of a word; pronunciations you add
+    augment the pronunciation from the base vocabulary. A word can have at most five
+    sounds-like pronunciations, and a pronunciation can include at most 40 characters not
+    including spaces.
+    :attr str display_as: (optional) An alternative spelling for the custom word when it
+    appears in a transcript. Use the parameter when you want the word to have a spelling
+    that is different from its usual representation or from its spelling in corpora
+    training data.
     """
 
     def __init__(self, word=None, sounds_like=None, display_as=None):
         """
         Initialize a CustomWord object.
 
-        :param str word: (optional) For the **Add custom words** method, you must specify the custom word that is to be added to or updated in the custom model. Do not include spaces in the word. Use a `-` (dash) or `_` (underscore) to connect the tokens of compound words.   Omit this field for the **Add a custom word** method.
-        :param list[str] sounds_like: (optional) An array of sounds-like pronunciations for the custom word. Specify how words that are difficult to pronounce, foreign words, acronyms, and so on can be pronounced by users. For a word that is not in the service's base vocabulary, omit the parameter to have the service automatically generate a sounds-like pronunciation for the word. For a word that is in the service's base vocabulary, use the parameter to specify additional pronunciations for the word. You cannot override the default pronunciation of a word; pronunciations you add augment the pronunciation from the base vocabulary. A word can have at most five sounds-like pronunciations, and a pronunciation can include at most 40 characters not including spaces.
-        :param str display_as: (optional) An alternative spelling for the custom word when it appears in a transcript. Use the parameter when you want the word to have a spelling that is different from its usual representation or from its spelling in corpora training data.
+        :param str word: (optional) For the **Add custom words** method, you must specify
+        the custom word that is to be added to or updated in the custom model. Do not
+        include spaces in the word. Use a `-` (dash) or `_` (underscore) to connect the
+        tokens of compound words.
+        Omit this field for the **Add a custom word** method.
+        :param list[str] sounds_like: (optional) An array of sounds-like pronunciations
+        for the custom word. Specify how words that are difficult to pronounce, foreign
+        words, acronyms, and so on can be pronounced by users. For a word that is not in
+        the service's base vocabulary, omit the parameter to have the service
+        automatically generate a sounds-like pronunciation for the word. For a word that
+        is in the service's base vocabulary, use the parameter to specify additional
+        pronunciations for the word. You cannot override the default pronunciation of a
+        word; pronunciations you add augment the pronunciation from the base vocabulary. A
+        word can have at most five sounds-like pronunciations, and a pronunciation can
+        include at most 40 characters not including spaces.
+        :param str display_as: (optional) An alternative spelling for the custom word when
+        it appears in a transcript. Use the parameter when you want the word to have a
+        spelling that is different from its usual representation or from its spelling in
+        corpora training data.
         """
         self.word = word
         self.sounds_like = sounds_like
@@ -2538,20 +3018,24 @@ class KeywordResult(object):
     """
     KeywordResult.
 
-    :attr str normalized_text: A specified keyword normalized to the spoken phrase that matched in the audio input.
+    :attr str normalized_text: A specified keyword normalized to the spoken phrase that
+    matched in the audio input.
     :attr float start_time: The start time in seconds of the keyword match.
     :attr float end_time: The end time in seconds of the keyword match.
-    :attr float confidence: A confidence score for the keyword match in the range of 0 to 1.
+    :attr float confidence: A confidence score for the keyword match in the range of 0 to
+    1.
     """
 
     def __init__(self, normalized_text, start_time, end_time, confidence):
         """
         Initialize a KeywordResult object.
 
-        :param str normalized_text: A specified keyword normalized to the spoken phrase that matched in the audio input.
+        :param str normalized_text: A specified keyword normalized to the spoken phrase
+        that matched in the audio input.
         :param float start_time: The start time in seconds of the keyword match.
         :param float end_time: The end time in seconds of the keyword match.
-        :param float confidence: A confidence score for the keyword match in the range of 0 to 1.
+        :param float confidence: A confidence score for the keyword match in the range of
+        0 to 1.
         """
         self.normalized_text = normalized_text
         self.start_time = start_time
@@ -2621,18 +3105,46 @@ class LanguageModel(object):
     """
     LanguageModel.
 
-    :attr str customization_id: The customization ID (GUID) of the custom language model. The **Create a custom language model** method returns only this field of the object; it does not return the other fields.
-    :attr str created: (optional) The date and time in Coordinated Universal Time (UTC) at which the custom language model was created. The value is provided in full ISO 8601 format (`YYYY-MM-DDThh:mm:ss.sTZD`).
-    :attr str language: (optional) The language identifier of the custom language model (for example, `en-US`).
-    :attr str dialect: (optional) The dialect of the language for the custom language model. By default, the dialect matches the language of the base model; for example, `en-US` for either of the US English language models. For Spanish models, the field indicates the dialect for which the model was created: * `es-ES` for Castilian Spanish (the default) * `es-LA` for Latin American Spanish * `es-US` for North American (Mexican) Spanish.
-    :attr list[str] versions: (optional) A list of the available versions of the custom language model. Each element of the array indicates a version of the base model with which the custom model can be used. Multiple versions exist only if the custom model has been upgraded; otherwise, only a single version is shown.
-    :attr str owner: (optional) The GUID of the service credentials for the instance of the service that owns the custom language model.
+    :attr str customization_id: The customization ID (GUID) of the custom language model.
+    The **Create a custom language model** method returns only this field of the object;
+    it does not return the other fields.
+    :attr str created: (optional) The date and time in Coordinated Universal Time (UTC) at
+    which the custom language model was created. The value is provided in full ISO 8601
+    format (`YYYY-MM-DDThh:mm:ss.sTZD`).
+    :attr str language: (optional) The language identifier of the custom language model
+    (for example, `en-US`).
+    :attr str dialect: (optional) The dialect of the language for the custom language
+    model. By default, the dialect matches the language of the base model; for example,
+    `en-US` for either of the US English language models. For Spanish models, the field
+    indicates the dialect for which the model was created:
+    * `es-ES` for Castilian Spanish (the default)
+    * `es-LA` for Latin American Spanish
+    * `es-US` for North American (Mexican) Spanish.
+    :attr list[str] versions: (optional) A list of the available versions of the custom
+    language model. Each element of the array indicates a version of the base model with
+    which the custom model can be used. Multiple versions exist only if the custom model
+    has been upgraded; otherwise, only a single version is shown.
+    :attr str owner: (optional) The GUID of the service credentials for the instance of
+    the service that owns the custom language model.
     :attr str name: (optional) The name of the custom language model.
     :attr str description: (optional) The description of the custom language model.
-    :attr str base_model_name: (optional) The name of the language model for which the custom language model was created.
-    :attr str status: (optional) The current status of the custom language model: * `pending` indicates that the model was created but is waiting either for training data to be added or for the service to finish analyzing added data. * `ready` indicates that the model contains data and is ready to be trained. * `training` indicates that the model is currently being trained. * `available` indicates that the model is trained and ready to use. * `upgrading` indicates that the model is currently being upgraded. * `failed` indicates that training of the model failed.
-    :attr int progress: (optional) A percentage that indicates the progress of the custom language model's current training. A value of `100` means that the model is fully trained. **Note:** The `progress` field does not currently reflect the progress of the training. The field changes from `0` to `100` when training is complete.
-    :attr str warnings: (optional) If the request included unknown parameters, the following message: `Unexpected query parameter(s) ['parameters'] detected`, where `parameters` is a list that includes a quoted string for each unknown parameter.
+    :attr str base_model_name: (optional) The name of the language model for which the
+    custom language model was created.
+    :attr str status: (optional) The current status of the custom language model:
+    * `pending` indicates that the model was created but is waiting either for training
+    data to be added or for the service to finish analyzing added data.
+    * `ready` indicates that the model contains data and is ready to be trained.
+    * `training` indicates that the model is currently being trained.
+    * `available` indicates that the model is trained and ready to use.
+    * `upgrading` indicates that the model is currently being upgraded.
+    * `failed` indicates that training of the model failed.
+    :attr int progress: (optional) A percentage that indicates the progress of the custom
+    language model's current training. A value of `100` means that the model is fully
+    trained. **Note:** The `progress` field does not currently reflect the progress of the
+    training. The field changes from `0` to `100` when training is complete.
+    :attr str warnings: (optional) If the request included unknown parameters, the
+    following message: `Unexpected query parameter(s) ['parameters'] detected`, where
+    `parameters` is a list that includes a quoted string for each unknown parameter.
     """
 
     def __init__(self,
@@ -2651,18 +3163,47 @@ class LanguageModel(object):
         """
         Initialize a LanguageModel object.
 
-        :param str customization_id: The customization ID (GUID) of the custom language model. The **Create a custom language model** method returns only this field of the object; it does not return the other fields.
-        :param str created: (optional) The date and time in Coordinated Universal Time (UTC) at which the custom language model was created. The value is provided in full ISO 8601 format (`YYYY-MM-DDThh:mm:ss.sTZD`).
-        :param str language: (optional) The language identifier of the custom language model (for example, `en-US`).
-        :param str dialect: (optional) The dialect of the language for the custom language model. By default, the dialect matches the language of the base model; for example, `en-US` for either of the US English language models. For Spanish models, the field indicates the dialect for which the model was created: * `es-ES` for Castilian Spanish (the default) * `es-LA` for Latin American Spanish * `es-US` for North American (Mexican) Spanish.
-        :param list[str] versions: (optional) A list of the available versions of the custom language model. Each element of the array indicates a version of the base model with which the custom model can be used. Multiple versions exist only if the custom model has been upgraded; otherwise, only a single version is shown.
-        :param str owner: (optional) The GUID of the service credentials for the instance of the service that owns the custom language model.
+        :param str customization_id: The customization ID (GUID) of the custom language
+        model. The **Create a custom language model** method returns only this field of
+        the object; it does not return the other fields.
+        :param str created: (optional) The date and time in Coordinated Universal Time
+        (UTC) at which the custom language model was created. The value is provided in
+        full ISO 8601 format (`YYYY-MM-DDThh:mm:ss.sTZD`).
+        :param str language: (optional) The language identifier of the custom language
+        model (for example, `en-US`).
+        :param str dialect: (optional) The dialect of the language for the custom language
+        model. By default, the dialect matches the language of the base model; for
+        example, `en-US` for either of the US English language models. For Spanish models,
+        the field indicates the dialect for which the model was created:
+        * `es-ES` for Castilian Spanish (the default)
+        * `es-LA` for Latin American Spanish
+        * `es-US` for North American (Mexican) Spanish.
+        :param list[str] versions: (optional) A list of the available versions of the
+        custom language model. Each element of the array indicates a version of the base
+        model with which the custom model can be used. Multiple versions exist only if the
+        custom model has been upgraded; otherwise, only a single version is shown.
+        :param str owner: (optional) The GUID of the service credentials for the instance
+        of the service that owns the custom language model.
         :param str name: (optional) The name of the custom language model.
         :param str description: (optional) The description of the custom language model.
-        :param str base_model_name: (optional) The name of the language model for which the custom language model was created.
-        :param str status: (optional) The current status of the custom language model: * `pending` indicates that the model was created but is waiting either for training data to be added or for the service to finish analyzing added data. * `ready` indicates that the model contains data and is ready to be trained. * `training` indicates that the model is currently being trained. * `available` indicates that the model is trained and ready to use. * `upgrading` indicates that the model is currently being upgraded. * `failed` indicates that training of the model failed.
-        :param int progress: (optional) A percentage that indicates the progress of the custom language model's current training. A value of `100` means that the model is fully trained. **Note:** The `progress` field does not currently reflect the progress of the training. The field changes from `0` to `100` when training is complete.
-        :param str warnings: (optional) If the request included unknown parameters, the following message: `Unexpected query parameter(s) ['parameters'] detected`, where `parameters` is a list that includes a quoted string for each unknown parameter.
+        :param str base_model_name: (optional) The name of the language model for which
+        the custom language model was created.
+        :param str status: (optional) The current status of the custom language model:
+        * `pending` indicates that the model was created but is waiting either for
+        training data to be added or for the service to finish analyzing added data.
+        * `ready` indicates that the model contains data and is ready to be trained.
+        * `training` indicates that the model is currently being trained.
+        * `available` indicates that the model is trained and ready to use.
+        * `upgrading` indicates that the model is currently being upgraded.
+        * `failed` indicates that training of the model failed.
+        :param int progress: (optional) A percentage that indicates the progress of the
+        custom language model's current training. A value of `100` means that the model is
+        fully trained. **Note:** The `progress` field does not currently reflect the
+        progress of the training. The field changes from `0` to `100` when training is
+        complete.
+        :param str warnings: (optional) If the request included unknown parameters, the
+        following message: `Unexpected query parameter(s) ['parameters'] detected`, where
+        `parameters` is a list that includes a quoted string for each unknown parameter.
         """
         self.customization_id = customization_id
         self.created = created
@@ -2761,14 +3302,20 @@ class LanguageModels(object):
     """
     LanguageModels.
 
-    :attr list[LanguageModel] customizations: An array of objects that provides information about each available custom language model. The array is empty if the requesting service credentials own no custom language models (if no language is specified) or own no custom language models for the specified language.
+    :attr list[LanguageModel] customizations: An array of objects that provides
+    information about each available custom language model. The array is empty if the
+    requesting service credentials own no custom language models (if no language is
+    specified) or own no custom language models for the specified language.
     """
 
     def __init__(self, customizations):
         """
         Initialize a LanguageModels object.
 
-        :param list[LanguageModel] customizations: An array of objects that provides information about each available custom language model. The array is empty if the requesting service credentials own no custom language models (if no language is specified) or own no custom language models for the specified language.
+        :param list[LanguageModel] customizations: An array of objects that provides
+        information about each available custom language model. The array is empty if the
+        requesting service credentials own no custom language models (if no language is
+        specified) or own no custom language models for the specified language.
         """
         self.customizations = customizations
 
@@ -2816,13 +3363,38 @@ class RecognitionJob(object):
     RecognitionJob.
 
     :attr str id: The ID of the asynchronous job.
-    :attr str status: The current status of the job: * `waiting`: The service is preparing the job for processing. The service returns this status when the job is initially created or when it is waiting for capacity to process the job. The job remains in this state until the service has the capacity to begin processing it. * `processing`: The service is actively processing the job. * `completed`: The service has finished processing the job. If the job specified a callback URL and the event `recognitions.completed_with_results`, the service sent the results with the callback notification; otherwise, you must retrieve the results by checking the individual job. * `failed`: The job failed.
-    :attr str created: The date and time in Coordinated Universal Time (UTC) at which the job was created. The value is provided in full ISO 8601 format (`YYYY-MM-DDThh:mm:ss.sTZD`).
-    :attr str updated: (optional) The date and time in Coordinated Universal Time (UTC) at which the job was last updated by the service. The value is provided in full ISO 8601 format (`YYYY-MM-DDThh:mm:ss.sTZD`). This field is returned only by the **Check jobs** and **Check a job** methods.
-    :attr str url: (optional) The URL to use to request information about the job with the **Check a job** method. This field is returned only by the **Create a job** method.
-    :attr str user_token: (optional) The user token associated with a job that was created with a callback URL and a user token. This field can be returned only by the **Check jobs** method.
-    :attr list[SpeechRecognitionResults] results: (optional) If the status is `completed`, the results of the recognition request as an array that includes a single instance of a `SpeechRecognitionResults` object. This field is returned only by the **Check a job** method.
-    :attr list[str] warnings: (optional) An array of warning messages about invalid parameters included with the request. Each warning includes a descriptive message and a list of invalid argument strings, for example, `"unexpected query parameter 'user_token', query parameter 'callback_url' was not specified"`. The request succeeds despite the warnings. This field can be returned only by the **Create a job** method.
+    :attr str status: The current status of the job:
+    * `waiting`: The service is preparing the job for processing. The service returns this
+    status when the job is initially created or when it is waiting for capacity to process
+    the job. The job remains in this state until the service has the capacity to begin
+    processing it.
+    * `processing`: The service is actively processing the job.
+    * `completed`: The service has finished processing the job. If the job specified a
+    callback URL and the event `recognitions.completed_with_results`, the service sent the
+    results with the callback notification; otherwise, you must retrieve the results by
+    checking the individual job.
+    * `failed`: The job failed.
+    :attr str created: The date and time in Coordinated Universal Time (UTC) at which the
+    job was created. The value is provided in full ISO 8601 format
+    (`YYYY-MM-DDThh:mm:ss.sTZD`).
+    :attr str updated: (optional) The date and time in Coordinated Universal Time (UTC) at
+    which the job was last updated by the service. The value is provided in full ISO 8601
+    format (`YYYY-MM-DDThh:mm:ss.sTZD`). This field is returned only by the **Check jobs**
+    and **Check a job** methods.
+    :attr str url: (optional) The URL to use to request information about the job with the
+    **Check a job** method. This field is returned only by the **Create a job** method.
+    :attr str user_token: (optional) The user token associated with a job that was created
+    with a callback URL and a user token. This field can be returned only by the **Check
+    jobs** method.
+    :attr list[SpeechRecognitionResults] results: (optional) If the status is `completed`,
+    the results of the recognition request as an array that includes a single instance of
+    a `SpeechRecognitionResults` object. This field is returned only by the **Check a
+    job** method.
+    :attr list[str] warnings: (optional) An array of warning messages about invalid
+    parameters included with the request. Each warning includes a descriptive message and
+    a list of invalid argument strings, for example, `"unexpected query parameter
+    'user_token', query parameter 'callback_url' was not specified"`. The request succeeds
+    despite the warnings. This field can be returned only by the **Create a job** method.
     """
 
     def __init__(self,
@@ -2838,13 +3410,40 @@ class RecognitionJob(object):
         Initialize a RecognitionJob object.
 
         :param str id: The ID of the asynchronous job.
-        :param str status: The current status of the job: * `waiting`: The service is preparing the job for processing. The service returns this status when the job is initially created or when it is waiting for capacity to process the job. The job remains in this state until the service has the capacity to begin processing it. * `processing`: The service is actively processing the job. * `completed`: The service has finished processing the job. If the job specified a callback URL and the event `recognitions.completed_with_results`, the service sent the results with the callback notification; otherwise, you must retrieve the results by checking the individual job. * `failed`: The job failed.
-        :param str created: The date and time in Coordinated Universal Time (UTC) at which the job was created. The value is provided in full ISO 8601 format (`YYYY-MM-DDThh:mm:ss.sTZD`).
-        :param str updated: (optional) The date and time in Coordinated Universal Time (UTC) at which the job was last updated by the service. The value is provided in full ISO 8601 format (`YYYY-MM-DDThh:mm:ss.sTZD`). This field is returned only by the **Check jobs** and **Check a job** methods.
-        :param str url: (optional) The URL to use to request information about the job with the **Check a job** method. This field is returned only by the **Create a job** method.
-        :param str user_token: (optional) The user token associated with a job that was created with a callback URL and a user token. This field can be returned only by the **Check jobs** method.
-        :param list[SpeechRecognitionResults] results: (optional) If the status is `completed`, the results of the recognition request as an array that includes a single instance of a `SpeechRecognitionResults` object. This field is returned only by the **Check a job** method.
-        :param list[str] warnings: (optional) An array of warning messages about invalid parameters included with the request. Each warning includes a descriptive message and a list of invalid argument strings, for example, `"unexpected query parameter 'user_token', query parameter 'callback_url' was not specified"`. The request succeeds despite the warnings. This field can be returned only by the **Create a job** method.
+        :param str status: The current status of the job:
+        * `waiting`: The service is preparing the job for processing. The service returns
+        this status when the job is initially created or when it is waiting for capacity
+        to process the job. The job remains in this state until the service has the
+        capacity to begin processing it.
+        * `processing`: The service is actively processing the job.
+        * `completed`: The service has finished processing the job. If the job specified a
+        callback URL and the event `recognitions.completed_with_results`, the service sent
+        the results with the callback notification; otherwise, you must retrieve the
+        results by checking the individual job.
+        * `failed`: The job failed.
+        :param str created: The date and time in Coordinated Universal Time (UTC) at which
+        the job was created. The value is provided in full ISO 8601 format
+        (`YYYY-MM-DDThh:mm:ss.sTZD`).
+        :param str updated: (optional) The date and time in Coordinated Universal Time
+        (UTC) at which the job was last updated by the service. The value is provided in
+        full ISO 8601 format (`YYYY-MM-DDThh:mm:ss.sTZD`). This field is returned only by
+        the **Check jobs** and **Check a job** methods.
+        :param str url: (optional) The URL to use to request information about the job
+        with the **Check a job** method. This field is returned only by the **Create a
+        job** method.
+        :param str user_token: (optional) The user token associated with a job that was
+        created with a callback URL and a user token. This field can be returned only by
+        the **Check jobs** method.
+        :param list[SpeechRecognitionResults] results: (optional) If the status is
+        `completed`, the results of the recognition request as an array that includes a
+        single instance of a `SpeechRecognitionResults` object. This field is returned
+        only by the **Check a job** method.
+        :param list[str] warnings: (optional) An array of warning messages about invalid
+        parameters included with the request. Each warning includes a descriptive message
+        and a list of invalid argument strings, for example, `"unexpected query parameter
+        'user_token', query parameter 'callback_url' was not specified"`. The request
+        succeeds despite the warnings. This field can be returned only by the **Create a
+        job** method.
         """
         self.id = id
         self.status = status
@@ -2931,14 +3530,18 @@ class RecognitionJobs(object):
     """
     RecognitionJobs.
 
-    :attr list[RecognitionJob] recognitions: An array of objects that provides the status for each of the user's current jobs. The array is empty if the user has no current jobs.
+    :attr list[RecognitionJob] recognitions: An array of objects that provides the status
+    for each of the user's current jobs. The array is empty if the user has no current
+    jobs.
     """
 
     def __init__(self, recognitions):
         """
         Initialize a RecognitionJobs object.
 
-        :param list[RecognitionJob] recognitions: An array of objects that provides the status for each of the user's current jobs. The array is empty if the user has no current jobs.
+        :param list[RecognitionJob] recognitions: An array of objects that provides the
+        status for each of the user's current jobs. The array is empty if the user has no
+        current jobs.
         """
         self.recognitions = recognitions
 
@@ -2983,7 +3586,9 @@ class RegisterStatus(object):
     """
     RegisterStatus.
 
-    :attr str status: The current status of the job: * `created` if the callback URL was successfully white-listed as a result of the call. * `already created` if the URL was already white-listed.
+    :attr str status: The current status of the job:
+    * `created` if the callback URL was successfully white-listed as a result of the call.
+    * `already created` if the URL was already white-listed.
     :attr str url: The callback URL that is successfully registered.
     """
 
@@ -2991,7 +3596,10 @@ class RegisterStatus(object):
         """
         Initialize a RegisterStatus object.
 
-        :param str status: The current status of the job: * `created` if the callback URL was successfully white-listed as a result of the call. * `already created` if the URL was already white-listed.
+        :param str status: The current status of the job:
+        * `created` if the callback URL was successfully white-listed as a result of the
+        call.
+        * `already created` if the URL was already white-listed.
         :param str url: The callback URL that is successfully registered.
         """
         self.status = status
@@ -3042,24 +3650,44 @@ class SpeakerLabelsResult(object):
     """
     SpeakerLabelsResult.
 
-    :attr float _from: The start time of a word from the transcript. The value matches the start time of a word from the `timestamps` array.
-    :attr float to: The end time of a word from the transcript. The value matches the end time of a word from the `timestamps` array.
-    :attr int speaker: The numeric identifier that the service assigns to a speaker from the audio. Speaker IDs begin at `0` initially but can evolve and change across interim results (if supported by the method) and between interim and final results as the service processes the audio. They are not guaranteed to be sequential, contiguous, or ordered.
-    :attr float confidence: A score that indicates the service's confidence in its identification of the speaker in the range of 0 to 1.
-    :attr bool final_results: An indication of whether the service might further change word and speaker-label results. A value of `true` means that the service guarantees not to send any further updates for the current or any preceding results; `false` means that the service might send further updates to the results.
+    :attr float from: The start time of a word from the transcript. The value matches the
+    start time of a word from the `timestamps` array.
+    :attr float to: The end time of a word from the transcript. The value matches the end
+    time of a word from the `timestamps` array.
+    :attr int speaker: The numeric identifier that the service assigns to a speaker from
+    the audio. Speaker IDs begin at `0` initially but can evolve and change across interim
+    results (if supported by the method) and between interim and final results as the
+    service processes the audio. They are not guaranteed to be sequential, contiguous, or
+    ordered.
+    :attr float confidence: A score that indicates the service's confidence in its
+    identification of the speaker in the range of 0 to 1.
+    :attr bool final_results: An indication of whether the service might further change
+    word and speaker-label results. A value of `true` means that the service guarantees
+    not to send any further updates for the current or any preceding results; `false`
+    means that the service might send further updates to the results.
     """
 
-    def __init__(self, _from, to, speaker, confidence, final_results):
+    def __init__(self, from, to, speaker, confidence, final_results):
         """
         Initialize a SpeakerLabelsResult object.
 
-        :param float _from: The start time of a word from the transcript. The value matches the start time of a word from the `timestamps` array.
-        :param float to: The end time of a word from the transcript. The value matches the end time of a word from the `timestamps` array.
-        :param int speaker: The numeric identifier that the service assigns to a speaker from the audio. Speaker IDs begin at `0` initially but can evolve and change across interim results (if supported by the method) and between interim and final results as the service processes the audio. They are not guaranteed to be sequential, contiguous, or ordered.
-        :param float confidence: A score that indicates the service's confidence in its identification of the speaker in the range of 0 to 1.
-        :param bool final_results: An indication of whether the service might further change word and speaker-label results. A value of `true` means that the service guarantees not to send any further updates for the current or any preceding results; `false` means that the service might send further updates to the results.
+        :param float from: The start time of a word from the transcript. The value matches
+        the start time of a word from the `timestamps` array.
+        :param float to: The end time of a word from the transcript. The value matches the
+        end time of a word from the `timestamps` array.
+        :param int speaker: The numeric identifier that the service assigns to a speaker
+        from the audio. Speaker IDs begin at `0` initially but can evolve and change
+        across interim results (if supported by the method) and between interim and final
+        results as the service processes the audio. They are not guaranteed to be
+        sequential, contiguous, or ordered.
+        :param float confidence: A score that indicates the service's confidence in its
+        identification of the speaker in the range of 0 to 1.
+        :param bool final_results: An indication of whether the service might further
+        change word and speaker-label results. A value of `true` means that the service
+        guarantees not to send any further updates for the current or any preceding
+        results; `false` means that the service might send further updates to the results.
         """
-        self._from = _from
+        self.from = from
         self.to = to
         self.speaker = speaker
         self.confidence = confidence
@@ -3070,42 +3698,32 @@ class SpeakerLabelsResult(object):
         """Initialize a SpeakerLabelsResult object from a json dictionary."""
         args = {}
         if 'from' in _dict:
-            args['_from'] = _dict.get('from')
+            args['from'] = _dict.get('from')
         else:
-            raise ValueError(
-                'Required property \'from\' not present in SpeakerLabelsResult JSON'
-            )
+            raise ValueError('Required property \'from\' not present in SpeakerLabelsResult JSON')
         if 'to' in _dict:
             args['to'] = _dict.get('to')
         else:
-            raise ValueError(
-                'Required property \'to\' not present in SpeakerLabelsResult JSON'
-            )
+            raise ValueError('Required property \'to\' not present in SpeakerLabelsResult JSON')
         if 'speaker' in _dict:
             args['speaker'] = _dict.get('speaker')
         else:
-            raise ValueError(
-                'Required property \'speaker\' not present in SpeakerLabelsResult JSON'
-            )
+            raise ValueError('Required property \'speaker\' not present in SpeakerLabelsResult JSON')
         if 'confidence' in _dict:
             args['confidence'] = _dict.get('confidence')
         else:
-            raise ValueError(
-                'Required property \'confidence\' not present in SpeakerLabelsResult JSON'
-            )
+            raise ValueError('Required property \'confidence\' not present in SpeakerLabelsResult JSON')
         if 'final' in _dict or 'final_results' in _dict:
             args['final_results'] = _dict.get('final') or _dict.get('final_results')
         else:
-            raise ValueError(
-                'Required property \'final\' not present in SpeakerLabelsResult JSON'
-            )
+            raise ValueError('Required property \'final\' not present in SpeakerLabelsResult JSON')
         return cls(**args)
 
     def _to_dict(self):
         """Return a json dictionary representing this model."""
         _dict = {}
-        if hasattr(self, '_from') and self._from is not None:
-            _dict['from'] = self._from
+        if hasattr(self, 'from') and self.from is not None:
+            _dict['from'] = self.from
         if hasattr(self, 'to') and self.to is not None:
             _dict['to'] = self.to
         if hasattr(self, 'speaker') and self.speaker is not None:
@@ -3130,17 +3748,22 @@ class SpeakerLabelsResult(object):
         """Return `true` when self and other are not equal, false otherwise."""
         return not self == other
 
+
 class SpeechModel(object):
     """
     SpeechModel.
 
-    :attr str name: The name of the model for use as an identifier in calls to the service (for example, `en-US_BroadbandModel`).
+    :attr str name: The name of the model for use as an identifier in calls to the service
+    (for example, `en-US_BroadbandModel`).
     :attr str language: The language identifier of the model (for example, `en-US`).
-    :attr int rate: The sampling rate (minimum acceptable rate for audio) used by the model in Hertz.
+    :attr int rate: The sampling rate (minimum acceptable rate for audio) used by the
+    model in Hertz.
     :attr str url: The URI for the model.
-    :attr SupportedFeatures supported_features: Describes the additional service features supported with the model.
+    :attr SupportedFeatures supported_features: Describes the additional service features
+    supported with the model.
     :attr str description: Brief description of the model.
-    :attr str sessions: (optional) The URI for the model for use with the **Create a session** method. This field is returned only by the **Get a model** method.
+    :attr str sessions: (optional) The URI for the model for use with the **Create a
+    session** method. This field is returned only by the **Get a model** method.
     """
 
     def __init__(self,
@@ -3154,13 +3777,17 @@ class SpeechModel(object):
         """
         Initialize a SpeechModel object.
 
-        :param str name: The name of the model for use as an identifier in calls to the service (for example, `en-US_BroadbandModel`).
+        :param str name: The name of the model for use as an identifier in calls to the
+        service (for example, `en-US_BroadbandModel`).
         :param str language: The language identifier of the model (for example, `en-US`).
-        :param int rate: The sampling rate (minimum acceptable rate for audio) used by the model in Hertz.
+        :param int rate: The sampling rate (minimum acceptable rate for audio) used by the
+        model in Hertz.
         :param str url: The URI for the model.
-        :param SupportedFeatures supported_features: Describes the additional service features supported with the model.
+        :param SupportedFeatures supported_features: Describes the additional service
+        features supported with the model.
         :param str description: Brief description of the model.
-        :param str sessions: (optional) The URI for the model for use with the **Create a session** method. This field is returned only by the **Get a model** method.
+        :param str sessions: (optional) The URI for the model for use with the **Create a
+        session** method. This field is returned only by the **Get a model** method.
         """
         self.name = name
         self.language = language
@@ -3252,14 +3879,16 @@ class SpeechModels(object):
     """
     SpeechModels.
 
-    :attr list[SpeechModel] models: Information about each available model.
+    :attr list[SpeechModel] models: An array of objects that provides information about
+    each available model.
     """
 
     def __init__(self, models):
         """
         Initialize a SpeechModels object.
 
-        :param list[SpeechModel] models: Information about each available model.
+        :param list[SpeechModel] models: An array of objects that provides information
+        about each available model.
         """
         self.models = models
 
@@ -3303,9 +3932,18 @@ class SpeechRecognitionAlternative(object):
     SpeechRecognitionAlternative.
 
     :attr str transcript: A transcription of the audio.
-    :attr float confidence: (optional) A score that indicates the service's confidence in the transcript in the range of 0 to 1. Returned only for the best alternative and only with results marked as final.
-    :attr list[str] timestamps: (optional) Time alignments for each word from the transcript as a list of lists. Each inner list consists of three elements: the word followed by its start and end time in seconds. Example: `[["hello",0.0,1.2],["world",1.2,2.5]]`. Returned only for the best alternative.
-    :attr list[str] word_confidence: (optional) A confidence score for each word of the transcript as a list of lists. Each inner list consists of two elements: the word and its confidence score in the range of 0 to 1. Example: `[["hello",0.95],["world",0.866]]`. Returned only for the best alternative and only with results marked as final.
+    :attr float confidence: (optional) A score that indicates the service's confidence in
+    the transcript in the range of 0 to 1. Returned only for the best alternative and only
+    with results marked as final.
+    :attr list[str] timestamps: (optional) Time alignments for each word from the
+    transcript as a list of lists. Each inner list consists of three elements: the word
+    followed by its start and end time in seconds. Example:
+    `[["hello",0.0,1.2],["world",1.2,2.5]]`. Returned only for the best alternative.
+    :attr list[str] word_confidence: (optional) A confidence score for each word of the
+    transcript as a list of lists. Each inner list consists of two elements: the word and
+    its confidence score in the range of 0 to 1. Example:
+    `[["hello",0.95],["world",0.866]]`. Returned only for the best alternative and only
+    with results marked as final.
     """
 
     def __init__(self,
@@ -3317,9 +3955,18 @@ class SpeechRecognitionAlternative(object):
         Initialize a SpeechRecognitionAlternative object.
 
         :param str transcript: A transcription of the audio.
-        :param float confidence: (optional) A score that indicates the service's confidence in the transcript in the range of 0 to 1. Returned only for the best alternative and only with results marked as final.
-        :param list[str] timestamps: (optional) Time alignments for each word from the transcript as a list of lists. Each inner list consists of three elements: the word followed by its start and end time in seconds. Example: `[["hello",0.0,1.2],["world",1.2,2.5]]`. Returned only for the best alternative.
-        :param list[str] word_confidence: (optional) A confidence score for each word of the transcript as a list of lists. Each inner list consists of two elements: the word and its confidence score in the range of 0 to 1. Example: `[["hello",0.95],["world",0.866]]`. Returned only for the best alternative and only with results marked as final.
+        :param float confidence: (optional) A score that indicates the service's
+        confidence in the transcript in the range of 0 to 1. Returned only for the best
+        alternative and only with results marked as final.
+        :param list[str] timestamps: (optional) Time alignments for each word from the
+        transcript as a list of lists. Each inner list consists of three elements: the
+        word followed by its start and end time in seconds. Example:
+        `[["hello",0.0,1.2],["world",1.2,2.5]]`. Returned only for the best alternative.
+        :param list[str] word_confidence: (optional) A confidence score for each word of
+        the transcript as a list of lists. Each inner list consists of two elements: the
+        word and its confidence score in the range of 0 to 1. Example:
+        `[["hello",0.95],["world",0.866]]`. Returned only for the best alternative and
+        only with results marked as final.
         """
         self.transcript = transcript
         self.confidence = confidence
@@ -3377,10 +4024,20 @@ class SpeechRecognitionResult(object):
     """
     SpeechRecognitionResult.
 
-    :attr bool final_results: An indication of whether the transcription results are final. If `true`, the results for this utterance are not updated further; no additional results are sent for a `result_index` once its results are indicated as final.
-    :attr list[SpeechRecognitionAlternative] alternatives: An array of alternative transcripts. The `alternatives` array can include additional requested output such as word confidence or timestamps.
-    :attr dict keywords_result: (optional) A dictionary (or associative array) whose keys are the strings specified for `keywords` if both that parameter and `keywords_threshold` are specified. A keyword for which no matches are found is omitted from the array. The array is omitted if no matches are found for any keywords.
-    :attr list[WordAlternativeResults] word_alternatives: (optional) An array of alternative hypotheses found for words of the input audio if a `word_alternatives_threshold` is specified.
+    :attr bool final_results: An indication of whether the transcription results are
+    final. If `true`, the results for this utterance are not updated further; no
+    additional results are sent for a `result_index` once its results are indicated as
+    final.
+    :attr list[SpeechRecognitionAlternative] alternatives: An array of alternative
+    transcripts. The `alternatives` array can include additional requested output such as
+    word confidence or timestamps.
+    :attr dict keywords_result: (optional) A dictionary (or associative array) whose keys
+    are the strings specified for `keywords` if both that parameter and
+    `keywords_threshold` are specified. A keyword for which no matches are found is
+    omitted from the array. The array is omitted if no matches are found for any keywords.
+    :attr list[WordAlternativeResults] word_alternatives: (optional) An array of
+    alternative hypotheses found for words of the input audio if a
+    `word_alternatives_threshold` is specified.
     """
 
     def __init__(self,
@@ -3391,10 +4048,21 @@ class SpeechRecognitionResult(object):
         """
         Initialize a SpeechRecognitionResult object.
 
-        :param bool final_results: An indication of whether the transcription results are final. If `true`, the results for this utterance are not updated further; no additional results are sent for a `result_index` once its results are indicated as final.
-        :param list[SpeechRecognitionAlternative] alternatives: An array of alternative transcripts. The `alternatives` array can include additional requested output such as word confidence or timestamps.
-        :param dict keywords_result: (optional) A dictionary (or associative array) whose keys are the strings specified for `keywords` if both that parameter and `keywords_threshold` are specified. A keyword for which no matches are found is omitted from the array. The array is omitted if no matches are found for any keywords.
-        :param list[WordAlternativeResults] word_alternatives: (optional) An array of alternative hypotheses found for words of the input audio if a `word_alternatives_threshold` is specified.
+        :param bool final_results: An indication of whether the transcription results are
+        final. If `true`, the results for this utterance are not updated further; no
+        additional results are sent for a `result_index` once its results are indicated as
+        final.
+        :param list[SpeechRecognitionAlternative] alternatives: An array of alternative
+        transcripts. The `alternatives` array can include additional requested output such
+        as word confidence or timestamps.
+        :param dict keywords_result: (optional) A dictionary (or associative array) whose
+        keys are the strings specified for `keywords` if both that parameter and
+        `keywords_threshold` are specified. A keyword for which no matches are found is
+        omitted from the array. The array is omitted if no matches are found for any
+        keywords.
+        :param list[WordAlternativeResults] word_alternatives: (optional) An array of
+        alternative hypotheses found for words of the input audio if a
+        `word_alternatives_threshold` is specified.
         """
         self.final_results = final_results
         self.alternatives = alternatives
@@ -3466,10 +4134,32 @@ class SpeechRecognitionResults(object):
     """
     SpeechRecognitionResults.
 
-    :attr list[SpeechRecognitionResult] results: (optional) An array that can include interim and final results (interim results are returned only if supported by the method). Final results are guaranteed not to change; interim results might be replaced by further interim results and final results. The service periodically sends updates to the results list; the `result_index` is set to the lowest index in the array that has changed; it is incremented for new results.
-    :attr int result_index: (optional) An index that indicates a change point in the `results` array. The service increments the index only for additional results that it sends for new audio for the same request.
-    :attr list[SpeakerLabelsResult] speaker_labels: (optional) An array that identifies which words were spoken by which speakers in a multi-person exchange. Returned in the response only if `speaker_labels` is `true`. When interim results are also requested for methods that support them, it is possible for a `SpeechRecognitionResults` object to include only the `speaker_labels` field.
-    :attr list[str] warnings: (optional) An array of warning messages associated with the request: * Warnings for invalid parameters or fields can include a descriptive message and a list of invalid argument strings, for example, `"Unknown arguments:"` or `"Unknown url query arguments:"` followed by a list of the form `"invalid_arg_1, invalid_arg_2."` * The following warning is returned if the request passes a custom model that is based on an older version of a base model for which an updated version is available: `"Using previous version of base model, because your custom model has been built with it. Please note that this version will be supported only for a limited time. Consider updating your custom model to the new base model. If you do not do that you will be automatically switched to base model when you used the non-updated custom model."`  In both cases, the request succeeds despite the warnings.
+    :attr list[SpeechRecognitionResult] results: (optional) An array that can include
+    interim and final results (interim results are returned only if supported by the
+    method). Final results are guaranteed not to change; interim results might be replaced
+    by further interim results and final results. The service periodically sends updates
+    to the results list; the `result_index` is set to the lowest index in the array that
+    has changed; it is incremented for new results.
+    :attr int result_index: (optional) An index that indicates a change point in the
+    `results` array. The service increments the index only for additional results that it
+    sends for new audio for the same request.
+    :attr list[SpeakerLabelsResult] speaker_labels: (optional) An array that identifies
+    which words were spoken by which speakers in a multi-person exchange. Returned in the
+    response only if `speaker_labels` is `true`. When interim results are also requested
+    for methods that support them, it is possible for a `SpeechRecognitionResults` object
+    to include only the `speaker_labels` field.
+    :attr list[str] warnings: (optional) An array of warning messages associated with the
+    request:
+    * Warnings for invalid parameters or fields can include a descriptive message and a
+    list of invalid argument strings, for example, `"Unknown arguments:"` or `"Unknown url
+    query arguments:"` followed by a list of the form `"invalid_arg_1, invalid_arg_2."`
+    * The following warning is returned if the request passes a custom model that is based
+    on an older version of a base model for which an updated version is available: `"Using
+    previous version of base model, because your custom model has been built with it.
+    Please note that this version will be supported only for a limited time. Consider
+    updating your custom model to the new base model. If you do not do that you will be
+    automatically switched to base model when you used the non-updated custom model."`
+    In both cases, the request succeeds despite the warnings.
     """
 
     def __init__(self,
@@ -3480,10 +4170,34 @@ class SpeechRecognitionResults(object):
         """
         Initialize a SpeechRecognitionResults object.
 
-        :param list[SpeechRecognitionResult] results: (optional) An array that can include interim and final results (interim results are returned only if supported by the method). Final results are guaranteed not to change; interim results might be replaced by further interim results and final results. The service periodically sends updates to the results list; the `result_index` is set to the lowest index in the array that has changed; it is incremented for new results.
-        :param int result_index: (optional) An index that indicates a change point in the `results` array. The service increments the index only for additional results that it sends for new audio for the same request.
-        :param list[SpeakerLabelsResult] speaker_labels: (optional) An array that identifies which words were spoken by which speakers in a multi-person exchange. Returned in the response only if `speaker_labels` is `true`. When interim results are also requested for methods that support them, it is possible for a `SpeechRecognitionResults` object to include only the `speaker_labels` field.
-        :param list[str] warnings: (optional) An array of warning messages associated with the request: * Warnings for invalid parameters or fields can include a descriptive message and a list of invalid argument strings, for example, `"Unknown arguments:"` or `"Unknown url query arguments:"` followed by a list of the form `"invalid_arg_1, invalid_arg_2."` * The following warning is returned if the request passes a custom model that is based on an older version of a base model for which an updated version is available: `"Using previous version of base model, because your custom model has been built with it. Please note that this version will be supported only for a limited time. Consider updating your custom model to the new base model. If you do not do that you will be automatically switched to base model when you used the non-updated custom model."`  In both cases, the request succeeds despite the warnings.
+        :param list[SpeechRecognitionResult] results: (optional) An array that can include
+        interim and final results (interim results are returned only if supported by the
+        method). Final results are guaranteed not to change; interim results might be
+        replaced by further interim results and final results. The service periodically
+        sends updates to the results list; the `result_index` is set to the lowest index
+        in the array that has changed; it is incremented for new results.
+        :param int result_index: (optional) An index that indicates a change point in the
+        `results` array. The service increments the index only for additional results that
+        it sends for new audio for the same request.
+        :param list[SpeakerLabelsResult] speaker_labels: (optional) An array that
+        identifies which words were spoken by which speakers in a multi-person exchange.
+        Returned in the response only if `speaker_labels` is `true`. When interim results
+        are also requested for methods that support them, it is possible for a
+        `SpeechRecognitionResults` object to include only the `speaker_labels` field.
+        :param list[str] warnings: (optional) An array of warning messages associated with
+        the request:
+        * Warnings for invalid parameters or fields can include a descriptive message and
+        a list of invalid argument strings, for example, `"Unknown arguments:"` or
+        `"Unknown url query arguments:"` followed by a list of the form `"invalid_arg_1,
+        invalid_arg_2."`
+        * The following warning is returned if the request passes a custom model that is
+        based on an older version of a base model for which an updated version is
+        available: `"Using previous version of base model, because your custom model has
+        been built with it. Please note that this version will be supported only for a
+        limited time. Consider updating your custom model to the new base model. If you do
+        not do that you will be automatically switched to base model when you used the
+        non-updated custom model."`
+        In both cases, the request succeeds despite the warnings.
         """
         self.results = results
         self.result_index = result_index
@@ -3544,16 +4258,20 @@ class SupportedFeatures(object):
     """
     SupportedFeatures.
 
-    :attr bool custom_language_model: Indicates whether the customization interface can be used to create a custom language model based on the language model.
-    :attr bool speaker_labels: Indicates whether the `speaker_labels` parameter can be used with the language model.
+    :attr bool custom_language_model: Indicates whether the customization interface can be
+    used to create a custom language model based on the language model.
+    :attr bool speaker_labels: Indicates whether the `speaker_labels` parameter can be
+    used with the language model.
     """
 
     def __init__(self, custom_language_model, speaker_labels):
         """
         Initialize a SupportedFeatures object.
 
-        :param bool custom_language_model: Indicates whether the customization interface can be used to create a custom language model based on the language model.
-        :param bool speaker_labels: Indicates whether the `speaker_labels` parameter can be used with the language model.
+        :param bool custom_language_model: Indicates whether the customization interface
+        can be used to create a custom language model based on the language model.
+        :param bool speaker_labels: Indicates whether the `speaker_labels` parameter can
+        be used with the language model.
         """
         self.custom_language_model = custom_language_model
         self.speaker_labels = speaker_labels
@@ -3605,12 +4323,28 @@ class Word(object):
     """
     Word.
 
-    :attr str word: A word from the custom model's words resource. The spelling of the word is used to train the model.
-    :attr list[str] sounds_like: An array of pronunciations for the word. The array can include the sounds-like pronunciation automatically generated by the service if none is provided for the word; the service adds this pronunciation when it finishes processing the word.
-    :attr str display_as: The spelling of the word that the service uses to display the word in a transcript. The field contains an empty string if no display-as value is provided for the word, in which case the word is displayed as it is spelled.
-    :attr int count: A sum of the number of times the word is found across all corpora. For example, if the word occurs five times in one corpus and seven times in another, its count is `12`. If you add a custom word to a model before it is added by any corpora, the count begins at `1`; if the word is added from a corpus first and later modified, the count reflects only the number of times it is found in corpora.
-    :attr list[str] source: An array of sources that describes how the word was added to the custom model's words resource. For OOV words added from a corpus, includes the name of the corpus; if the word was added by multiple corpora, the names of all corpora are listed. If the word was modified or added by the user directly, the field includes the string `user`.
-    :attr list[WordError] error: (optional) If the service discovered one or more problems that you need to correct for the word's definition, an array that describes each of the errors.
+    :attr str word: A word from the custom model's words resource. The spelling of the
+    word is used to train the model.
+    :attr list[str] sounds_like: An array of pronunciations for the word. The array can
+    include the sounds-like pronunciation automatically generated by the service if none
+    is provided for the word; the service adds this pronunciation when it finishes
+    processing the word.
+    :attr str display_as: The spelling of the word that the service uses to display the
+    word in a transcript. The field contains an empty string if no display-as value is
+    provided for the word, in which case the word is displayed as it is spelled.
+    :attr int count: A sum of the number of times the word is found across all corpora.
+    For example, if the word occurs five times in one corpus and seven times in another,
+    its count is `12`. If you add a custom word to a model before it is added by any
+    corpora, the count begins at `1`; if the word is added from a corpus first and later
+    modified, the count reflects only the number of times it is found in corpora.
+    :attr list[str] source: An array of sources that describes how the word was added to
+    the custom model's words resource. For OOV words added from a corpus, includes the
+    name of the corpus; if the word was added by multiple corpora, the names of all
+    corpora are listed. If the word was modified or added by the user directly, the field
+    includes the string `user`.
+    :attr list[WordError] error: (optional) If the service discovered one or more problems
+    that you need to correct for the word's definition, an array that describes each of
+    the errors.
     """
 
     def __init__(self, word, sounds_like, display_as, count, source,
@@ -3618,12 +4352,30 @@ class Word(object):
         """
         Initialize a Word object.
 
-        :param str word: A word from the custom model's words resource. The spelling of the word is used to train the model.
-        :param list[str] sounds_like: An array of pronunciations for the word. The array can include the sounds-like pronunciation automatically generated by the service if none is provided for the word; the service adds this pronunciation when it finishes processing the word.
-        :param str display_as: The spelling of the word that the service uses to display the word in a transcript. The field contains an empty string if no display-as value is provided for the word, in which case the word is displayed as it is spelled.
-        :param int count: A sum of the number of times the word is found across all corpora. For example, if the word occurs five times in one corpus and seven times in another, its count is `12`. If you add a custom word to a model before it is added by any corpora, the count begins at `1`; if the word is added from a corpus first and later modified, the count reflects only the number of times it is found in corpora.
-        :param list[str] source: An array of sources that describes how the word was added to the custom model's words resource. For OOV words added from a corpus, includes the name of the corpus; if the word was added by multiple corpora, the names of all corpora are listed. If the word was modified or added by the user directly, the field includes the string `user`.
-        :param list[WordError] error: (optional) If the service discovered one or more problems that you need to correct for the word's definition, an array that describes each of the errors.
+        :param str word: A word from the custom model's words resource. The spelling of
+        the word is used to train the model.
+        :param list[str] sounds_like: An array of pronunciations for the word. The array
+        can include the sounds-like pronunciation automatically generated by the service
+        if none is provided for the word; the service adds this pronunciation when it
+        finishes processing the word.
+        :param str display_as: The spelling of the word that the service uses to display
+        the word in a transcript. The field contains an empty string if no display-as
+        value is provided for the word, in which case the word is displayed as it is
+        spelled.
+        :param int count: A sum of the number of times the word is found across all
+        corpora. For example, if the word occurs five times in one corpus and seven times
+        in another, its count is `12`. If you add a custom word to a model before it is
+        added by any corpora, the count begins at `1`; if the word is added from a corpus
+        first and later modified, the count reflects only the number of times it is found
+        in corpora.
+        :param list[str] source: An array of sources that describes how the word was added
+        to the custom model's words resource. For OOV words added from a corpus, includes
+        the name of the corpus; if the word was added by multiple corpora, the names of
+        all corpora are listed. If the word was modified or added by the user directly,
+        the field includes the string `user`.
+        :param list[WordError] error: (optional) If the service discovered one or more
+        problems that you need to correct for the word's definition, an array that
+        describes each of the errors.
         """
         self.word = word
         self.sounds_like = sounds_like
@@ -3703,7 +4455,8 @@ class WordAlternativeResult(object):
     """
     WordAlternativeResult.
 
-    :attr float confidence: A confidence score for the word alternative hypothesis in the range of 0 to 1.
+    :attr float confidence: A confidence score for the word alternative hypothesis in the
+    range of 0 to 1.
     :attr str word: An alternative hypothesis for a word from the input audio.
     """
 
@@ -3711,7 +4464,8 @@ class WordAlternativeResult(object):
         """
         Initialize a WordAlternativeResult object.
 
-        :param float confidence: A confidence score for the word alternative hypothesis in the range of 0 to 1.
+        :param float confidence: A confidence score for the word alternative hypothesis in
+        the range of 0 to 1.
         :param str word: An alternative hypothesis for a word from the input audio.
         """
         self.confidence = confidence
@@ -3763,18 +4517,24 @@ class WordAlternativeResults(object):
     """
     WordAlternativeResults.
 
-    :attr float start_time: The start time in seconds of the word from the input audio that corresponds to the word alternatives.
-    :attr float end_time: The end time in seconds of the word from the input audio that corresponds to the word alternatives.
-    :attr list[WordAlternativeResult] alternatives: An array of alternative hypotheses for a word from the input audio.
+    :attr float start_time: The start time in seconds of the word from the input audio
+    that corresponds to the word alternatives.
+    :attr float end_time: The end time in seconds of the word from the input audio that
+    corresponds to the word alternatives.
+    :attr list[WordAlternativeResult] alternatives: An array of alternative hypotheses for
+    a word from the input audio.
     """
 
     def __init__(self, start_time, end_time, alternatives):
         """
         Initialize a WordAlternativeResults object.
 
-        :param float start_time: The start time in seconds of the word from the input audio that corresponds to the word alternatives.
-        :param float end_time: The end time in seconds of the word from the input audio that corresponds to the word alternatives.
-        :param list[WordAlternativeResult] alternatives: An array of alternative hypotheses for a word from the input audio.
+        :param float start_time: The start time in seconds of the word from the input
+        audio that corresponds to the word alternatives.
+        :param float end_time: The end time in seconds of the word from the input audio
+        that corresponds to the word alternatives.
+        :param list[WordAlternativeResult] alternatives: An array of alternative
+        hypotheses for a word from the input audio.
         """
         self.start_time = start_time
         self.end_time = end_time
@@ -3837,14 +4597,26 @@ class WordError(object):
     """
     WordError.
 
-    :attr str element: A key-value pair that describes an error associated with the definition of a word in the words resource. Each pair has the format `"element": "message"`, where `element` is the aspect of the definition that caused the problem and `message` describes the problem. The following example describes a problem with one of the word's sounds-like definitions: `"{sounds_like_string}": "Numbers are not allowed in sounds-like. You can try for example '{suggested_string}'."` You must correct the error before you can train the model.
+    :attr str element: A key-value pair that describes an error associated with the
+    definition of a word in the words resource. Each pair has the format `"element":
+    "message"`, where `element` is the aspect of the definition that caused the problem
+    and `message` describes the problem. The following example describes a problem with
+    one of the word's sounds-like definitions: `"{sounds_like_string}": "Numbers are not
+    allowed in sounds-like. You can try for example '{suggested_string}'."` You must
+    correct the error before you can train the model.
     """
 
     def __init__(self, element):
         """
         Initialize a WordError object.
 
-        :param str element: A key-value pair that describes an error associated with the definition of a word in the words resource. Each pair has the format `"element": "message"`, where `element` is the aspect of the definition that caused the problem and `message` describes the problem. The following example describes a problem with one of the word's sounds-like definitions: `"{sounds_like_string}": "Numbers are not allowed in sounds-like. You can try for example '{suggested_string}'."` You must correct the error before you can train the model.
+        :param str element: A key-value pair that describes an error associated with the
+        definition of a word in the words resource. Each pair has the format `"element":
+        "message"`, where `element` is the aspect of the definition that caused the
+        problem and `message` describes the problem. The following example describes a
+        problem with one of the word's sounds-like definitions: `"{sounds_like_string}":
+        "Numbers are not allowed in sounds-like. You can try for example
+        '{suggested_string}'."` You must correct the error before you can train the model.
         """
         self.element = element
 
@@ -3885,14 +4657,18 @@ class Words(object):
     """
     Words.
 
-    :attr list[Word] words: Information about each word in the custom model's words resource. The array is empty if the custom model has no words.
+    :attr list[Word] words: An array of objects that provides information about each word
+    in the custom model's words resource. The array is empty if the custom model has no
+    words.
     """
 
     def __init__(self, words):
         """
         Initialize a Words object.
 
-        :param list[Word] words: Information about each word in the custom model's words resource. The array is empty if the custom model has no words.
+        :param list[Word] words: An array of objects that provides information about each
+        word in the custom model's words resource. The array is empty if the custom model
+        has no words.
         """
         self.words = words
 
@@ -3901,7 +4677,7 @@ class Words(object):
         """Initialize a Words object from a json dictionary."""
         args = {}
         if 'words' in _dict:
-            args['words'] = [Word._from_dict(x) for x in _dict.get('words')]
+            args['words'] = [Word._from_dict(x) for x in (_dict.get('words'))]
         else:
             raise ValueError(
                 'Required property \'words\' not present in Words JSON')

--- a/watson_developer_cloud/text_to_speech_v1.py
+++ b/watson_developer_cloud/text_to_speech_v1.py
@@ -66,7 +66,6 @@ from __future__ import absolute_import
 
 import json
 from .watson_service import WatsonService
-from .utils import deprecated
 
 ##############################################################################
 # Service
@@ -144,7 +143,11 @@ class TextToSpeechV1(WatsonService):
         information about all available voices, use the **List voices** method.
 
         :param str voice: The voice for which information is to be returned.
-        :param str customization_id: The customization ID (GUID) of a custom voice model for which information is to be returned. You must make the request with service credentials created for the instance of the service that owns the custom model. Omit the parameter to see information about the specified voice with no customization.
+        :param str customization_id: The customization ID (GUID) of a custom voice model
+        for which information is to be returned. You must make the request with service
+        credentials created for the instance of the service that owns the custom model.
+        Omit the parameter to see information about the specified voice with no
+        customization.
         :param dict headers: A `dict` containing the request headers
         :return: A `dict` containing the `Voice` response.
         :rtype: dict
@@ -184,10 +187,6 @@ class TextToSpeechV1(WatsonService):
             method='GET', url=url, headers=headers, accept_json=True)
         return response
 
-    @deprecated('Use list_voices() instead')
-    def voices(self):
-        return self.list_voices()
-
     #########################
     # Synthesis
     #########################
@@ -208,8 +207,7 @@ class TextToSpeechV1(WatsonService):
         information about the supported audio formats and sampling rates, see [Specifying
         an audio
         format](https://console.bluemix.net/docs/services/text-to-speech/http.html#format).
-        Specify a value of `application/json` for the `Content-Type` header.   If a
-        request includes invalid query parameters, the service returns a `Warnings`
+        If a request includes invalid query parameters, the service returns a `Warnings`
         response header that provides messages about the invalid parameters. The warning
         includes a descriptive message and a list of invalid argument strings. For
         example, a message such as `\"Unknown arguments:\"` or `\"Unknown url query
@@ -217,9 +215,20 @@ class TextToSpeechV1(WatsonService):
         The request succeeds despite the warnings.
 
         :param str text: The text to synthesize.
-        :param str accept: The type of the response: audio/basic, audio/flac, audio/l16;rate=nnnn, audio/ogg, audio/ogg;codecs=opus, audio/ogg;codecs=vorbis, audio/mp3, audio/mpeg, audio/mulaw;rate=nnnn, audio/wav, audio/webm, audio/webm;codecs=opus, or audio/webm;codecs=vorbis.
+        :param str accept: The requested audio format (MIME type) of the audio. You can
+        use the `Accept` header or the `accept` query parameter to specify the audio
+        format. (For the `audio/l16` format, you can optionally specify
+        `endianness=big-endian` or `endianness=little-endian`; the default is little
+        endian.) For detailed information about the supported audio formats and sampling
+        rates, see [Specifying an audio
+        format](https://console.bluemix.net/docs/services/text-to-speech/http.html#format).
         :param str voice: The voice to use for synthesis.
-        :param str customization_id: The customization ID (GUID) of a custom voice model to use for the synthesis. If a custom voice model is specified, it is guaranteed to work only if it matches the language of the indicated voice. You must make the request with service credentials created for the instance of the service that owns the custom model. Omit the parameter to use the specified voice with no customization.
+        :param str customization_id: The customization ID (GUID) of a custom voice model
+        to use for the synthesis. If a custom voice model is specified, it is guaranteed
+        to work only if it matches the language of the indicated voice. You must make the
+        request with service credentials created for the instance of the service that owns
+        the custom model. Omit the parameter to use the specified voice with no
+        customization.
         :param dict headers: A `dict` containing the request headers
         :return: A `Response <Response>` object representing the response.
         :rtype: requests.models.Response
@@ -261,9 +270,18 @@ class TextToSpeechV1(WatsonService):
         **Note:** This method is currently a beta release.
 
         :param str text: The word for which the pronunciation is requested.
-        :param str voice: A voice that specifies the language in which the pronunciation is to be returned. All voices for the same language (for example, `en-US`) return the same translation.
-        :param str format: The phoneme format in which to return the pronunciation. Omit the parameter to obtain the pronunciation in the default format.
-        :param str customization_id: The customization ID (GUID) of a custom voice model for which the pronunciation is to be returned. The language of a specified custom model must match the language of the specified voice. If the word is not defined in the specified custom model, the service returns the default translation for the custom model's language. You must make the request with service credentials created for the instance of the service that owns the custom model. Omit the parameter to see the translation for the specified voice with no customization.
+        :param str voice: A voice that specifies the language in which the pronunciation
+        is to be returned. All voices for the same language (for example, `en-US`) return
+        the same translation.
+        :param str format: The phoneme format in which to return the pronunciation. Omit
+        the parameter to obtain the pronunciation in the default format.
+        :param str customization_id: The customization ID (GUID) of a custom voice model
+        for which the pronunciation is to be returned. The language of a specified custom
+        model must match the language of the specified voice. If the word is not defined
+        in the specified custom model, the service returns the default translation for the
+        custom model's language. You must make the request with service credentials
+        created for the instance of the service that owns the custom model. Omit the
+        parameter to see the translation for the specified voice with no customization.
         :param dict headers: A `dict` containing the request headers
         :return: A `dict` containing the `Pronunciation` response.
         :rtype: dict
@@ -288,10 +306,6 @@ class TextToSpeechV1(WatsonService):
             accept_json=True)
         return response
 
-    @deprecated('Use get_pronunciation() instead')
-    def pronunciation(self, text, voice=None, pronunciation_format='ipa'):
-        return self.get_pronunciation(text, voice, pronunciation_format)
-
     #########################
     # Custom models
     #########################
@@ -306,13 +320,15 @@ class TextToSpeechV1(WatsonService):
 
         Creates a new empty custom voice model. You must specify a name for the new custom
         model. You can optionally specify the language and a description for the new
-        model. Specify a value of `application/json` for the `Content-Type` header. The
-        model is owned by the instance of the service whose credentials are used to create
-        it.  **Note:** This method is currently a beta release.
+        model. The model is owned by the instance of the service whose credentials are
+        used to create it.
+        **Note:** This method is currently a beta release.
 
         :param str name: The name of the new custom voice model.
-        :param str language: The language of the new custom voice model. Omit the parameter to use the the default language, `en-US`.
-        :param str description: A description of the new custom voice model. Specifying a description is recommended.
+        :param str language: The language of the new custom voice model. Omit the
+        parameter to use the the default language, `en-US`.
+        :param str description: A description of the new custom voice model. Specifying a
+        description is recommended.
         :param dict headers: A `dict` containing the request headers
         :return: A `dict` containing the `VoiceModel` response.
         :rtype: dict
@@ -332,19 +348,17 @@ class TextToSpeechV1(WatsonService):
             accept_json=True)
         return response
 
-    @deprecated('Use create_voice_model() instead.')
-    def create_customization(self, name, language=None, description=None):
-        return self.create_voice_model(name, language, description)
-
     def delete_voice_model(self, customization_id, **kwargs):
         """
         Delete a custom model.
 
         Deletes the specified custom voice model. You must use credentials for the
-        instance of the service that owns a model to delete it.  **Note:** This method is
-        currently a beta release.
+        instance of the service that owns a model to delete it.
+        **Note:** This method is currently a beta release.
 
-        :param str customization_id: The customization ID (GUID) of the custom voice model. You must make the request with service credentials created for the instance of the service that owns the custom model.
+        :param str customization_id: The customization ID (GUID) of the custom voice
+        model. You must make the request with service credentials created for the instance
+        of the service that owns the custom model.
         :param dict headers: A `dict` containing the request headers
         :rtype: None
         """
@@ -359,10 +373,6 @@ class TextToSpeechV1(WatsonService):
             method='DELETE', url=url, headers=headers, accept_json=True)
         return None
 
-    @deprecated('Use delete_voice_model() instead.')
-    def delete_customization(self, customization_id):
-        return self.delete_voice_model(customization_id)
-
     def get_voice_model(self, customization_id, **kwargs):
         """
         Get a custom model.
@@ -370,10 +380,12 @@ class TextToSpeechV1(WatsonService):
         Gets all information about a specified custom voice model. In addition to metadata
         such as the name and description of the voice model, the output includes the words
         and their translations as defined in the model. To see just the metadata for a
-        voice model, use the **List custom models** method.   **Note:** This method is
-        currently a beta release.
+        voice model, use the **List custom models** method.
+        **Note:** This method is currently a beta release.
 
-        :param str customization_id: The customization ID (GUID) of the custom voice model. You must make the request with service credentials created for the instance of the service that owns the custom model.
+        :param str customization_id: The customization ID (GUID) of the custom voice
+        model. You must make the request with service credentials created for the instance
+        of the service that owns the custom model.
         :param dict headers: A `dict` containing the request headers
         :return: A `dict` containing the `VoiceModel` response.
         :rtype: dict
@@ -389,10 +401,6 @@ class TextToSpeechV1(WatsonService):
             method='GET', url=url, headers=headers, accept_json=True)
         return response
 
-    @deprecated('Use get_voice_model instead.')
-    def get_customization(self, customization_id):
-        return self.get_voice_model(customization_id)
-
     def list_voice_models(self, language=None, **kwargs):
         """
         List custom models.
@@ -402,9 +410,12 @@ class TextToSpeechV1(WatsonService):
         models for that language only. To see the words in addition to the metadata for a
         specific voice model, use the **List a custom model** method. You must use
         credentials for the instance of the service that owns a model to list information
-        about it.  **Note:** This method is currently a beta release.
+        about it.
+        **Note:** This method is currently a beta release.
 
-        :param str language: The language for which custom voice models that are owned by the requesting service credentials are to be returned. Omit the parameter to see all custom voice models that are owned by the requester.
+        :param str language: The language for which custom voice models that are owned by
+        the requesting service credentials are to be returned. Omit the parameter to see
+        all custom voice models that are owned by the requester.
         :param dict headers: A `dict` containing the request headers
         :return: A `dict` containing the `VoiceModels` response.
         :rtype: dict
@@ -422,10 +433,6 @@ class TextToSpeechV1(WatsonService):
             accept_json=True)
         return response
 
-    @deprecated('Use list_voice_models() instead.')
-    def customizations(self, language=None):
-        return self.list_voice_models(language)
-
     def update_voice_model(self,
                            customization_id,
                            name=None,
@@ -439,15 +446,18 @@ class TextToSpeechV1(WatsonService):
         such as the name and description of the voice model. You can also update the words
         in the model and their translations. Adding a new translation for a word that
         already exists in a custom model overwrites the word's existing translation. A
-        custom model can contain no more than 20,000 entries. Specify a value of
-        `application/json` for the `Content-Type` header. You must use credentials for the
-        instance of the service that owns a model to update it.  **Note:** This method is
-        currently a beta release.
+        custom model can contain no more than 20,000 entries. You must use credentials for
+        the instance of the service that owns a model to update it.
+        **Note:** This method is currently a beta release.
 
-        :param str customization_id: The customization ID (GUID) of the custom voice model. You must make the request with service credentials created for the instance of the service that owns the custom model.
+        :param str customization_id: The customization ID (GUID) of the custom voice
+        model. You must make the request with service credentials created for the instance
+        of the service that owns the custom model.
         :param str name: A new name for the custom voice model.
         :param str description: A new description for the custom voice model.
-        :param list[Word] words: An array of `Word` objects that provides the words and their translations that are to be added or updated for the custom voice model. Pass an empty array to make no additions or updates.
+        :param list[Word] words: An array of `Word` objects that provides the words and
+        their translations that are to be added or updated for the custom voice model.
+        Pass an empty array to make no additions or updates.
         :param dict headers: A `dict` containing the request headers
         :rtype: None
         """
@@ -469,11 +479,6 @@ class TextToSpeechV1(WatsonService):
             accept_json=True)
         return None
 
-    @deprecated('Use update_voice_model() instead')
-    def update_customization(self, customization_id, name=None,
-                             description=None, words=None):
-        return self.update_voice_model(customization_id, name, description, words)
-
     #########################
     # Custom words
     #########################
@@ -490,14 +495,25 @@ class TextToSpeechV1(WatsonService):
         Adds a single word and its translation to the specified custom voice model. Adding
         a new translation for a word that already exists in a custom model overwrites the
         word's existing translation. A custom model can contain no more than 20,000
-        entries. Specify a value of `application/json` for the `Content-Type` header. You
-        must use credentials for the instance of the service that owns a model to add a
-        word to it.   **Note:** This method is currently a beta release.
+        entries. You must use credentials for the instance of the service that owns a
+        model to add a word to it.
+        **Note:** This method is currently a beta release.
 
-        :param str customization_id: The customization ID (GUID) of the custom voice model. You must make the request with service credentials created for the instance of the service that owns the custom model.
-        :param str word: The word that is to be added or updated for the custom voice model.
-        :param str translation: The phonetic or sounds-like translation for the word. A phonetic translation is based on the SSML format for representing the phonetic string of a word either as an IPA translation or as an IBM SPR translation. A sounds-like is one or more words that, when combined, sound like the word.
-        :param str part_of_speech: **Japanese only.** The part of speech for the word. The service uses the value to produce the correct intonation for the word. You can create only a single entry, with or without a single part of speech, for any word; you cannot create multiple entries with different parts of speech for the same word. For more information, see [Working with Japanese entries](https://console.bluemix.net/docs/services/text-to-speech/custom-rules.html#jaNotes).
+        :param str customization_id: The customization ID (GUID) of the custom voice
+        model. You must make the request with service credentials created for the instance
+        of the service that owns the custom model.
+        :param str word: The word that is to be added or updated for the custom voice
+        model.
+        :param str translation: The phonetic or sounds-like translation for the word. A
+        phonetic translation is based on the SSML format for representing the phonetic
+        string of a word either as an IPA translation or as an IBM SPR translation. A
+        sounds-like is one or more words that, when combined, sound like the word.
+        :param str part_of_speech: **Japanese only.** The part of speech for the word. The
+        service uses the value to produce the correct intonation for the word. You can
+        create only a single entry, with or without a single part of speech, for any word;
+        you cannot create multiple entries with different parts of speech for the same
+        word. For more information, see [Working with Japanese
+        entries](https://console.bluemix.net/docs/services/text-to-speech/custom-rules.html#jaNotes).
         :param dict headers: A `dict` containing the request headers
         :rtype: None
         """
@@ -521,10 +537,6 @@ class TextToSpeechV1(WatsonService):
             accept_json=True)
         return None
 
-    @deprecated('Use add_word() instead.')
-    def set_customization_word(self, customization_id, word, translation):
-        return self.add_word(customization_id, word, translation)
-
     def add_words(self, customization_id, words, **kwargs):
         """
         Add custom words.
@@ -532,12 +544,20 @@ class TextToSpeechV1(WatsonService):
         Adds one or more words and their translations to the specified custom voice model.
         Adding a new translation for a word that already exists in a custom model
         overwrites the word's existing translation. A custom model can contain no more
-        than 20,000 entries. Specify a value of `application/json` for the `Content-Type`
-        header. You must use credentials for the instance of the service that owns a model
-        to add words to it.   **Note:** This method is currently a beta release.
+        than 20,000 entries. You must use credentials for the instance of the service that
+        owns a model to add words to it.
+        **Note:** This method is currently a beta release.
 
-        :param str customization_id: The customization ID (GUID) of the custom voice model. You must make the request with service credentials created for the instance of the service that owns the custom model.
-        :param list[Word] words: The **Add custom words** method accepts an array of `Word` objects. Each object provides a word that is to be added or updated for the custom voice model and the word's translation.   The **List custom words** method returns an array of `Word` objects. Each object shows a word and its translation from the custom voice model. The words are listed in alphabetical order, with uppercase letters listed before lowercase letters. The array is empty if the custom model contains no words.
+        :param str customization_id: The customization ID (GUID) of the custom voice
+        model. You must make the request with service credentials created for the instance
+        of the service that owns the custom model.
+        :param list[Word] words: The **Add custom words** method accepts an array of
+        `Word` objects. Each object provides a word that is to be added or updated for the
+        custom voice model and the word's translation.
+        The **List custom words** method returns an array of `Word` objects. Each object
+        shows a word and its translation from the custom voice model. The words are listed
+        in alphabetical order, with uppercase letters listed before lowercase letters. The
+        array is empty if the custom model contains no words.
         :param dict headers: A `dict` containing the request headers
         :rtype: None
         """
@@ -560,19 +580,17 @@ class TextToSpeechV1(WatsonService):
             accept_json=True)
         return None
 
-    @deprecated('Use add_words() instead.')
-    def add_customization_words(self, customization_id, words):
-        return self.add_words(customization_id, words)
-
     def delete_word(self, customization_id, word, **kwargs):
         """
         Delete a custom word.
 
         Deletes a single word from the specified custom voice model. You must use
         credentials for the instance of the service that owns a model to delete its words.
-          **Note:** This method is currently a beta release.
+        **Note:** This method is currently a beta release.
 
-        :param str customization_id: The customization ID (GUID) of the custom voice model. You must make the request with service credentials created for the instance of the service that owns the custom model.
+        :param str customization_id: The customization ID (GUID) of the custom voice
+        model. You must make the request with service credentials created for the instance
+        of the service that owns the custom model.
         :param str word: The word that is to be deleted from the custom voice model.
         :param dict headers: A `dict` containing the request headers
         :rtype: None
@@ -590,20 +608,18 @@ class TextToSpeechV1(WatsonService):
             method='DELETE', url=url, headers=headers, accept_json=True)
         return None
 
-    @deprecated('Use delete_word() instead.')
-    def delete_customization_word(self, customization_id, word):
-        return self.delete_word(customization_id, word)
-
     def get_word(self, customization_id, word, **kwargs):
         """
         Get a custom word.
 
         Gets the translation for a single word from the specified custom model. The output
         shows the translation as it is defined in the model. You must use credentials for
-        the instance of the service that owns a model to list its words.   **Note:** This
-        method is currently a beta release.
+        the instance of the service that owns a model to list its words.
+        **Note:** This method is currently a beta release.
 
-        :param str customization_id: The customization ID (GUID) of the custom voice model. You must make the request with service credentials created for the instance of the service that owns the custom model.
+        :param str customization_id: The customization ID (GUID) of the custom voice
+        model. You must make the request with service credentials created for the instance
+        of the service that owns the custom model.
         :param str word: The word that is to be queried from the custom voice model.
         :param dict headers: A `dict` containing the request headers
         :return: A `dict` containing the `Translation` response.
@@ -622,10 +638,6 @@ class TextToSpeechV1(WatsonService):
             method='GET', url=url, headers=headers, accept_json=True)
         return response
 
-    @deprecated('Use get_word() instead.')
-    def get_customization_word(self, customization_id, word):
-        return self.get_word(customization_id, word)
-
     def list_words(self, customization_id, **kwargs):
         """
         List custom words.
@@ -633,9 +645,12 @@ class TextToSpeechV1(WatsonService):
         Lists all of the words and their translations for the specified custom voice
         model. The output shows the translations as they are defined in the model. You
         must use credentials for the instance of the service that owns a model to list its
-        words.  **Note:** This method is currently a beta release.
+        words.
+        **Note:** This method is currently a beta release.
 
-        :param str customization_id: The customization ID (GUID) of the custom voice model. You must make the request with service credentials created for the instance of the service that owns the custom model.
+        :param str customization_id: The customization ID (GUID) of the custom voice
+        model. You must make the request with service credentials created for the instance
+        of the service that owns the custom model.
         :param dict headers: A `dict` containing the request headers
         :return: A `dict` containing the `Words` response.
         :rtype: dict
@@ -651,10 +666,6 @@ class TextToSpeechV1(WatsonService):
             method='GET', url=url, headers=headers, accept_json=True)
         return response
 
-    @deprecated('Use list_words() instead.')
-    def get_customization_words(self, customization_id):
-        return self.list_words(customization_id)
-
     #########################
     # User data
     #########################
@@ -667,10 +678,10 @@ class TextToSpeechV1(WatsonService):
         deletes all data for the customer ID, regardless of the method by which the
         information was added. The method has no effect if no data is associated with the
         customer ID. You must issue the request with credentials for the same instance of
-        the service that was used to associate the customer ID with the data.   You
-        associate a customer ID with data by passing the `X-Watson-Metadata` header with a
-        request that passes the data. For more information about customer IDs and about
-        using this method, see [Information
+        the service that was used to associate the customer ID with the data.
+        You associate a customer ID with data by passing the `X-Watson-Metadata` header
+        with a request that passes the data. For more information about customer IDs and
+        about using this method, see [Information
         security](https://console.bluemix.net/docs/services/text-to-speech/information-security.html).
 
         :param str customer_id: The customer ID for which all data is to be deleted.
@@ -702,14 +713,18 @@ class Pronunciation(object):
     """
     Pronunciation.
 
-    :attr str pronunciation: The pronunciation of the specified text in the requested voice and format. If a custom voice model is specified, the pronunciation also reflects that custom voice.
+    :attr str pronunciation: The pronunciation of the specified text in the requested
+    voice and format. If a custom voice model is specified, the pronunciation also
+    reflects that custom voice.
     """
 
     def __init__(self, pronunciation):
         """
         Initialize a Pronunciation object.
 
-        :param str pronunciation: The pronunciation of the specified text in the requested voice and format. If a custom voice model is specified, the pronunciation also reflects that custom voice.
+        :param str pronunciation: The pronunciation of the specified text in the requested
+        voice and format. If a custom voice model is specified, the pronunciation also
+        reflects that custom voice.
         """
         self.pronunciation = pronunciation
 
@@ -751,16 +766,22 @@ class SupportedFeatures(object):
     """
     SupportedFeatures.
 
-    :attr bool custom_pronunciation: If `true`, the voice can be customized; if `false`, the voice cannot be customized. (Same as `customizable`.).
-    :attr bool voice_transformation: If `true`, the voice can be transformed by using the SSML &lt;voice-transformation&gt; element; if `false`, the voice cannot be transformed.
+    :attr bool custom_pronunciation: If `true`, the voice can be customized; if `false`,
+    the voice cannot be customized. (Same as `customizable`.).
+    :attr bool voice_transformation: If `true`, the voice can be transformed by using the
+    SSML &lt;voice-transformation&gt; element; if `false`, the voice cannot be
+    transformed.
     """
 
     def __init__(self, custom_pronunciation, voice_transformation):
         """
         Initialize a SupportedFeatures object.
 
-        :param bool custom_pronunciation: If `true`, the voice can be customized; if `false`, the voice cannot be customized. (Same as `customizable`.).
-        :param bool voice_transformation: If `true`, the voice can be transformed by using the SSML &lt;voice-transformation&gt; element; if `false`, the voice cannot be transformed.
+        :param bool custom_pronunciation: If `true`, the voice can be customized; if
+        `false`, the voice cannot be customized. (Same as `customizable`.).
+        :param bool voice_transformation: If `true`, the voice can be transformed by using
+        the SSML &lt;voice-transformation&gt; element; if `false`, the voice cannot be
+        transformed.
         """
         self.custom_pronunciation = custom_pronunciation
         self.voice_transformation = voice_transformation
@@ -787,10 +808,10 @@ class SupportedFeatures(object):
         """Return a json dictionary representing this model."""
         _dict = {}
         if hasattr(self, 'custom_pronunciation'
-                  ) and self.custom_pronunciation is not None:
+                   ) and self.custom_pronunciation is not None:
             _dict['custom_pronunciation'] = self.custom_pronunciation
         if hasattr(self, 'voice_transformation'
-                  ) and self.voice_transformation is not None:
+                   ) and self.voice_transformation is not None:
             _dict['voice_transformation'] = self.voice_transformation
         return _dict
 
@@ -813,16 +834,32 @@ class Translation(object):
     """
     Translation.
 
-    :attr str translation: The phonetic or sounds-like translation for the word. A phonetic translation is based on the SSML format for representing the phonetic string of a word either as an IPA translation or as an IBM SPR translation. A sounds-like is one or more words that, when combined, sound like the word.
-    :attr str part_of_speech: (optional) **Japanese only.** The part of speech for the word. The service uses the value to produce the correct intonation for the word. You can create only a single entry, with or without a single part of speech, for any word; you cannot create multiple entries with different parts of speech for the same word. For more information, see [Working with Japanese entries](https://console.bluemix.net/docs/services/text-to-speech/custom-rules.html#jaNotes).
+    :attr str translation: The phonetic or sounds-like translation for the word. A
+    phonetic translation is based on the SSML format for representing the phonetic string
+    of a word either as an IPA translation or as an IBM SPR translation. A sounds-like is
+    one or more words that, when combined, sound like the word.
+    :attr str part_of_speech: (optional) **Japanese only.** The part of speech for the
+    word. The service uses the value to produce the correct intonation for the word. You
+    can create only a single entry, with or without a single part of speech, for any word;
+    you cannot create multiple entries with different parts of speech for the same word.
+    For more information, see [Working with Japanese
+    entries](https://console.bluemix.net/docs/services/text-to-speech/custom-rules.html#jaNotes).
     """
 
     def __init__(self, translation, part_of_speech=None):
         """
         Initialize a Translation object.
 
-        :param str translation: The phonetic or sounds-like translation for the word. A phonetic translation is based on the SSML format for representing the phonetic string of a word either as an IPA translation or as an IBM SPR translation. A sounds-like is one or more words that, when combined, sound like the word.
-        :param str part_of_speech: (optional) **Japanese only.** The part of speech for the word. The service uses the value to produce the correct intonation for the word. You can create only a single entry, with or without a single part of speech, for any word; you cannot create multiple entries with different parts of speech for the same word. For more information, see [Working with Japanese entries](https://console.bluemix.net/docs/services/text-to-speech/custom-rules.html#jaNotes).
+        :param str translation: The phonetic or sounds-like translation for the word. A
+        phonetic translation is based on the SSML format for representing the phonetic
+        string of a word either as an IPA translation or as an IBM SPR translation. A
+        sounds-like is one or more words that, when combined, sound like the word.
+        :param str part_of_speech: (optional) **Japanese only.** The part of speech for
+        the word. The service uses the value to produce the correct intonation for the
+        word. You can create only a single entry, with or without a single part of speech,
+        for any word; you cannot create multiple entries with different parts of speech
+        for the same word. For more information, see [Working with Japanese
+        entries](https://console.bluemix.net/docs/services/text-to-speech/custom-rules.html#jaNotes).
         """
         self.translation = translation
         self.part_of_speech = part_of_speech
@@ -871,12 +908,18 @@ class Voice(object):
 
     :attr str url: The URI of the voice.
     :attr str gender: The gender of the voice: `male` or `female`.
-    :attr str name: The name of the voice. Use this as the voice identifier in all requests.
+    :attr str name: The name of the voice. Use this as the voice identifier in all
+    requests.
     :attr str language: The language and region of the voice (for example, `en-US`).
     :attr str description: A textual description of the voice.
-    :attr bool customizable: If `true`, the voice can be customized; if `false`, the voice cannot be customized. (Same as `custom_pronunciation`; maintained for backward compatibility.).
-    :attr SupportedFeatures supported_features: Describes the additional service features supported with the voice.
-    :attr VoiceModel customization: (optional) Returns information about a specified custom voice model. This field is returned only by the **Get a voice** method and only when you specify the customization ID of a custom voice model.
+    :attr bool customizable: If `true`, the voice can be customized; if `false`, the voice
+    cannot be customized. (Same as `custom_pronunciation`; maintained for backward
+    compatibility.).
+    :attr SupportedFeatures supported_features: Describes the additional service features
+    supported with the voice.
+    :attr VoiceModel customization: (optional) Returns information about a specified
+    custom voice model. This field is returned only by the **Get a voice** method and only
+    when you specify the customization ID of a custom voice model.
     """
 
     def __init__(self,
@@ -893,12 +936,18 @@ class Voice(object):
 
         :param str url: The URI of the voice.
         :param str gender: The gender of the voice: `male` or `female`.
-        :param str name: The name of the voice. Use this as the voice identifier in all requests.
+        :param str name: The name of the voice. Use this as the voice identifier in all
+        requests.
         :param str language: The language and region of the voice (for example, `en-US`).
         :param str description: A textual description of the voice.
-        :param bool customizable: If `true`, the voice can be customized; if `false`, the voice cannot be customized. (Same as `custom_pronunciation`; maintained for backward compatibility.).
-        :param SupportedFeatures supported_features: Describes the additional service features supported with the voice.
-        :param VoiceModel customization: (optional) Returns information about a specified custom voice model. This field is returned only by the **Get a voice** method and only when you specify the customization ID of a custom voice model.
+        :param bool customizable: If `true`, the voice can be customized; if `false`, the
+        voice cannot be customized. (Same as `custom_pronunciation`; maintained for
+        backward compatibility.).
+        :param SupportedFeatures supported_features: Describes the additional service
+        features supported with the voice.
+        :param VoiceModel customization: (optional) Returns information about a specified
+        custom voice model. This field is returned only by the **Get a voice** method and
+        only when you specify the customization ID of a custom voice model.
         """
         self.url = url
         self.gender = gender
@@ -997,14 +1046,27 @@ class VoiceModel(object):
     """
     VoiceModel.
 
-    :attr str customization_id: The customization ID (GUID) of the custom voice model. The **Create a custom model** method returns only this field. It does not not return the other fields of this object.
+    :attr str customization_id: The customization ID (GUID) of the custom voice model. The
+    **Create a custom model** method returns only this field. It does not not return the
+    other fields of this object.
     :attr str name: (optional) The name of the custom voice model.
-    :attr str language: (optional) The language identifier of the custom voice model (for example, `en-US`).
-    :attr str owner: (optional) The GUID of the service credentials for the instance of the service that owns the custom voice model.
-    :attr str created: (optional) The date and time in Coordinated Universal Time (UTC) at which the custom voice model was created. The value is provided in full ISO 8601 format (`YYYY-MM-DDThh:mm:ss.sTZD`).
-    :attr str last_modified: (optional) The date and time in Coordinated Universal Time (UTC) at which the custom voice model was last modified. Equals `created` when a new voice model is first added but has yet to be updated. The value is provided in full ISO 8601 format (`YYYY-MM-DDThh:mm:ss.sTZD`).
+    :attr str language: (optional) The language identifier of the custom voice model (for
+    example, `en-US`).
+    :attr str owner: (optional) The GUID of the service credentials for the instance of
+    the service that owns the custom voice model.
+    :attr str created: (optional) The date and time in Coordinated Universal Time (UTC) at
+    which the custom voice model was created. The value is provided in full ISO 8601
+    format (`YYYY-MM-DDThh:mm:ss.sTZD`).
+    :attr str last_modified: (optional) The date and time in Coordinated Universal Time
+    (UTC) at which the custom voice model was last modified. Equals `created` when a new
+    voice model is first added but has yet to be updated. The value is provided in full
+    ISO 8601 format (`YYYY-MM-DDThh:mm:ss.sTZD`).
     :attr str description: (optional) The description of the custom voice model.
-    :attr list[Word] words: (optional) An array of `Word` objects that lists the words and their translations from the custom voice model. The words are listed in alphabetical order, with uppercase letters listed before lowercase letters. The array is empty if the custom model contains no words. This field is returned only by the **Get a voice** method and only when you specify the customization ID of a custom voice model.
+    :attr list[Word] words: (optional) An array of `Word` objects that lists the words and
+    their translations from the custom voice model. The words are listed in alphabetical
+    order, with uppercase letters listed before lowercase letters. The array is empty if
+    the custom model contains no words. This field is returned only by the **Get a voice**
+    method and only when you specify the customization ID of a custom voice model.
     """
 
     def __init__(self,
@@ -1019,14 +1081,28 @@ class VoiceModel(object):
         """
         Initialize a VoiceModel object.
 
-        :param str customization_id: The customization ID (GUID) of the custom voice model. The **Create a custom model** method returns only this field. It does not not return the other fields of this object.
+        :param str customization_id: The customization ID (GUID) of the custom voice
+        model. The **Create a custom model** method returns only this field. It does not
+        not return the other fields of this object.
         :param str name: (optional) The name of the custom voice model.
-        :param str language: (optional) The language identifier of the custom voice model (for example, `en-US`).
-        :param str owner: (optional) The GUID of the service credentials for the instance of the service that owns the custom voice model.
-        :param str created: (optional) The date and time in Coordinated Universal Time (UTC) at which the custom voice model was created. The value is provided in full ISO 8601 format (`YYYY-MM-DDThh:mm:ss.sTZD`).
-        :param str last_modified: (optional) The date and time in Coordinated Universal Time (UTC) at which the custom voice model was last modified. Equals `created` when a new voice model is first added but has yet to be updated. The value is provided in full ISO 8601 format (`YYYY-MM-DDThh:mm:ss.sTZD`).
+        :param str language: (optional) The language identifier of the custom voice model
+        (for example, `en-US`).
+        :param str owner: (optional) The GUID of the service credentials for the instance
+        of the service that owns the custom voice model.
+        :param str created: (optional) The date and time in Coordinated Universal Time
+        (UTC) at which the custom voice model was created. The value is provided in full
+        ISO 8601 format (`YYYY-MM-DDThh:mm:ss.sTZD`).
+        :param str last_modified: (optional) The date and time in Coordinated Universal
+        Time (UTC) at which the custom voice model was last modified. Equals `created`
+        when a new voice model is first added but has yet to be updated. The value is
+        provided in full ISO 8601 format (`YYYY-MM-DDThh:mm:ss.sTZD`).
         :param str description: (optional) The description of the custom voice model.
-        :param list[Word] words: (optional) An array of `Word` objects that lists the words and their translations from the custom voice model. The words are listed in alphabetical order, with uppercase letters listed before lowercase letters. The array is empty if the custom model contains no words. This field is returned only by the **Get a voice** method and only when you specify the customization ID of a custom voice model.
+        :param list[Word] words: (optional) An array of `Word` objects that lists the
+        words and their translations from the custom voice model. The words are listed in
+        alphabetical order, with uppercase letters listed before lowercase letters. The
+        array is empty if the custom model contains no words. This field is returned only
+        by the **Get a voice** method and only when you specify the customization ID of a
+        custom voice model.
         """
         self.customization_id = customization_id
         self.name = name
@@ -1060,7 +1136,7 @@ class VoiceModel(object):
         if 'description' in _dict:
             args['description'] = _dict.get('description')
         if 'words' in _dict:
-            args['words'] = [Word._from_dict(x) for x in _dict.get('words')]
+            args['words'] = [Word._from_dict(x) for x in (_dict.get('words'))]
         return cls(**args)
 
     def _to_dict(self):
@@ -1104,14 +1180,20 @@ class VoiceModels(object):
     """
     VoiceModels.
 
-    :attr list[VoiceModel] customizations: An array of `VoiceModel` objects that provides information about each available custom voice model. The array is empty if the requesting service credentials own no custom voice models (if no language is specified) or own no custom voice models for the specified language.
+    :attr list[VoiceModel] customizations: An array of `VoiceModel` objects that provides
+    information about each available custom voice model. The array is empty if the
+    requesting service credentials own no custom voice models (if no language is
+    specified) or own no custom voice models for the specified language.
     """
 
     def __init__(self, customizations):
         """
         Initialize a VoiceModels object.
 
-        :param list[VoiceModel] customizations: An array of `VoiceModel` objects that provides information about each available custom voice model. The array is empty if the requesting service credentials own no custom voice models (if no language is specified) or own no custom voice models for the specified language.
+        :param list[VoiceModel] customizations: An array of `VoiceModel` objects that
+        provides information about each available custom voice model. The array is empty
+        if the requesting service credentials own no custom voice models (if no language
+        is specified) or own no custom voice models for the specified language.
         """
         self.customizations = customizations
 
@@ -1208,8 +1290,16 @@ class Word(object):
     Word.
 
     :attr str word: A word from the custom voice model.
-    :attr str translation: The phonetic or sounds-like translation for the word. A phonetic translation is based on the SSML format for representing the phonetic string of a word either as an IPA or IBM SPR translation. A sounds-like translation consists of one or more words that, when combined, sound like the word.
-    :attr str part_of_speech: (optional) **Japanese only.** The part of speech for the word. The service uses the value to produce the correct intonation for the word. You can create only a single entry, with or without a single part of speech, for any word; you cannot create multiple entries with different parts of speech for the same word. For more information, see [Working with Japanese entries](https://console.bluemix.net/docs/services/text-to-speech/custom-rules.html#jaNotes).
+    :attr str translation: The phonetic or sounds-like translation for the word. A
+    phonetic translation is based on the SSML format for representing the phonetic string
+    of a word either as an IPA or IBM SPR translation. A sounds-like translation consists
+    of one or more words that, when combined, sound like the word.
+    :attr str part_of_speech: (optional) **Japanese only.** The part of speech for the
+    word. The service uses the value to produce the correct intonation for the word. You
+    can create only a single entry, with or without a single part of speech, for any word;
+    you cannot create multiple entries with different parts of speech for the same word.
+    For more information, see [Working with Japanese
+    entries](https://console.bluemix.net/docs/services/text-to-speech/custom-rules.html#jaNotes).
     """
 
     def __init__(self, word, translation, part_of_speech=None):
@@ -1217,8 +1307,17 @@ class Word(object):
         Initialize a Word object.
 
         :param str word: A word from the custom voice model.
-        :param str translation: The phonetic or sounds-like translation for the word. A phonetic translation is based on the SSML format for representing the phonetic string of a word either as an IPA or IBM SPR translation. A sounds-like translation consists of one or more words that, when combined, sound like the word.
-        :param str part_of_speech: (optional) **Japanese only.** The part of speech for the word. The service uses the value to produce the correct intonation for the word. You can create only a single entry, with or without a single part of speech, for any word; you cannot create multiple entries with different parts of speech for the same word. For more information, see [Working with Japanese entries](https://console.bluemix.net/docs/services/text-to-speech/custom-rules.html#jaNotes).
+        :param str translation: The phonetic or sounds-like translation for the word. A
+        phonetic translation is based on the SSML format for representing the phonetic
+        string of a word either as an IPA or IBM SPR translation. A sounds-like
+        translation consists of one or more words that, when combined, sound like the
+        word.
+        :param str part_of_speech: (optional) **Japanese only.** The part of speech for
+        the word. The service uses the value to produce the correct intonation for the
+        word. You can create only a single entry, with or without a single part of speech,
+        for any word; you cannot create multiple entries with different parts of speech
+        for the same word. For more information, see [Working with Japanese
+        entries](https://console.bluemix.net/docs/services/text-to-speech/custom-rules.html#jaNotes).
         """
         self.word = word
         self.translation = translation
@@ -1272,14 +1371,26 @@ class Words(object):
     """
     Words.
 
-    :attr list[Word] words: The **Add custom words** method accepts an array of `Word` objects. Each object provides a word that is to be added or updated for the custom voice model and the word's translation.   The **List custom words** method returns an array of `Word` objects. Each object shows a word and its translation from the custom voice model. The words are listed in alphabetical order, with uppercase letters listed before lowercase letters. The array is empty if the custom model contains no words.
+    :attr list[Word] words: The **Add custom words** method accepts an array of `Word`
+    objects. Each object provides a word that is to be added or updated for the custom
+    voice model and the word's translation.
+    The **List custom words** method returns an array of `Word` objects. Each object shows
+    a word and its translation from the custom voice model. The words are listed in
+    alphabetical order, with uppercase letters listed before lowercase letters. The array
+    is empty if the custom model contains no words.
     """
 
     def __init__(self, words):
         """
         Initialize a Words object.
 
-        :param list[Word] words: The **Add custom words** method accepts an array of `Word` objects. Each object provides a word that is to be added or updated for the custom voice model and the word's translation.   The **List custom words** method returns an array of `Word` objects. Each object shows a word and its translation from the custom voice model. The words are listed in alphabetical order, with uppercase letters listed before lowercase letters. The array is empty if the custom model contains no words.
+        :param list[Word] words: The **Add custom words** method accepts an array of
+        `Word` objects. Each object provides a word that is to be added or updated for the
+        custom voice model and the word's translation.
+        The **List custom words** method returns an array of `Word` objects. Each object
+        shows a word and its translation from the custom voice model. The words are listed
+        in alphabetical order, with uppercase letters listed before lowercase letters. The
+        array is empty if the custom model contains no words.
         """
         self.words = words
 
@@ -1288,7 +1399,7 @@ class Words(object):
         """Initialize a Words object from a json dictionary."""
         args = {}
         if 'words' in _dict:
-            args['words'] = [Word._from_dict(x) for x in _dict.get('words')]
+            args['words'] = [Word._from_dict(x) for x in (_dict.get('words'))]
         else:
             raise ValueError(
                 'Required property \'words\' not present in Words JSON')

--- a/watson_developer_cloud/text_to_speech_v1.py
+++ b/watson_developer_cloud/text_to_speech_v1.py
@@ -66,6 +66,7 @@ from __future__ import absolute_import
 
 import json
 from .watson_service import WatsonService
+from .utils import deprecated
 
 ##############################################################################
 # Service
@@ -187,6 +188,10 @@ class TextToSpeechV1(WatsonService):
             method='GET', url=url, headers=headers, accept_json=True)
         return response
 
+    @deprecated('Use list_voices() instead')
+    def voices(self):
+        return self.list_voices()
+
     #########################
     # Synthesis
     #########################
@@ -306,6 +311,10 @@ class TextToSpeechV1(WatsonService):
             accept_json=True)
         return response
 
+    @deprecated('Use get_pronunciation() instead')
+    def pronunciation(self, text, voice=None, pronunciation_format='ipa'):
+        return self.get_pronunciation(text, voice, pronunciation_format)
+
     #########################
     # Custom models
     #########################
@@ -348,6 +357,10 @@ class TextToSpeechV1(WatsonService):
             accept_json=True)
         return response
 
+    @deprecated('Use create_voice_model() instead.')
+    def create_customization(self, name, language=None, description=None):
+        return self.create_voice_model(name, language, description)
+
     def delete_voice_model(self, customization_id, **kwargs):
         """
         Delete a custom model.
@@ -372,6 +385,10 @@ class TextToSpeechV1(WatsonService):
         self.request(
             method='DELETE', url=url, headers=headers, accept_json=True)
         return None
+
+    @deprecated('Use delete_voice_model() instead.')
+    def delete_customization(self, customization_id):
+        return self.delete_voice_model(customization_id)
 
     def get_voice_model(self, customization_id, **kwargs):
         """
@@ -400,6 +417,10 @@ class TextToSpeechV1(WatsonService):
         response = self.request(
             method='GET', url=url, headers=headers, accept_json=True)
         return response
+
+    @deprecated('Use get_voice_model instead.')
+    def get_customization(self, customization_id):
+        return self.get_voice_model(customization_id)
 
     def list_voice_models(self, language=None, **kwargs):
         """
@@ -432,6 +453,10 @@ class TextToSpeechV1(WatsonService):
             params=params,
             accept_json=True)
         return response
+
+    @deprecated('Use list_voice_models() instead.')
+    def customizations(self, language=None):
+        return self.list_voice_models(language)
 
     def update_voice_model(self,
                            customization_id,
@@ -478,6 +503,11 @@ class TextToSpeechV1(WatsonService):
             json=data,
             accept_json=True)
         return None
+
+    @deprecated('Use update_voice_model() instead')
+    def update_customization(self, customization_id, name=None,
+                             description=None, words=None):
+        return self.update_voice_model(customization_id, name, description, words)
 
     #########################
     # Custom words
@@ -537,6 +567,10 @@ class TextToSpeechV1(WatsonService):
             accept_json=True)
         return None
 
+    @deprecated('Use add_word() instead.')
+    def set_customization_word(self, customization_id, word, translation):
+        return self.add_word(customization_id, word, translation)
+
     def add_words(self, customization_id, words, **kwargs):
         """
         Add custom words.
@@ -580,6 +614,10 @@ class TextToSpeechV1(WatsonService):
             accept_json=True)
         return None
 
+    @deprecated('Use add_words() instead.')
+    def add_customization_words(self, customization_id, words):
+        return self.add_words(customization_id, words)
+
     def delete_word(self, customization_id, word, **kwargs):
         """
         Delete a custom word.
@@ -607,6 +645,10 @@ class TextToSpeechV1(WatsonService):
         self.request(
             method='DELETE', url=url, headers=headers, accept_json=True)
         return None
+
+    @deprecated('Use delete_word() instead.')
+    def delete_customization_word(self, customization_id, word):
+        return self.delete_word(customization_id, word)
 
     def get_word(self, customization_id, word, **kwargs):
         """
@@ -638,6 +680,10 @@ class TextToSpeechV1(WatsonService):
             method='GET', url=url, headers=headers, accept_json=True)
         return response
 
+    @deprecated('Use get_word() instead.')
+    def get_customization_word(self, customization_id, word):
+        return self.get_word(customization_id, word)
+
     def list_words(self, customization_id, **kwargs):
         """
         List custom words.
@@ -665,6 +711,10 @@ class TextToSpeechV1(WatsonService):
         response = self.request(
             method='GET', url=url, headers=headers, accept_json=True)
         return response
+
+    @deprecated('Use list_words() instead.')
+    def get_customization_words(self, customization_id):
+        return self.list_words(customization_id)
 
     #########################
     # User data
@@ -808,10 +858,10 @@ class SupportedFeatures(object):
         """Return a json dictionary representing this model."""
         _dict = {}
         if hasattr(self, 'custom_pronunciation'
-                   ) and self.custom_pronunciation is not None:
+                  ) and self.custom_pronunciation is not None:
             _dict['custom_pronunciation'] = self.custom_pronunciation
         if hasattr(self, 'voice_transformation'
-                   ) and self.voice_transformation is not None:
+                  ) and self.voice_transformation is not None:
             _dict['voice_transformation'] = self.voice_transformation
         return _dict
 
@@ -1136,7 +1186,7 @@ class VoiceModel(object):
         if 'description' in _dict:
             args['description'] = _dict.get('description')
         if 'words' in _dict:
-            args['words'] = [Word._from_dict(x) for x in (_dict.get('words'))]
+            args['words'] = [Word._from_dict(x) for x in _dict.get('words')]
         return cls(**args)
 
     def _to_dict(self):
@@ -1399,7 +1449,7 @@ class Words(object):
         """Initialize a Words object from a json dictionary."""
         args = {}
         if 'words' in _dict:
-            args['words'] = [Word._from_dict(x) for x in (_dict.get('words'))]
+            args['words'] = [Word._from_dict(x) for x in _dict.get('words')]
         else:
             raise ValueError(
                 'Required property \'words\' not present in Words JSON')

--- a/watson_developer_cloud/tone_analyzer_v3.py
+++ b/watson_developer_cloud/tone_analyzer_v3.py
@@ -14,8 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """
-The IBM Watson Tone Analyzer service uses linguistic analysis to detect emotional and
-language tones in written text. The service can analyze tone at both the document and
+The IBM Watson&trade; Tone Analyzer service uses linguistic analysis to detect emotional
+and language tones in written text. The service can analyze tone at both the document and
 sentence levels. You can use the service to understand how your written communications are
 perceived and then to improve the tone of your communications. Businesses can use the
 service to learn the tone of their customers' communications and to respond to each
@@ -123,24 +123,45 @@ class ToneAnalyzerV3(WatsonService):
         Use the general purpose endpoint to analyze the tone of your input content. The
         service analyzes the content for emotional and language tones. The method always
         analyzes the tone of the full document; by default, it also analyzes the tone of
-        each individual sentence of the content.   You can submit no more than 128 KB of
-        total input content and no more than 1000 individual sentences in JSON, plain
-        text, or HTML format. The service analyzes the first 1000 sentences for
-        document-level analysis and only the first 100 sentences for sentence-level
-        analysis.   Per the JSON specification, the default character encoding for JSON
-        content is effectively always UTF-8; per the HTTP specification, the default
-        encoding for plain text and HTML is ISO-8859-1 (effectively, the ASCII character
-        set). When specifying a content type of plain text or HTML, include the `charset`
-        parameter to indicate the character encoding of the input text; for example:
-        `Content-Type: text/plain;charset=utf-8`. For `text/html`, the service removes
-        HTML tags and analyzes only the textual content.
+        each individual sentence of the content.
+        You can submit no more than 128 KB of total input content and no more than 1000
+        individual sentences in JSON, plain text, or HTML format. The service analyzes the
+        first 1000 sentences for document-level analysis and only the first 100 sentences
+        for sentence-level analysis.
+        Per the JSON specification, the default character encoding for JSON content is
+        effectively always UTF-8; per the HTTP specification, the default encoding for
+        plain text and HTML is ISO-8859-1 (effectively, the ASCII character set). When
+        specifying a content type of plain text or HTML, include the `charset` parameter
+        to indicate the character encoding of the input text; for example: `Content-Type:
+        text/plain;charset=utf-8`. For `text/html`, the service removes HTML tags and
+        analyzes only the textual content.
 
-        :param ToneInput tone_input: JSON, plain text, or HTML input that contains the content to be analyzed. For JSON input, provide an object of type `ToneInput`.
-        :param str content_type: The type of the input: application/json, text/plain, or text/html. A character encoding can be specified by including a `charset` parameter. For example, 'text/plain;charset=utf-8'.
-        :param bool sentences: Indicates whether the service is to return an analysis of each individual sentence in addition to its analysis of the full document. If `true` (the default), the service returns results for each sentence.
-        :param list[str] tones: **`2017-09-21`:** Deprecated. The service continues to accept the parameter for backward-compatibility, but the parameter no longer affects the response.   **`2016-05-19`:** A comma-separated list of tones for which the service is to return its analysis of the input; the indicated tones apply both to the full document and to individual sentences of the document. You can specify one or more of the valid values. Omit the parameter to request results for all three tones.
-        :param str content_language: The language of the input text for the request: English or French. Regional variants are treated as their parent language; for example, `en-US` is interpreted as `en`. The input content must match the specified language. Do not submit content that contains both languages. You can use different languages for **Content-Language** and **Accept-Language**. * **`2017-09-21`:** Accepts `en` or `fr`. * **`2016-05-19`:** Accepts only `en`.
-        :param str accept_language: The desired language of the response. For two-character arguments, regional variants are treated as their parent language; for example, `en-US` is interpreted as `en`. You can use different languages for **Content-Language** and **Accept-Language**.
+        :param ToneInput tone_input: JSON, plain text, or HTML input that contains the
+        content to be analyzed. For JSON input, provide an object of type `ToneInput`.
+        :param str content_type: The type of the input: application/json, text/plain, or
+        text/html. A character encoding can be specified by including a `charset`
+        parameter. For example, 'text/plain;charset=utf-8'.
+        :param bool sentences: Indicates whether the service is to return an analysis of
+        each individual sentence in addition to its analysis of the full document. If
+        `true` (the default), the service returns results for each sentence.
+        :param list[str] tones: **`2017-09-21`:** Deprecated. The service continues to
+        accept the parameter for backward-compatibility, but the parameter no longer
+        affects the response.
+        **`2016-05-19`:** A comma-separated list of tones for which the service is to
+        return its analysis of the input; the indicated tones apply both to the full
+        document and to individual sentences of the document. You can specify one or more
+        of the valid values. Omit the parameter to request results for all three tones.
+        :param str content_language: The language of the input text for the request:
+        English or French. Regional variants are treated as their parent language; for
+        example, `en-US` is interpreted as `en`. The input content must match the
+        specified language. Do not submit content that contains both languages. You can
+        use different languages for **Content-Language** and **Accept-Language**.
+        * **`2017-09-21`:** Accepts `en` or `fr`.
+        * **`2016-05-19`:** Accepts only `en`.
+        :param str accept_language: The desired language of the response. For
+        two-character arguments, regional variants are treated as their parent language;
+        for example, `en-US` is interpreted as `en`. You can use different languages for
+        **Content-Language** and **Accept-Language**.
         :param dict headers: A `dict` containing the request headers
         :return: A `dict` containing the `ToneAnalysis` response.
         :rtype: dict
@@ -186,17 +207,28 @@ class ToneAnalyzerV3(WatsonService):
         Use the customer engagement endpoint to analyze the tone of customer service and
         customer support conversations. For each utterance of a conversation, the method
         reports the most prevalent subset of the following seven tones: sad, frustrated,
-        satisfied, excited, polite, impolite, and sympathetic.   If you submit more than
-        50 utterances, the service returns a warning for the overall content and analyzes
-        only the first 50 utterances. If you submit a single utterance that contains more
-        than 500 characters, the service returns an error for that utterance and does not
-        analyze the utterance. The request fails if all utterances have more than 500
-        characters.   Per the JSON specification, the default character encoding for JSON
-        content is effectively always UTF-8.
+        satisfied, excited, polite, impolite, and sympathetic.
+        If you submit more than 50 utterances, the service returns a warning for the
+        overall content and analyzes only the first 50 utterances. If you submit a single
+        utterance that contains more than 500 characters, the service returns an error for
+        that utterance and does not analyze the utterance. The request fails if all
+        utterances have more than 500 characters.
+        Per the JSON specification, the default character encoding for JSON content is
+        effectively always UTF-8.
 
-        :param list[Utterance] utterances: An array of `Utterance` objects that provides the input content that the service is to analyze.
-        :param str content_language: The language of the input text for the request: English or French. Regional variants are treated as their parent language; for example, `en-US` is interpreted as `en`. The input content must match the specified language. Do not submit content that contains both languages. You can use different languages for **Content-Language** and **Accept-Language**. * **`2017-09-21`:** Accepts `en` or `fr`. * **`2016-05-19`:** Accepts only `en`.
-        :param str accept_language: The desired language of the response. For two-character arguments, regional variants are treated as their parent language; for example, `en-US` is interpreted as `en`. You can use different languages for **Content-Language** and **Accept-Language**.
+        :param list[Utterance] utterances: An array of `Utterance` objects that provides
+        the input content that the service is to analyze.
+        :param str content_language: The language of the input text for the request:
+        English or French. Regional variants are treated as their parent language; for
+        example, `en-US` is interpreted as `en`. The input content must match the
+        specified language. Do not submit content that contains both languages. You can
+        use different languages for **Content-Language** and **Accept-Language**.
+        * **`2017-09-21`:** Accepts `en` or `fr`.
+        * **`2016-05-19`:** Accepts only `en`.
+        :param str accept_language: The desired language of the response. For
+        two-character arguments, regional variants are treated as their parent language;
+        for example, `en-US` is interpreted as `en`. You can use different languages for
+        **Content-Language** and **Accept-Language**.
         :param dict headers: A `dict` containing the request headers
         :return: A `dict` containing the `UtteranceAnalyses` response.
         :rtype: dict
@@ -232,18 +264,39 @@ class DocumentAnalysis(object):
     """
     DocumentAnalysis.
 
-    :attr list[ToneScore] tones: (optional) **`2017-09-21`:** An array of `ToneScore` objects that provides the results of the analysis for each qualifying tone of the document. The array includes results for any tone whose score is at least 0.5. The array is empty if no tone has a score that meets this threshold. **`2016-05-19`:** Not returned.
-    :attr list[ToneCategory] tone_categories: (optional) **`2017-09-21`:** Not returned. **`2016-05-19`:** An array of `ToneCategory` objects that provides the results of the tone analysis for the full document of the input content. The service returns results only for the tones specified with the `tones` parameter of the request.
-    :attr str warning: (optional) **`2017-09-21`:** A warning message if the overall content exceeds 128 KB or contains more than 1000 sentences. The service analyzes only the first 1000 sentences for document-level analysis and the first 100 sentences for sentence-level analysis. **`2016-05-19`:** Not returned.
+    :attr list[ToneScore] tones: (optional) **`2017-09-21`:** An array of `ToneScore`
+    objects that provides the results of the analysis for each qualifying tone of the
+    document. The array includes results for any tone whose score is at least 0.5. The
+    array is empty if no tone has a score that meets this threshold. **`2016-05-19`:** Not
+    returned.
+    :attr list[ToneCategory] tone_categories: (optional) **`2017-09-21`:** Not returned.
+    **`2016-05-19`:** An array of `ToneCategory` objects that provides the results of the
+    tone analysis for the full document of the input content. The service returns results
+    only for the tones specified with the `tones` parameter of the request.
+    :attr str warning: (optional) **`2017-09-21`:** A warning message if the overall
+    content exceeds 128 KB or contains more than 1000 sentences. The service analyzes only
+    the first 1000 sentences for document-level analysis and the first 100 sentences for
+    sentence-level analysis. **`2016-05-19`:** Not returned.
     """
 
     def __init__(self, tones=None, tone_categories=None, warning=None):
         """
         Initialize a DocumentAnalysis object.
 
-        :param list[ToneScore] tones: (optional) **`2017-09-21`:** An array of `ToneScore` objects that provides the results of the analysis for each qualifying tone of the document. The array includes results for any tone whose score is at least 0.5. The array is empty if no tone has a score that meets this threshold. **`2016-05-19`:** Not returned.
-        :param list[ToneCategory] tone_categories: (optional) **`2017-09-21`:** Not returned. **`2016-05-19`:** An array of `ToneCategory` objects that provides the results of the tone analysis for the full document of the input content. The service returns results only for the tones specified with the `tones` parameter of the request.
-        :param str warning: (optional) **`2017-09-21`:** A warning message if the overall content exceeds 128 KB or contains more than 1000 sentences. The service analyzes only the first 1000 sentences for document-level analysis and the first 100 sentences for sentence-level analysis. **`2016-05-19`:** Not returned.
+        :param list[ToneScore] tones: (optional) **`2017-09-21`:** An array of `ToneScore`
+        objects that provides the results of the analysis for each qualifying tone of the
+        document. The array includes results for any tone whose score is at least 0.5. The
+        array is empty if no tone has a score that meets this threshold. **`2016-05-19`:**
+        Not returned.
+        :param list[ToneCategory] tone_categories: (optional) **`2017-09-21`:** Not
+        returned. **`2016-05-19`:** An array of `ToneCategory` objects that provides the
+        results of the tone analysis for the full document of the input content. The
+        service returns results only for the tones specified with the `tones` parameter of
+        the request.
+        :param str warning: (optional) **`2017-09-21`:** A warning message if the overall
+        content exceeds 128 KB or contains more than 1000 sentences. The service analyzes
+        only the first 1000 sentences for document-level analysis and the first 100
+        sentences for sentence-level analysis. **`2016-05-19`:** Not returned.
         """
         self.tones = tones
         self.tone_categories = tone_categories
@@ -299,12 +352,22 @@ class SentenceAnalysis(object):
     """
     SentenceAnalysis.
 
-    :attr int sentence_id: The unique identifier of a sentence of the input content. The first sentence has ID 0, and the ID of each subsequent sentence is incremented by one.
+    :attr int sentence_id: The unique identifier of a sentence of the input content. The
+    first sentence has ID 0, and the ID of each subsequent sentence is incremented by one.
     :attr str text: The text of the input sentence.
-    :attr list[ToneScore] tones: (optional) **`2017-09-21`:** An array of `ToneScore` objects that provides the results of the analysis for each qualifying tone of the sentence. The array includes results for any tone whose score is at least 0.5. The array is empty if no tone has a score that meets this threshold. **`2016-05-19`:** Not returned.
-    :attr list[ToneCategory] tone_categories: (optional) **`2017-09-21`:** Not returned. **`2016-05-19`:** An array of `ToneCategory` objects that provides the results of the tone analysis for the sentence. The service returns results only for the tones specified with the `tones` parameter of the request.
-    :attr int input_from: (optional) **`2017-09-21`:** Not returned. **`2016-05-19`:** The offset of the first character of the sentence in the overall input content.
-    :attr int input_to: (optional) **`2017-09-21`:** Not returned. **`2016-05-19`:** The offset of the last character of the sentence in the overall input content.
+    :attr list[ToneScore] tones: (optional) **`2017-09-21`:** An array of `ToneScore`
+    objects that provides the results of the analysis for each qualifying tone of the
+    sentence. The array includes results for any tone whose score is at least 0.5. The
+    array is empty if no tone has a score that meets this threshold. **`2016-05-19`:** Not
+    returned.
+    :attr list[ToneCategory] tone_categories: (optional) **`2017-09-21`:** Not returned.
+    **`2016-05-19`:** An array of `ToneCategory` objects that provides the results of the
+    tone analysis for the sentence. The service returns results only for the tones
+    specified with the `tones` parameter of the request.
+    :attr int input_from: (optional) **`2017-09-21`:** Not returned. **`2016-05-19`:** The
+    offset of the first character of the sentence in the overall input content.
+    :attr int input_to: (optional) **`2017-09-21`:** Not returned. **`2016-05-19`:** The
+    offset of the last character of the sentence in the overall input content.
     """
 
     def __init__(self,
@@ -317,12 +380,24 @@ class SentenceAnalysis(object):
         """
         Initialize a SentenceAnalysis object.
 
-        :param int sentence_id: The unique identifier of a sentence of the input content. The first sentence has ID 0, and the ID of each subsequent sentence is incremented by one.
+        :param int sentence_id: The unique identifier of a sentence of the input content.
+        The first sentence has ID 0, and the ID of each subsequent sentence is incremented
+        by one.
         :param str text: The text of the input sentence.
-        :param list[ToneScore] tones: (optional) **`2017-09-21`:** An array of `ToneScore` objects that provides the results of the analysis for each qualifying tone of the sentence. The array includes results for any tone whose score is at least 0.5. The array is empty if no tone has a score that meets this threshold. **`2016-05-19`:** Not returned.
-        :param list[ToneCategory] tone_categories: (optional) **`2017-09-21`:** Not returned. **`2016-05-19`:** An array of `ToneCategory` objects that provides the results of the tone analysis for the sentence. The service returns results only for the tones specified with the `tones` parameter of the request.
-        :param int input_from: (optional) **`2017-09-21`:** Not returned. **`2016-05-19`:** The offset of the first character of the sentence in the overall input content.
-        :param int input_to: (optional) **`2017-09-21`:** Not returned. **`2016-05-19`:** The offset of the last character of the sentence in the overall input content.
+        :param list[ToneScore] tones: (optional) **`2017-09-21`:** An array of `ToneScore`
+        objects that provides the results of the analysis for each qualifying tone of the
+        sentence. The array includes results for any tone whose score is at least 0.5. The
+        array is empty if no tone has a score that meets this threshold. **`2016-05-19`:**
+        Not returned.
+        :param list[ToneCategory] tone_categories: (optional) **`2017-09-21`:** Not
+        returned. **`2016-05-19`:** An array of `ToneCategory` objects that provides the
+        results of the tone analysis for the sentence. The service returns results only
+        for the tones specified with the `tones` parameter of the request.
+        :param int input_from: (optional) **`2017-09-21`:** Not returned.
+        **`2016-05-19`:** The offset of the first character of the sentence in the overall
+        input content.
+        :param int input_to: (optional) **`2017-09-21`:** Not returned. **`2016-05-19`:**
+        The offset of the last character of the sentence in the overall input content.
         """
         self.sentence_id = sentence_id
         self.text = text
@@ -401,16 +476,26 @@ class ToneAnalysis(object):
     """
     ToneAnalysis.
 
-    :attr DocumentAnalysis document_tone: An object of type `DocumentAnalysis` that provides the results of the analysis for the full input document.
-    :attr list[SentenceAnalysis] sentences_tone: (optional) An array of `SentenceAnalysis` objects that provides the results of the analysis for the individual sentences of the input content. The service returns results only for the first 100 sentences of the input. The field is omitted if the `sentences` parameter of the request is set to `false`.
+    :attr DocumentAnalysis document_tone: An object of type `DocumentAnalysis` that
+    provides the results of the analysis for the full input document.
+    :attr list[SentenceAnalysis] sentences_tone: (optional) An array of `SentenceAnalysis`
+    objects that provides the results of the analysis for the individual sentences of the
+    input content. The service returns results only for the first 100 sentences of the
+    input. The field is omitted if the `sentences` parameter of the request is set to
+    `false`.
     """
 
     def __init__(self, document_tone, sentences_tone=None):
         """
         Initialize a ToneAnalysis object.
 
-        :param DocumentAnalysis document_tone: An object of type `DocumentAnalysis` that provides the results of the analysis for the full input document.
-        :param list[SentenceAnalysis] sentences_tone: (optional) An array of `SentenceAnalysis` objects that provides the results of the analysis for the individual sentences of the input content. The service returns results only for the first 100 sentences of the input. The field is omitted if the `sentences` parameter of the request is set to `false`.
+        :param DocumentAnalysis document_tone: An object of type `DocumentAnalysis` that
+        provides the results of the analysis for the full input document.
+        :param list[SentenceAnalysis] sentences_tone: (optional) An array of
+        `SentenceAnalysis` objects that provides the results of the analysis for the
+        individual sentences of the input content. The service returns results only for
+        the first 100 sentences of the input. The field is omitted if the `sentences`
+        parameter of the request is set to `false`.
         """
         self.document_tone = document_tone
         self.sentences_tone = sentences_tone
@@ -463,8 +548,11 @@ class ToneCategory(object):
     """
     ToneCategory.
 
-    :attr list[ToneScore] tones: An array of `ToneScore` objects that provides the results for the tones of the category.
-    :attr str category_id: The unique, non-localized identifier of the category for the results. The service can return results for the following category IDs: `emotion_tone`, `language_tone`, and `social_tone`.
+    :attr list[ToneScore] tones: An array of `ToneScore` objects that provides the results
+    for the tones of the category.
+    :attr str category_id: The unique, non-localized identifier of the category for the
+    results. The service can return results for the following category IDs:
+    `emotion_tone`, `language_tone`, and `social_tone`.
     :attr str category_name: The user-visible, localized name of the category.
     """
 
@@ -472,8 +560,11 @@ class ToneCategory(object):
         """
         Initialize a ToneCategory object.
 
-        :param list[ToneScore] tones: An array of `ToneScore` objects that provides the results for the tones of the category.
-        :param str category_id: The unique, non-localized identifier of the category for the results. The service can return results for the following category IDs: `emotion_tone`, `language_tone`, and `social_tone`.
+        :param list[ToneScore] tones: An array of `ToneScore` objects that provides the
+        results for the tones of the category.
+        :param str category_id: The unique, non-localized identifier of the category for
+        the results. The service can return results for the following category IDs:
+        `emotion_tone`, `language_tone`, and `social_tone`.
         :param str category_name: The user-visible, localized name of the category.
         """
         self.tones = tones
@@ -535,8 +626,12 @@ class ToneChatScore(object):
     """
     ToneChatScore.
 
-    :attr float score: The score for the tone in the range of 0.5 to 1. A score greater than 0.75 indicates a high likelihood that the tone is perceived in the utterance.
-    :attr str tone_id: The unique, non-localized identifier of the tone for the results. The service can return results for the following tone IDs: `sad`, `frustrated`, `satisfied`, `excited`, `polite`, `impolite`, and `sympathetic`. The service returns results only for tones whose scores meet a minimum threshold of 0.5.
+    :attr float score: The score for the tone in the range of 0.5 to 1. A score greater
+    than 0.75 indicates a high likelihood that the tone is perceived in the utterance.
+    :attr str tone_id: The unique, non-localized identifier of the tone for the results.
+    The service can return results for the following tone IDs: `sad`, `frustrated`,
+    `satisfied`, `excited`, `polite`, `impolite`, and `sympathetic`. The service returns
+    results only for tones whose scores meet a minimum threshold of 0.5.
     :attr str tone_name: The user-visible, localized name of the tone.
     """
 
@@ -544,8 +639,14 @@ class ToneChatScore(object):
         """
         Initialize a ToneChatScore object.
 
-        :param float score: The score for the tone in the range of 0.5 to 1. A score greater than 0.75 indicates a high likelihood that the tone is perceived in the utterance.
-        :param str tone_id: The unique, non-localized identifier of the tone for the results. The service can return results for the following tone IDs: `sad`, `frustrated`, `satisfied`, `excited`, `polite`, `impolite`, and `sympathetic`. The service returns results only for tones whose scores meet a minimum threshold of 0.5.
+        :param float score: The score for the tone in the range of 0.5 to 1. A score
+        greater than 0.75 indicates a high likelihood that the tone is perceived in the
+        utterance.
+        :param str tone_id: The unique, non-localized identifier of the tone for the
+        results. The service can return results for the following tone IDs: `sad`,
+        `frustrated`, `satisfied`, `excited`, `polite`, `impolite`, and `sympathetic`. The
+        service returns results only for tones whose scores meet a minimum threshold of
+        0.5.
         :param str tone_name: The user-visible, localized name of the tone.
         """
         self.score = score
@@ -654,8 +755,24 @@ class ToneScore(object):
     """
     ToneScore.
 
-    :attr float score: The score for the tone. * **`2017-09-21`:** The score that is returned lies in the range of 0.5 to 1. A score greater than 0.75 indicates a high likelihood that the tone is perceived in the content. * **`2016-05-19`:** The score that is returned lies in the range of 0 to 1. A score less than 0.5 indicates that the tone is unlikely to be perceived in the content; a score greater than 0.75 indicates a high likelihood that the tone is perceived.
-    :attr str tone_id: The unique, non-localized identifier of the tone. * **`2017-09-21`:** The service can return results for the following tone IDs: `anger`, `fear`, `joy`, and `sadness` (emotional tones); `analytical`, `confident`, and `tentative` (language tones). The service returns results only for tones whose scores meet a minimum threshold of 0.5. * **`2016-05-19`:** The service can return results for the following tone IDs of the different categories: for the `emotion` category: `anger`, `disgust`, `fear`, `joy`, and `sadness`; for the `language` category: `analytical`, `confident`, and `tentative`; for the `social` category: `openness_big5`, `conscientiousness_big5`, `extraversion_big5`, `agreeableness_big5`, and `emotional_range_big5`. The service returns scores for all tones of a category, regardless of their values.
+    :attr float score: The score for the tone.
+    * **`2017-09-21`:** The score that is returned lies in the range of 0.5 to 1. A score
+    greater than 0.75 indicates a high likelihood that the tone is perceived in the
+    content.
+    * **`2016-05-19`:** The score that is returned lies in the range of 0 to 1. A score
+    less than 0.5 indicates that the tone is unlikely to be perceived in the content; a
+    score greater than 0.75 indicates a high likelihood that the tone is perceived.
+    :attr str tone_id: The unique, non-localized identifier of the tone.
+    * **`2017-09-21`:** The service can return results for the following tone IDs:
+    `anger`, `fear`, `joy`, and `sadness` (emotional tones); `analytical`, `confident`,
+    and `tentative` (language tones). The service returns results only for tones whose
+    scores meet a minimum threshold of 0.5.
+    * **`2016-05-19`:** The service can return results for the following tone IDs of the
+    different categories: for the `emotion` category: `anger`, `disgust`, `fear`, `joy`,
+    and `sadness`; for the `language` category: `analytical`, `confident`, and
+    `tentative`; for the `social` category: `openness_big5`, `conscientiousness_big5`,
+    `extraversion_big5`, `agreeableness_big5`, and `emotional_range_big5`. The service
+    returns scores for all tones of a category, regardless of their values.
     :attr str tone_name: The user-visible, localized name of the tone.
     """
 
@@ -663,8 +780,25 @@ class ToneScore(object):
         """
         Initialize a ToneScore object.
 
-        :param float score: The score for the tone. * **`2017-09-21`:** The score that is returned lies in the range of 0.5 to 1. A score greater than 0.75 indicates a high likelihood that the tone is perceived in the content. * **`2016-05-19`:** The score that is returned lies in the range of 0 to 1. A score less than 0.5 indicates that the tone is unlikely to be perceived in the content; a score greater than 0.75 indicates a high likelihood that the tone is perceived.
-        :param str tone_id: The unique, non-localized identifier of the tone. * **`2017-09-21`:** The service can return results for the following tone IDs: `anger`, `fear`, `joy`, and `sadness` (emotional tones); `analytical`, `confident`, and `tentative` (language tones). The service returns results only for tones whose scores meet a minimum threshold of 0.5. * **`2016-05-19`:** The service can return results for the following tone IDs of the different categories: for the `emotion` category: `anger`, `disgust`, `fear`, `joy`, and `sadness`; for the `language` category: `analytical`, `confident`, and `tentative`; for the `social` category: `openness_big5`, `conscientiousness_big5`, `extraversion_big5`, `agreeableness_big5`, and `emotional_range_big5`. The service returns scores for all tones of a category, regardless of their values.
+        :param float score: The score for the tone.
+        * **`2017-09-21`:** The score that is returned lies in the range of 0.5 to 1. A
+        score greater than 0.75 indicates a high likelihood that the tone is perceived in
+        the content.
+        * **`2016-05-19`:** The score that is returned lies in the range of 0 to 1. A
+        score less than 0.5 indicates that the tone is unlikely to be perceived in the
+        content; a score greater than 0.75 indicates a high likelihood that the tone is
+        perceived.
+        :param str tone_id: The unique, non-localized identifier of the tone.
+        * **`2017-09-21`:** The service can return results for the following tone IDs:
+        `anger`, `fear`, `joy`, and `sadness` (emotional tones); `analytical`,
+        `confident`, and `tentative` (language tones). The service returns results only
+        for tones whose scores meet a minimum threshold of 0.5.
+        * **`2016-05-19`:** The service can return results for the following tone IDs of
+        the different categories: for the `emotion` category: `anger`, `disgust`, `fear`,
+        `joy`, and `sadness`; for the `language` category: `analytical`, `confident`, and
+        `tentative`; for the `social` category: `openness_big5`, `conscientiousness_big5`,
+        `extraversion_big5`, `agreeableness_big5`, and `emotional_range_big5`. The service
+        returns scores for all tones of a category, regardless of their values.
         :param str tone_name: The user-visible, localized name of the tone.
         """
         self.score = score
@@ -723,16 +857,20 @@ class Utterance(object):
     """
     Utterance.
 
-    :attr str text: An utterance contributed by a user in the conversation that is to be analyzed. The utterance can contain multiple sentences.
-    :attr str user: (optional) A string that identifies the user who contributed the utterance specified by the `text` parameter.
+    :attr str text: An utterance contributed by a user in the conversation that is to be
+    analyzed. The utterance can contain multiple sentences.
+    :attr str user: (optional) A string that identifies the user who contributed the
+    utterance specified by the `text` parameter.
     """
 
     def __init__(self, text, user=None):
         """
         Initialize a Utterance object.
 
-        :param str text: An utterance contributed by a user in the conversation that is to be analyzed. The utterance can contain multiple sentences.
-        :param str user: (optional) A string that identifies the user who contributed the utterance specified by the `text` parameter.
+        :param str text: An utterance contributed by a user in the conversation that is to
+        be analyzed. The utterance can contain multiple sentences.
+        :param str user: (optional) A string that identifies the user who contributed the
+        utterance specified by the `text` parameter.
         """
         self.text = text
         self.user = user
@@ -778,16 +916,22 @@ class UtteranceAnalyses(object):
     """
     UtteranceAnalyses.
 
-    :attr list[UtteranceAnalysis] utterances_tone: An array of `UtteranceAnalysis` objects that provides the results for each utterance of the input.
-    :attr str warning: (optional) **`2017-09-21`:** A warning message if the content contains more than 50 utterances. The service analyzes only the first 50 utterances. **`2016-05-19`:** Not returned.
+    :attr list[UtteranceAnalysis] utterances_tone: An array of `UtteranceAnalysis` objects
+    that provides the results for each utterance of the input.
+    :attr str warning: (optional) **`2017-09-21`:** A warning message if the content
+    contains more than 50 utterances. The service analyzes only the first 50 utterances.
+    **`2016-05-19`:** Not returned.
     """
 
     def __init__(self, utterances_tone, warning=None):
         """
         Initialize a UtteranceAnalyses object.
 
-        :param list[UtteranceAnalysis] utterances_tone: An array of `UtteranceAnalysis` objects that provides the results for each utterance of the input.
-        :param str warning: (optional) **`2017-09-21`:** A warning message if the content contains more than 50 utterances. The service analyzes only the first 50 utterances. **`2016-05-19`:** Not returned.
+        :param list[UtteranceAnalysis] utterances_tone: An array of `UtteranceAnalysis`
+        objects that provides the results for each utterance of the input.
+        :param str warning: (optional) **`2017-09-21`:** A warning message if the content
+        contains more than 50 utterances. The service analyzes only the first 50
+        utterances. **`2016-05-19`:** Not returned.
         """
         self.utterances_tone = utterances_tone
         self.warning = warning
@@ -840,20 +984,32 @@ class UtteranceAnalysis(object):
     """
     UtteranceAnalysis.
 
-    :attr int utterance_id: The unique identifier of the utterance. The first utterance has ID 0, and the ID of each subsequent utterance is incremented by one.
+    :attr int utterance_id: The unique identifier of the utterance. The first utterance
+    has ID 0, and the ID of each subsequent utterance is incremented by one.
     :attr str utterance_text: The text of the utterance.
-    :attr list[ToneChatScore] tones: An array of `ToneChatScore` objects that provides results for the most prevalent tones of the utterance. The array includes results for any tone whose score is at least 0.5. The array is empty if no tone has a score that meets this threshold.
-    :attr str error: (optional) **`2017-09-21`:** An error message if the utterance contains more than 500 characters. The service does not analyze the utterance. **`2016-05-19`:** Not returned.
+    :attr list[ToneChatScore] tones: An array of `ToneChatScore` objects that provides
+    results for the most prevalent tones of the utterance. The array includes results for
+    any tone whose score is at least 0.5. The array is empty if no tone has a score that
+    meets this threshold.
+    :attr str error: (optional) **`2017-09-21`:** An error message if the utterance
+    contains more than 500 characters. The service does not analyze the utterance.
+    **`2016-05-19`:** Not returned.
     """
 
     def __init__(self, utterance_id, utterance_text, tones, error=None):
         """
         Initialize a UtteranceAnalysis object.
 
-        :param int utterance_id: The unique identifier of the utterance. The first utterance has ID 0, and the ID of each subsequent utterance is incremented by one.
+        :param int utterance_id: The unique identifier of the utterance. The first
+        utterance has ID 0, and the ID of each subsequent utterance is incremented by one.
         :param str utterance_text: The text of the utterance.
-        :param list[ToneChatScore] tones: An array of `ToneChatScore` objects that provides results for the most prevalent tones of the utterance. The array includes results for any tone whose score is at least 0.5. The array is empty if no tone has a score that meets this threshold.
-        :param str error: (optional) **`2017-09-21`:** An error message if the utterance contains more than 500 characters. The service does not analyze the utterance. **`2016-05-19`:** Not returned.
+        :param list[ToneChatScore] tones: An array of `ToneChatScore` objects that
+        provides results for the most prevalent tones of the utterance. The array includes
+        results for any tone whose score is at least 0.5. The array is empty if no tone
+        has a score that meets this threshold.
+        :param str error: (optional) **`2017-09-21`:** An error message if the utterance
+        contains more than 500 characters. The service does not analyze the utterance.
+        **`2016-05-19`:** Not returned.
         """
         self.utterance_id = utterance_id
         self.utterance_text = utterance_text

--- a/watson_developer_cloud/visual_recognition_v3.py
+++ b/watson_developer_cloud/visual_recognition_v3.py
@@ -94,55 +94,29 @@ class VisualRecognitionV3(WatsonService):
 
     def classify(self,
                  images_file=None,
+                 parameters=None,
                  accept_language=None,
+                 images_file_content_type=None,
+                 images_filename=None,
                  url=None,
                  threshold=None,
                  owners=None,
                  classifier_ids=None,
-                 images_file_content_type=None,
-                 images_filename=None,
                  **kwargs):
         """
         Classify images.
 
         Classify images with built-in or custom classifiers.
 
-        :param file images_file: An image file (.jpg, .png) or .zip file with images.
-        Maximum image size is 10 MB. Include no more than 20 images and limit the .zip
-        file to 100 MB. Encode the image and .zip file names in UTF-8 if they contain
-        non-ASCII characters. The service assumes UTF-8 encoding if it encounters
-        non-ASCII characters.
-        You can also include an image with the **url** parameter.
-        :param str accept_language: The language of the output class names. The full set
-        of languages is supported only for the built-in `default` classifier ID. The class
-        names of custom classifiers are not translated.
-        The response might not be in the specified language when the requested language is
-        not supported or when there is no translation for the class name.
-        :param str url: The URL of an image to analyze. Must be in .jpg, or .png format.
-        The minimum recommended pixel density is 32X32 pixels per inch, and the maximum
-        image size is 10 MB.
-        You can also include images with the **images_file** parameter.
-        :param float threshold: The minimum score a class must have to be displayed in the
-        response. Set the threshold to `0.0` to ignore the classification score and return
-        all values.
-        :param list[str] owners: The categories of classifiers to apply. Use `IBM` to
-        classify against the `default` general classifier, and use `me` to classify
-        against your custom classifiers. To analyze the image against both classifier
-        categories, set the value to both `IBM` and `me`.
-        The built-in `default` classifier is used if both **classifier_ids** and
-        **owners** parameters are empty.
-        The **classifier_ids** parameter overrides **owners**, so make sure that
-        **classifier_ids** is empty.
-        :param list[str] classifier_ids: Which classifiers to apply. Overrides the
-        **owners** parameter. You can specify both custom and built-in classifier IDs. The
-        built-in `default` classifier is used if both **classifier_ids** and **owners**
-        parameters are empty.
-        The following built-in classifier IDs require no training:
-        - `default`: Returns classes from thousands of general tags.
-        - `food`: (Beta) Enhances specificity and accuracy for images of food items.
-        - `explicit`: (Beta) Evaluates whether the image might be pornographic.
+        :param file images_file: An image file (.jpg, .png) or .zip file with images. Maximum image size is 10 MB. Include no more than 20 images and limit the .zip file to 100 MB. Encode the image and .zip file names in UTF-8 if they contain non-ASCII characters. The service assumes UTF-8 encoding if it encounters non-ASCII characters. You can also include images with the `url` property in the **parameters** object.
+        :param str parameters: (Deprecated) A JSON object that specifies additional request options. The parameter can be sent as a string or a file, and can include these inputs:  - **url**: A string with the image URL to analyze. Must be in .jpg, or .png format. The minimum recommended pixel density is 32X32 pixels per inch, and the maximum image size is 10 MB. You can also include images in the **images_file** parameter. - **threshold**: A floating point value that specifies the minimum score a class must have to be displayed in the response. The default threshold for returning scores from a classifier is `0.5`. Set the threshold to `0.0` to ignore the classification score and return all values. - **owners**: An array of the categories of classifiers to apply. Use `IBM` to classify against the `default` general classifier, and use `me` to classify against your custom classifiers. To analyze the image against both classifier categories, set the value to both `IBM` and `me`. The built-in `default` classifier is used if both **classifier_ids** and **owners** parameters are empty.      The **classifier_ids** parameter overrides **owners**, so make sure that **classifier_ids** is empty. - **classifier_ids**: Specifies which classifiers to apply and overrides the **owners** parameter. You can specify both custom and built-in classifiers. The built-in `default` classifier is used if both **classifier_ids** and **owners** parameters are empty.  The following built-in classifier IDs require no training: - `default`: Returns classes from thousands of general tags. - `food`: (Beta) Enhances specificity and accuracy for images of food items. - `explicit`: (Beta) Evaluates whether the image might be pornographic.  Example: `{\"classifier_ids\":[\"CarsvsTrucks_1479118188\",\"explicit\"],\"threshold\":0.6}`.
+        :param str accept_language: Specifies the language of the output class names.  Can be `en` (English), `ar` (Arabic), `de` (German), `es` (Spanish), `it` (Italian), `ja` (Japanese), or `ko` (Korean).  Classes for which no translation is available are omitted.  The response might not be in the specified language under these conditions: - English is returned when the requested language is not supported. - Classes are not returned when there is no translation for them. - Custom classifiers returned with this method return tags in the language of the custom classifier.
         :param str images_file_content_type: The content type of images_file.
         :param str images_filename: The filename for images_file.
+        :param str url: A string with the image URL to analyze. Must be in .jpg, or .png format. The minimum recommended pixel density is 32X32 pixels per inch, and the maximum image size is 10 MB. You can also include images in the **images_file** parameter.
+        :param float threshold: A floating point value that specifies the minimum score a class must have to be displayed in the response. The default threshold for returning scores from a classifier is `0.5`. Set the threshold to `0.0` to ignore the classification score and return all values.
+        :param list[str] owners: An array of the categories of classifiers to apply. Use `IBM` to classify against the `default` general classifier, and use `me` to classify against your custom classifiers. To analyze the image against both classifier categories, set the value to both `IBM` and `me`.   The built-in `default` classifier is used if both **classifier_ids** and **owners** parameters are empty.  The **classifier_ids** parameter overrides **owners**, so make sure that **classifier_ids** is empty.
+        :param list[str] classifier_ids: The **classifier_ids** parameter overrides **owners**, so make sure that **classifier_ids** is empty. - **classifier_ids**: Specifies which classifiers to apply and overrides the **owners** parameter. You can specify both custom and built-in classifiers. The built-in `default` classifier is used if both **classifier_ids** and **owners** parameters are empty.  The following built-in classifier IDs require no training: - `default`: Returns classes from thousands of general tags. - `food`: (Beta) Enhances specificity and accuracy for images of food items. - `explicit`: (Beta) Evaluates whether the image might be pornographic.  Example: `\"classifier_ids=\"CarsvsTrucks_1479118188\",\"explicit\"`.
         :param dict headers: A `dict` containing the request headers
         :return: A `dict` containing the `ClassifiedImages` response.
         :rtype: dict
@@ -157,6 +131,11 @@ class VisualRecognitionV3(WatsonService):
                 images_filename = images_file.name
             mime_type = images_file_content_type or 'application/octet-stream'
             images_file_tuple = (images_filename, images_file, mime_type)
+
+        parameters_tuple = None
+        if parameters is not None:
+            parameters_tuple = (None, parameters, 'text/plain')
+
         url_tuple = None
         if url:
             url_tuple = (None, url, 'text/plain')
@@ -165,9 +144,13 @@ class VisualRecognitionV3(WatsonService):
             threshold_tuple = (None, threshold, 'application/json')
         owners_tuple = None
         if owners:
+            if isinstance(owners, (list,)):
+                owners = ','.join(owners)
             owners_tuple = (None, owners, 'application/json')
         classifier_ids_tuple = None
         if classifier_ids:
+            if isinstance(classifier_ids, (list,)):
+                classifier_ids = ','.join(classifier_ids)
             classifier_ids_tuple = (None, classifier_ids, 'application/json')
         url = '/v3/classify'
         response = self.request(
@@ -176,6 +159,7 @@ class VisualRecognitionV3(WatsonService):
             headers=headers,
             params=params,
             files={
+                'parameters': parameters_tuple,
                 'images_file': images_file_tuple,
                 'url': url_tuple,
                 'threshold': threshold_tuple,
@@ -191,38 +175,24 @@ class VisualRecognitionV3(WatsonService):
 
     def detect_faces(self,
                      images_file=None,
-                     url=None,
+                     parameters=None,
                      images_file_content_type=None,
                      images_filename=None,
+                     url=None,
                      **kwargs):
         """
         Detect faces in images.
 
-        **Important:** On April 2, 2018, the identity information in the response to calls
-        to the Face model was removed. The identity information refers to the `name` of
-        the person, `score`, and `type_hierarchy` knowledge graph. For details about the
-        enhanced Face model, see the [Release
-        notes](https://console.bluemix.net/docs/services/visual-recognition/release-notes.html#2april2018).
         Analyze and get data about faces in images. Responses can include estimated age
-        and gender. This feature uses a built-in model, so no training is necessary. The
-        Detect faces method does not support general biometric facial recognition.
-        Supported image formats include .gif, .jpg, .png, and .tif. The maximum image size
-        is 10 MB. The minimum recommended pixel density is 32X32 pixels per inch.
+        and gender, and the service can identify celebrities. This feature uses a built-in
+        classifier, so you do not train it on custom classifiers. The Detect faces method
+        does not support general biometric facial recognition.
 
-        :param file images_file: An image file (gif, .jpg, .png, .tif.) or .zip file with
-        images. Limit the .zip file to 100 MB. You can include a maximum of 15 images in a
-        request.
-        Encode the image and .zip file names in UTF-8 if they contain non-ASCII
-        characters. The service assumes UTF-8 encoding if it encounters non-ASCII
-        characters.
-        You can also include an image with the **url** parameter.
-        :param str url: The URL of an image to analyze. Must be in .gif, .jpg, .png, or
-        .tif format. The minimum recommended pixel density is 32X32 pixels per inch, and
-        the maximum image size is 10 MB. Redirects are followed, so you can use a
-        shortened URL.
-        You can also include images with the **images_file** parameter.
+        :param file images_file: An image file (.jpg, .png) or .zip file with images. Include no more than 15 images. You can also include images with the `url` property in the **parameters** object.  All faces are detected, but if there are more than 10 faces in an image, age and gender confidence scores might return scores of 0.
+        :param str parameters: (Deprecated) A JSON object that specifies a single image (.jpg, .png) to analyze by URL. The parameter can be sent as a string or a file.  Example: `{\"url\":\"http://www.example.com/images/myimage.jpg\"}`.
         :param str images_file_content_type: The content type of images_file.
         :param str images_filename: The filename for images_file.
+        :param str url: The URL of an image to analyze. Must be in .gif, .jpg, .png, or .tif format. The minimum recommended pixel density is 32X32 pixels per inch, and the maximum image size is 10 MB. Redirects are followed, so you can use a shortened URL.  You can also include images with the **images_file** parameter.
         :param dict headers: A `dict` containing the request headers
         :return: A `dict` containing the `DetectedFaces` response.
         :rtype: dict
@@ -237,6 +207,9 @@ class VisualRecognitionV3(WatsonService):
                 images_filename = images_file.name
             mime_type = images_file_content_type or 'application/octet-stream'
             images_file_tuple = (images_filename, images_file, mime_type)
+        parameters_tuple = None
+        if parameters is not None:
+            parameters_tuple = (None, parameters, 'text/plain')
         url_tuple = None
         if url:
             url_tuple = (None, url, 'text/plain')
@@ -247,6 +220,7 @@ class VisualRecognitionV3(WatsonService):
             headers=headers,
             params=params,
             files={'images_file': images_file_tuple,
+                   'parameters': parameters_tuple,
                    'url': url_tuple},
             accept_json=True)
         return response
@@ -257,83 +231,31 @@ class VisualRecognitionV3(WatsonService):
 
     def create_classifier(self,
                           name,
-                          classname_positive_examples,
-                          negative_examples=None,
-                          classname_positive_examples_filename=None,
-                          negative_examples_filename=None,
                           **kwargs):
         """
         Create a classifier.
-
-        Train a new multi-faceted classifier on the uploaded image data. Create your
-        custom classifier with positive or negative examples. Include at least two sets of
-        examples, either two positive example files or one positive and one negative file.
-        You can upload a maximum of 256 MB per call.
-        Encode all names in UTF-8 if they contain non-ASCII characters (.zip and image
-        file names, and classifier and class names). The service assumes UTF-8 encoding if
-        it encounters non-ASCII characters.
-
-        :param str name: The name of the new classifier. Encode special characters in
-        UTF-8.
-        :param file classname_positive_examples: A .zip file of images that depict the
-        visual subject of a class in the new classifier. You can include more than one
-        positive example file in a call.
-        Specify the parameter name by appending `_positive_examples` to the class name.
-        For example, `goldenretriever_positive_examples` creates the class
-        **goldenretriever**.
-        Include at least 10 images in .jpg or .png format. The minimum recommended image
-        resolution is 32X32 pixels. The maximum number of images is 10,000 images or 100
-        MB per .zip file.
-        Encode special characters in the file name in UTF-8.
-        :param file negative_examples: A .zip file of images that do not depict the visual
-        subject of any of the classes of the new classifier. Must contain a minimum of 10
-        images.
-        Encode special characters in the file name in UTF-8.
-        :param str classname_positive_examples_filename: The filename for
-        classname_positive_examples.
-        :param str negative_examples_filename: The filename for negative_examples.
+        :param str name: The name of the new classifier. Encode special characters in UTF-8.
+        :param file <NAME>_positive_examples: A compressed (.zip) file of images that depict the visual subject for a class within the new classifier. Must contain a minimum of 10 images. The swagger limits you to training only one class. To train more classes, use the API functionality.
+        :param file negative_examples: A compressed (.zip) file of images that do not depict the visual subject of any of the classes of the new classifier. Must contain a minimum of 10 images.
         :param dict headers: A `dict` containing the request headers
         :return: A `dict` containing the `Classifier` response.
         :rtype: dict
         """
         if name is None:
             raise ValueError('name must be provided')
-        if classname_positive_examples is None:
-            raise ValueError('classname_positive_examples must be provided')
         headers = {}
         if 'headers' in kwargs:
             headers.update(kwargs.get('headers'))
         params = {'version': self.version}
-        name_tuple = (None, name, 'text/plain')
-        if not classname_positive_examples_filename and hasattr(
-                classname_positive_examples, 'name'):
-            classname_positive_examples_filename = classname_positive_examples.name
-        mime_type = 'application/octet-stream'
-        classname_positive_examples_tuple = (
-            classname_positive_examples_filename, classname_positive_examples,
-            mime_type)
-        negative_examples_tuple = None
-        if negative_examples:
-            if not negative_examples_filename and hasattr(
-                    negative_examples, 'name'):
-                negative_examples_filename = negative_examples.name
-            if not negative_examples_filename:
-                raise ValueError('negative_examples_filename must be provided')
-            mime_type = 'application/octet-stream'
-            negative_examples_tuple = (negative_examples_filename,
-                                       negative_examples, mime_type)
+        data = {'name': name}
         url = '/v3/classifiers'
         response = self.request(
             method='POST',
             url=url,
             headers=headers,
             params=params,
-            files={
-                'name': name_tuple,
-                'classname_positive_examples':
-                classname_positive_examples_tuple,
-                'negative_examples': negative_examples_tuple
-            },
+            data=data,
+            files=kwargs,
             accept_json=True)
         return response
 
@@ -413,45 +335,12 @@ class VisualRecognitionV3(WatsonService):
 
     def update_classifier(self,
                           classifier_id,
-                          classname_positive_examples=None,
-                          negative_examples=None,
-                          classname_positive_examples_filename=None,
-                          negative_examples_filename=None,
                           **kwargs):
         """
         Update a classifier.
-
-        Update a custom classifier by adding new positive or negative classes (examples)
-        or by adding new images to existing classes. You must supply at least one set of
-        positive or negative examples. For details, see [Updating custom
-        classifiers](https://console.bluemix.net/docs/services/visual-recognition/customizing.html#updating-custom-classifiers).
-        Encode all names in UTF-8 if they contain non-ASCII characters (.zip and image
-        file names, and classifier and class names). The service assumes UTF-8 encoding if
-        it encounters non-ASCII characters.
-        **Tip:** Don't make retraining calls on a classifier until the status is ready.
-        When you submit retraining requests in parallel, the last request overwrites the
-        previous requests. The retrained property shows the last time the classifier
-        retraining finished.
-
         :param str classifier_id: The ID of the classifier.
-        :param file classname_positive_examples: A .zip file of images that depict the
-        visual subject of a class in the classifier. The positive examples create or
-        update classes in the classifier. You can include more than one positive example
-        file in a call.
-        Specify the parameter name by appending `_positive_examples` to the class name.
-        For example, `goldenretriever_positive_examples` creates the class
-        `goldenretriever`.
-        Include at least 10 images in .jpg or .png format. The minimum recommended image
-        resolution is 32X32 pixels. The maximum number of images is 10,000 images or 100
-        MB per .zip file.
-        Encode special characters in the file name in UTF-8.
-        :param file negative_examples: A .zip file of images that do not depict the visual
-        subject of any of the classes of the new classifier. Must contain a minimum of 10
-        images.
-        Encode special characters in the file name in UTF-8.
-        :param str classname_positive_examples_filename: The filename for
-        classname_positive_examples.
-        :param str negative_examples_filename: The filename for negative_examples.
+        :param file <NAME>_positive_examples: A compressed (.zip) file of images that depict the visual subject for a class within the classifier. Must contain a minimum of 10 images.
+        :param file negative_examples: A compressed (.zip) file of images that do not depict the visual subject of any of the classes of the new classifier. Must contain a minimum of 10 images.
         :param dict headers: A `dict` containing the request headers
         :return: A `dict` containing the `Classifier` response.
         :rtype: dict
@@ -462,25 +351,6 @@ class VisualRecognitionV3(WatsonService):
         if 'headers' in kwargs:
             headers.update(kwargs.get('headers'))
         params = {'version': self.version}
-        classname_positive_examples_tuple = None
-        if classname_positive_examples:
-            if not classname_positive_examples_filename and hasattr(
-                    classname_positive_examples, 'name'):
-                classname_positive_examples_filename = classname_positive_examples.name
-            mime_type = 'application/octet-stream'
-            classname_positive_examples_tuple = (
-                classname_positive_examples_filename,
-                classname_positive_examples, mime_type)
-        negative_examples_tuple = None
-        if negative_examples:
-            if not negative_examples_filename and hasattr(
-                    negative_examples, 'name'):
-                negative_examples_filename = negative_examples.name
-            if not negative_examples_filename:
-                raise ValueError('negative_examples_filename must be provided')
-            mime_type = 'application/octet-stream'
-            negative_examples_tuple = (negative_examples_filename,
-                                       negative_examples, mime_type)
         url = '/v3/classifiers/{0}'.format(
             *self._encode_path_vars(classifier_id))
         response = self.request(
@@ -488,11 +358,7 @@ class VisualRecognitionV3(WatsonService):
             url=url,
             headers=headers,
             params=params,
-            files={
-                'classname_positive_examples':
-                classname_positive_examples_tuple,
-                'negative_examples': negative_examples_tuple
-            },
+            files=kwargs,
             accept_json=True)
         return response
 
@@ -1591,7 +1457,7 @@ class ImageWithFaces(object):
         """Initialize a ImageWithFaces object from a json dictionary."""
         args = {}
         if 'faces' in _dict:
-            args['faces'] = [Face._from_dict(x) for x in (_dict.get('faces'))]
+            args['faces'] = [Face._from_dict(x) for x in _dict.get('faces')]
         else:
             raise ValueError(
                 'Required property \'faces\' not present in ImageWithFaces JSON'

--- a/watson_developer_cloud/visual_recognition_v3.py
+++ b/watson_developer_cloud/visual_recognition_v3.py
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """
-The IBM Watson Visual Recognition service uses deep learning algorithms to identify
+The IBM Watson&trade; Visual Recognition service uses deep learning algorithms to identify
 scenes, objects, and faces  in images you upload to the service. You can create and train
 a custom classifier to identify subjects that suit your needs.
 """
@@ -94,29 +94,55 @@ class VisualRecognitionV3(WatsonService):
 
     def classify(self,
                  images_file=None,
-                 parameters=None,
                  accept_language=None,
-                 images_file_content_type=None,
-                 images_filename=None,
                  url=None,
                  threshold=None,
                  owners=None,
                  classifier_ids=None,
+                 images_file_content_type=None,
+                 images_filename=None,
                  **kwargs):
         """
         Classify images.
 
         Classify images with built-in or custom classifiers.
 
-        :param file images_file: An image file (.jpg, .png) or .zip file with images. Maximum image size is 10 MB. Include no more than 20 images and limit the .zip file to 100 MB. Encode the image and .zip file names in UTF-8 if they contain non-ASCII characters. The service assumes UTF-8 encoding if it encounters non-ASCII characters. You can also include images with the `url` property in the **parameters** object.
-        :param str parameters: (Deprecated) A JSON object that specifies additional request options. The parameter can be sent as a string or a file, and can include these inputs:  - **url**: A string with the image URL to analyze. Must be in .jpg, or .png format. The minimum recommended pixel density is 32X32 pixels per inch, and the maximum image size is 10 MB. You can also include images in the **images_file** parameter. - **threshold**: A floating point value that specifies the minimum score a class must have to be displayed in the response. The default threshold for returning scores from a classifier is `0.5`. Set the threshold to `0.0` to ignore the classification score and return all values. - **owners**: An array of the categories of classifiers to apply. Use `IBM` to classify against the `default` general classifier, and use `me` to classify against your custom classifiers. To analyze the image against both classifier categories, set the value to both `IBM` and `me`. The built-in `default` classifier is used if both **classifier_ids** and **owners** parameters are empty.      The **classifier_ids** parameter overrides **owners**, so make sure that **classifier_ids** is empty. - **classifier_ids**: Specifies which classifiers to apply and overrides the **owners** parameter. You can specify both custom and built-in classifiers. The built-in `default` classifier is used if both **classifier_ids** and **owners** parameters are empty.  The following built-in classifier IDs require no training: - `default`: Returns classes from thousands of general tags. - `food`: (Beta) Enhances specificity and accuracy for images of food items. - `explicit`: (Beta) Evaluates whether the image might be pornographic.  Example: `{\"classifier_ids\":[\"CarsvsTrucks_1479118188\",\"explicit\"],\"threshold\":0.6}`.
-        :param str accept_language: Specifies the language of the output class names.  Can be `en` (English), `ar` (Arabic), `de` (German), `es` (Spanish), `it` (Italian), `ja` (Japanese), or `ko` (Korean).  Classes for which no translation is available are omitted.  The response might not be in the specified language under these conditions: - English is returned when the requested language is not supported. - Classes are not returned when there is no translation for them. - Custom classifiers returned with this method return tags in the language of the custom classifier.
+        :param file images_file: An image file (.jpg, .png) or .zip file with images.
+        Maximum image size is 10 MB. Include no more than 20 images and limit the .zip
+        file to 100 MB. Encode the image and .zip file names in UTF-8 if they contain
+        non-ASCII characters. The service assumes UTF-8 encoding if it encounters
+        non-ASCII characters.
+        You can also include an image with the **url** parameter.
+        :param str accept_language: The language of the output class names. The full set
+        of languages is supported only for the built-in `default` classifier ID. The class
+        names of custom classifiers are not translated.
+        The response might not be in the specified language when the requested language is
+        not supported or when there is no translation for the class name.
+        :param str url: The URL of an image to analyze. Must be in .jpg, or .png format.
+        The minimum recommended pixel density is 32X32 pixels per inch, and the maximum
+        image size is 10 MB.
+        You can also include images with the **images_file** parameter.
+        :param float threshold: The minimum score a class must have to be displayed in the
+        response. Set the threshold to `0.0` to ignore the classification score and return
+        all values.
+        :param list[str] owners: The categories of classifiers to apply. Use `IBM` to
+        classify against the `default` general classifier, and use `me` to classify
+        against your custom classifiers. To analyze the image against both classifier
+        categories, set the value to both `IBM` and `me`.
+        The built-in `default` classifier is used if both **classifier_ids** and
+        **owners** parameters are empty.
+        The **classifier_ids** parameter overrides **owners**, so make sure that
+        **classifier_ids** is empty.
+        :param list[str] classifier_ids: Which classifiers to apply. Overrides the
+        **owners** parameter. You can specify both custom and built-in classifier IDs. The
+        built-in `default` classifier is used if both **classifier_ids** and **owners**
+        parameters are empty.
+        The following built-in classifier IDs require no training:
+        - `default`: Returns classes from thousands of general tags.
+        - `food`: (Beta) Enhances specificity and accuracy for images of food items.
+        - `explicit`: (Beta) Evaluates whether the image might be pornographic.
         :param str images_file_content_type: The content type of images_file.
         :param str images_filename: The filename for images_file.
-        :param str url: A string with the image URL to analyze. Must be in .jpg, or .png format. The minimum recommended pixel density is 32X32 pixels per inch, and the maximum image size is 10 MB. You can also include images in the **images_file** parameter.
-        :param float threshold: A floating point value that specifies the minimum score a class must have to be displayed in the response. The default threshold for returning scores from a classifier is `0.5`. Set the threshold to `0.0` to ignore the classification score and return all values.
-        :param list[str] owners: An array of the categories of classifiers to apply. Use `IBM` to classify against the `default` general classifier, and use `me` to classify against your custom classifiers. To analyze the image against both classifier categories, set the value to both `IBM` and `me`.   The built-in `default` classifier is used if both **classifier_ids** and **owners** parameters are empty.  The **classifier_ids** parameter overrides **owners**, so make sure that **classifier_ids** is empty.
-        :param list[str] classifier_ids: The **classifier_ids** parameter overrides **owners**, so make sure that **classifier_ids** is empty. - **classifier_ids**: Specifies which classifiers to apply and overrides the **owners** parameter. You can specify both custom and built-in classifiers. The built-in `default` classifier is used if both **classifier_ids** and **owners** parameters are empty.  The following built-in classifier IDs require no training: - `default`: Returns classes from thousands of general tags. - `food`: (Beta) Enhances specificity and accuracy for images of food items. - `explicit`: (Beta) Evaluates whether the image might be pornographic.  Example: `\"classifier_ids=\"CarsvsTrucks_1479118188\",\"explicit\"`.
         :param dict headers: A `dict` containing the request headers
         :return: A `dict` containing the `ClassifiedImages` response.
         :rtype: dict
@@ -131,11 +157,6 @@ class VisualRecognitionV3(WatsonService):
                 images_filename = images_file.name
             mime_type = images_file_content_type or 'application/octet-stream'
             images_file_tuple = (images_filename, images_file, mime_type)
-
-        parameters_tuple = None
-        if parameters is not None:
-            parameters_tuple = (None, parameters, 'text/plain')
-
         url_tuple = None
         if url:
             url_tuple = (None, url, 'text/plain')
@@ -144,13 +165,9 @@ class VisualRecognitionV3(WatsonService):
             threshold_tuple = (None, threshold, 'application/json')
         owners_tuple = None
         if owners:
-            if isinstance(owners, (list,)):
-                owners = ','.join(owners)
             owners_tuple = (None, owners, 'application/json')
         classifier_ids_tuple = None
         if classifier_ids:
-            if isinstance(classifier_ids, (list,)):
-                classifier_ids = ','.join(classifier_ids)
             classifier_ids_tuple = (None, classifier_ids, 'application/json')
         url = '/v3/classify'
         response = self.request(
@@ -159,7 +176,6 @@ class VisualRecognitionV3(WatsonService):
             headers=headers,
             params=params,
             files={
-                'parameters': parameters_tuple,
                 'images_file': images_file_tuple,
                 'url': url_tuple,
                 'threshold': threshold_tuple,
@@ -175,24 +191,38 @@ class VisualRecognitionV3(WatsonService):
 
     def detect_faces(self,
                      images_file=None,
-                     parameters=None,
+                     url=None,
                      images_file_content_type=None,
                      images_filename=None,
-                     url=None,
                      **kwargs):
         """
         Detect faces in images.
 
+        **Important:** On April 2, 2018, the identity information in the response to calls
+        to the Face model was removed. The identity information refers to the `name` of
+        the person, `score`, and `type_hierarchy` knowledge graph. For details about the
+        enhanced Face model, see the [Release
+        notes](https://console.bluemix.net/docs/services/visual-recognition/release-notes.html#2april2018).
         Analyze and get data about faces in images. Responses can include estimated age
-        and gender, and the service can identify celebrities. This feature uses a built-in
-        classifier, so you do not train it on custom classifiers. The Detect faces method
-        does not support general biometric facial recognition.
+        and gender. This feature uses a built-in model, so no training is necessary. The
+        Detect faces method does not support general biometric facial recognition.
+        Supported image formats include .gif, .jpg, .png, and .tif. The maximum image size
+        is 10 MB. The minimum recommended pixel density is 32X32 pixels per inch.
 
-        :param file images_file: An image file (.jpg, .png) or .zip file with images. Include no more than 15 images. You can also include images with the `url` property in the **parameters** object.  All faces are detected, but if there are more than 10 faces in an image, age and gender confidence scores might return scores of 0.
-        :param str parameters: (Deprecated) A JSON object that specifies a single image (.jpg, .png) to analyze by URL. The parameter can be sent as a string or a file.  Example: `{\"url\":\"http://www.example.com/images/myimage.jpg\"}`.
+        :param file images_file: An image file (gif, .jpg, .png, .tif.) or .zip file with
+        images. Limit the .zip file to 100 MB. You can include a maximum of 15 images in a
+        request.
+        Encode the image and .zip file names in UTF-8 if they contain non-ASCII
+        characters. The service assumes UTF-8 encoding if it encounters non-ASCII
+        characters.
+        You can also include an image with the **url** parameter.
+        :param str url: The URL of an image to analyze. Must be in .gif, .jpg, .png, or
+        .tif format. The minimum recommended pixel density is 32X32 pixels per inch, and
+        the maximum image size is 10 MB. Redirects are followed, so you can use a
+        shortened URL.
+        You can also include images with the **images_file** parameter.
         :param str images_file_content_type: The content type of images_file.
         :param str images_filename: The filename for images_file.
-        :param str url: The URL of an image to analyze. Must be in .gif, .jpg, .png, or .tif format. The minimum recommended pixel density is 32X32 pixels per inch, and the maximum image size is 10 MB. Redirects are followed, so you can use a shortened URL.  You can also include images with the **images_file** parameter.
         :param dict headers: A `dict` containing the request headers
         :return: A `dict` containing the `DetectedFaces` response.
         :rtype: dict
@@ -207,9 +237,6 @@ class VisualRecognitionV3(WatsonService):
                 images_filename = images_file.name
             mime_type = images_file_content_type or 'application/octet-stream'
             images_file_tuple = (images_filename, images_file, mime_type)
-        parameters_tuple = None
-        if parameters is not None:
-            parameters_tuple = (None, parameters, 'text/plain')
         url_tuple = None
         if url:
             url_tuple = (None, url, 'text/plain')
@@ -220,7 +247,6 @@ class VisualRecognitionV3(WatsonService):
             headers=headers,
             params=params,
             files={'images_file': images_file_tuple,
-                   'parameters': parameters_tuple,
                    'url': url_tuple},
             accept_json=True)
         return response
@@ -231,31 +257,83 @@ class VisualRecognitionV3(WatsonService):
 
     def create_classifier(self,
                           name,
+                          classname_positive_examples,
+                          negative_examples=None,
+                          classname_positive_examples_filename=None,
+                          negative_examples_filename=None,
                           **kwargs):
         """
         Create a classifier.
-        :param str name: The name of the new classifier. Encode special characters in UTF-8.
-        :param file <NAME>_positive_examples: A compressed (.zip) file of images that depict the visual subject for a class within the new classifier. Must contain a minimum of 10 images. The swagger limits you to training only one class. To train more classes, use the API functionality.
-        :param file negative_examples: A compressed (.zip) file of images that do not depict the visual subject of any of the classes of the new classifier. Must contain a minimum of 10 images.
+
+        Train a new multi-faceted classifier on the uploaded image data. Create your
+        custom classifier with positive or negative examples. Include at least two sets of
+        examples, either two positive example files or one positive and one negative file.
+        You can upload a maximum of 256 MB per call.
+        Encode all names in UTF-8 if they contain non-ASCII characters (.zip and image
+        file names, and classifier and class names). The service assumes UTF-8 encoding if
+        it encounters non-ASCII characters.
+
+        :param str name: The name of the new classifier. Encode special characters in
+        UTF-8.
+        :param file classname_positive_examples: A .zip file of images that depict the
+        visual subject of a class in the new classifier. You can include more than one
+        positive example file in a call.
+        Specify the parameter name by appending `_positive_examples` to the class name.
+        For example, `goldenretriever_positive_examples` creates the class
+        **goldenretriever**.
+        Include at least 10 images in .jpg or .png format. The minimum recommended image
+        resolution is 32X32 pixels. The maximum number of images is 10,000 images or 100
+        MB per .zip file.
+        Encode special characters in the file name in UTF-8.
+        :param file negative_examples: A .zip file of images that do not depict the visual
+        subject of any of the classes of the new classifier. Must contain a minimum of 10
+        images.
+        Encode special characters in the file name in UTF-8.
+        :param str classname_positive_examples_filename: The filename for
+        classname_positive_examples.
+        :param str negative_examples_filename: The filename for negative_examples.
         :param dict headers: A `dict` containing the request headers
         :return: A `dict` containing the `Classifier` response.
         :rtype: dict
         """
         if name is None:
             raise ValueError('name must be provided')
+        if classname_positive_examples is None:
+            raise ValueError('classname_positive_examples must be provided')
         headers = {}
         if 'headers' in kwargs:
             headers.update(kwargs.get('headers'))
         params = {'version': self.version}
-        data = {'name': name}
+        name_tuple = (None, name, 'text/plain')
+        if not classname_positive_examples_filename and hasattr(
+                classname_positive_examples, 'name'):
+            classname_positive_examples_filename = classname_positive_examples.name
+        mime_type = 'application/octet-stream'
+        classname_positive_examples_tuple = (
+            classname_positive_examples_filename, classname_positive_examples,
+            mime_type)
+        negative_examples_tuple = None
+        if negative_examples:
+            if not negative_examples_filename and hasattr(
+                    negative_examples, 'name'):
+                negative_examples_filename = negative_examples.name
+            if not negative_examples_filename:
+                raise ValueError('negative_examples_filename must be provided')
+            mime_type = 'application/octet-stream'
+            negative_examples_tuple = (negative_examples_filename,
+                                       negative_examples, mime_type)
         url = '/v3/classifiers'
         response = self.request(
             method='POST',
             url=url,
             headers=headers,
             params=params,
-            data=data,
-            files=kwargs,
+            files={
+                'name': name_tuple,
+                'classname_positive_examples':
+                classname_positive_examples_tuple,
+                'negative_examples': negative_examples_tuple
+            },
             accept_json=True)
         return response
 
@@ -314,7 +392,8 @@ class VisualRecognitionV3(WatsonService):
         """
         Retrieve a list of classifiers.
 
-        :param bool verbose: Specify `true` to return details about the classifiers. Omit this parameter to return a brief list of classifiers.
+        :param bool verbose: Specify `true` to return details about the classifiers. Omit
+        this parameter to return a brief list of classifiers.
         :param dict headers: A `dict` containing the request headers
         :return: A `dict` containing the `Classifiers` response.
         :rtype: dict
@@ -334,12 +413,45 @@ class VisualRecognitionV3(WatsonService):
 
     def update_classifier(self,
                           classifier_id,
+                          classname_positive_examples=None,
+                          negative_examples=None,
+                          classname_positive_examples_filename=None,
+                          negative_examples_filename=None,
                           **kwargs):
         """
         Update a classifier.
+
+        Update a custom classifier by adding new positive or negative classes (examples)
+        or by adding new images to existing classes. You must supply at least one set of
+        positive or negative examples. For details, see [Updating custom
+        classifiers](https://console.bluemix.net/docs/services/visual-recognition/customizing.html#updating-custom-classifiers).
+        Encode all names in UTF-8 if they contain non-ASCII characters (.zip and image
+        file names, and classifier and class names). The service assumes UTF-8 encoding if
+        it encounters non-ASCII characters.
+        **Tip:** Don't make retraining calls on a classifier until the status is ready.
+        When you submit retraining requests in parallel, the last request overwrites the
+        previous requests. The retrained property shows the last time the classifier
+        retraining finished.
+
         :param str classifier_id: The ID of the classifier.
-        :param file <NAME>_positive_examples: A compressed (.zip) file of images that depict the visual subject for a class within the classifier. Must contain a minimum of 10 images.
-        :param file negative_examples: A compressed (.zip) file of images that do not depict the visual subject of any of the classes of the new classifier. Must contain a minimum of 10 images.
+        :param file classname_positive_examples: A .zip file of images that depict the
+        visual subject of a class in the classifier. The positive examples create or
+        update classes in the classifier. You can include more than one positive example
+        file in a call.
+        Specify the parameter name by appending `_positive_examples` to the class name.
+        For example, `goldenretriever_positive_examples` creates the class
+        `goldenretriever`.
+        Include at least 10 images in .jpg or .png format. The minimum recommended image
+        resolution is 32X32 pixels. The maximum number of images is 10,000 images or 100
+        MB per .zip file.
+        Encode special characters in the file name in UTF-8.
+        :param file negative_examples: A .zip file of images that do not depict the visual
+        subject of any of the classes of the new classifier. Must contain a minimum of 10
+        images.
+        Encode special characters in the file name in UTF-8.
+        :param str classname_positive_examples_filename: The filename for
+        classname_positive_examples.
+        :param str negative_examples_filename: The filename for negative_examples.
         :param dict headers: A `dict` containing the request headers
         :return: A `dict` containing the `Classifier` response.
         :rtype: dict
@@ -350,6 +462,25 @@ class VisualRecognitionV3(WatsonService):
         if 'headers' in kwargs:
             headers.update(kwargs.get('headers'))
         params = {'version': self.version}
+        classname_positive_examples_tuple = None
+        if classname_positive_examples:
+            if not classname_positive_examples_filename and hasattr(
+                    classname_positive_examples, 'name'):
+                classname_positive_examples_filename = classname_positive_examples.name
+            mime_type = 'application/octet-stream'
+            classname_positive_examples_tuple = (
+                classname_positive_examples_filename,
+                classname_positive_examples, mime_type)
+        negative_examples_tuple = None
+        if negative_examples:
+            if not negative_examples_filename and hasattr(
+                    negative_examples, 'name'):
+                negative_examples_filename = negative_examples.name
+            if not negative_examples_filename:
+                raise ValueError('negative_examples_filename must be provided')
+            mime_type = 'application/octet-stream'
+            negative_examples_tuple = (negative_examples_filename,
+                                       negative_examples, mime_type)
         url = '/v3/classifiers/{0}'.format(
             *self._encode_path_vars(classifier_id))
         response = self.request(
@@ -357,7 +488,11 @@ class VisualRecognitionV3(WatsonService):
             url=url,
             headers=headers,
             params=params,
-            files=kwargs,
+            files={
+                'classname_positive_examples':
+                classname_positive_examples_tuple,
+                'negative_examples': negative_examples_tuple
+            },
             accept_json=True)
         return response
 
@@ -402,9 +537,10 @@ class VisualRecognitionV3(WatsonService):
         Delete labeled data.
 
         Deletes all data associated with a specified customer ID. The method has no effect
-        if no data is associated with the customer ID.   You associate a customer ID with
-        data by passing the `X-Watson-Metadata` header with a request that passes data.
-        For more information about personal data and customer IDs, see [Information
+        if no data is associated with the customer ID.
+        You associate a customer ID with data by passing the `X-Watson-Metadata` header
+        with a request that passes data. For more information about personal data and
+        customer IDs, see [Information
         security](https://console.bluemix.net/docs/services/visual-recognition/information-security.html).
 
         :param str customer_id: The customer ID for which all data is to be deleted.
@@ -485,8 +621,11 @@ class ClassResult(object):
     Result of a class within a classifier.
 
     :attr str class_name: Name of the class.
-    :attr float score: (optional) Confidence score for the property in the range of 0 to 1. A higher score indicates greater likelihood that the class is depicted in the image. The default threshold for returning scores from a classifier is 0.5.
-    :attr str type_hierarchy: (optional) Knowledge graph of the property. For example, `/fruit/pome/apple/eating apple/Granny Smith`. Included only if identified.
+    :attr float score: (optional) Confidence score for the property in the range of 0 to
+    1. A higher score indicates greater likelihood that the class is depicted in the
+    image. The default threshold for returning scores from a classifier is 0.5.
+    :attr str type_hierarchy: (optional) Knowledge graph of the property. For example,
+    `/fruit/pome/apple/eating apple/Granny Smith`. Included only if identified.
     """
 
     def __init__(self, class_name, score=None, type_hierarchy=None):
@@ -494,8 +633,12 @@ class ClassResult(object):
         Initialize a ClassResult object.
 
         :param str class_name: Name of the class.
-        :param float score: (optional) Confidence score for the property in the range of 0 to 1. A higher score indicates greater likelihood that the class is depicted in the image. The default threshold for returning scores from a classifier is 0.5.
-        :param str type_hierarchy: (optional) Knowledge graph of the property. For example, `/fruit/pome/apple/eating apple/Granny Smith`. Included only if identified.
+        :param float score: (optional) Confidence score for the property in the range of 0
+        to 1. A higher score indicates greater likelihood that the class is depicted in
+        the image. The default threshold for returning scores from a classifier is 0.5.
+        :param str type_hierarchy: (optional) Knowledge graph of the property. For
+        example, `/fruit/pome/apple/eating apple/Granny Smith`. Included only if
+        identified.
         """
         self.class_name = class_name
         self.score = score
@@ -546,10 +689,14 @@ class ClassifiedImage(object):
     """
     Results for one image.
 
-    :attr str source_url: (optional) Source of the image before any redirects. Not returned when the image is uploaded.
-    :attr str resolved_url: (optional) Fully resolved URL of the image after redirects are followed. Not returned when the image is uploaded.
-    :attr str image: (optional) Relative path of the image file if uploaded directly. Not returned when the image is passed by URL.
-    :attr ErrorInfo error: (optional) Information about what might have caused a failure, such as an image that is too large. Not returned when there is no error.
+    :attr str source_url: (optional) Source of the image before any redirects. Not
+    returned when the image is uploaded.
+    :attr str resolved_url: (optional) Fully resolved URL of the image after redirects are
+    followed. Not returned when the image is uploaded.
+    :attr str image: (optional) Relative path of the image file if uploaded directly. Not
+    returned when the image is passed by URL.
+    :attr ErrorInfo error: (optional) Information about what might have caused a failure,
+    such as an image that is too large. Not returned when there is no error.
     :attr list[ClassifierResult] classifiers: The classifiers.
     """
 
@@ -563,10 +710,14 @@ class ClassifiedImage(object):
         Initialize a ClassifiedImage object.
 
         :param list[ClassifierResult] classifiers: The classifiers.
-        :param str source_url: (optional) Source of the image before any redirects. Not returned when the image is uploaded.
-        :param str resolved_url: (optional) Fully resolved URL of the image after redirects are followed. Not returned when the image is uploaded.
-        :param str image: (optional) Relative path of the image file if uploaded directly. Not returned when the image is passed by URL.
-        :param ErrorInfo error: (optional) Information about what might have caused a failure, such as an image that is too large. Not returned when there is no error.
+        :param str source_url: (optional) Source of the image before any redirects. Not
+        returned when the image is uploaded.
+        :param str resolved_url: (optional) Fully resolved URL of the image after
+        redirects are followed. Not returned when the image is uploaded.
+        :param str image: (optional) Relative path of the image file if uploaded directly.
+        Not returned when the image is passed by URL.
+        :param ErrorInfo error: (optional) Information about what might have caused a
+        failure, such as an image that is too large. Not returned when there is no error.
         """
         self.source_url = source_url
         self.resolved_url = resolved_url
@@ -631,10 +782,14 @@ class ClassifiedImages(object):
     """
     Results for all images.
 
-    :attr int custom_classes: (optional) Number of custom classes identified in the images.
+    :attr int custom_classes: (optional) Number of custom classes identified in the
+    images.
     :attr int images_processed: (optional) Number of images processed for the API call.
     :attr list[ClassifiedImage] images: Classified images.
-    :attr list[WarningInfo] warnings: (optional) Information about what might cause less than optimal output. For example, a request sent with a corrupt .zip file and a list of image URLs will still complete, but does not return the expected output. Not returned when there is no warning.
+    :attr list[WarningInfo] warnings: (optional) Information about what might cause less
+    than optimal output. For example, a request sent with a corrupt .zip file and a list
+    of image URLs will still complete, but does not return the expected output. Not
+    returned when there is no warning.
     """
 
     def __init__(self,
@@ -646,9 +801,14 @@ class ClassifiedImages(object):
         Initialize a ClassifiedImages object.
 
         :param list[ClassifiedImage] images: Classified images.
-        :param int custom_classes: (optional) Number of custom classes identified in the images.
-        :param int images_processed: (optional) Number of images processed for the API call.
-        :param list[WarningInfo] warnings: (optional) Information about what might cause less than optimal output. For example, a request sent with a corrupt .zip file and a list of image URLs will still complete, but does not return the expected output. Not returned when there is no warning.
+        :param int custom_classes: (optional) Number of custom classes identified in the
+        images.
+        :param int images_processed: (optional) Number of images processed for the API
+        call.
+        :param list[WarningInfo] warnings: (optional) Information about what might cause
+        less than optimal output. For example, a request sent with a corrupt .zip file and
+        a list of image URLs will still complete, but does not return the expected output.
+        Not returned when there is no warning.
         """
         self.custom_classes = custom_classes
         self.images_processed = images_processed
@@ -712,14 +872,22 @@ class Classifier(object):
 
     :attr str classifier_id: ID of a classifier identified in the image.
     :attr str name: Name of the classifier.
-    :attr str owner: (optional) Unique ID of the account who owns the classifier. Returned when verbose=`true`. Might not be returned by some requests.
+    :attr str owner: (optional) Unique ID of the account who owns the classifier. Returned
+    when verbose=`true`. Might not be returned by some requests.
     :attr str status: (optional) Training status of classifier.
-    :attr bool core_ml_enabled: Whether the classifier can be downloaded as a Core ML model after the training status is `ready`.
-    :attr str explanation: (optional) If classifier training has failed, this field may explain why.
-    :attr datetime created: (optional) Date and time in Coordinated Universal Time (UTC) that the classifier was created.
+    :attr bool core_ml_enabled: Whether the classifier can be downloaded as a Core ML
+    model after the training status is `ready`.
+    :attr str explanation: (optional) If classifier training has failed, this field may
+    explain why.
+    :attr datetime created: (optional) Date and time in Coordinated Universal Time (UTC)
+    that the classifier was created.
     :attr list[Class] classes: (optional) Classes that define a classifier.
-    :attr datetime retrained: (optional) Date and time in Coordinated Universal Time (UTC) that the classifier was updated. Returned when verbose=`true`. Might not be returned by some requests. Identical to `updated` and retained for backward compatibility.
-    :attr datetime updated: (optional) Date and time in Coordinated Universal Time (UTC) that the classifier was most recently updated. The field matches either `retrained` or `created`.  Returned when verbose=`true`. Might not be returned by some requests.
+    :attr datetime retrained: (optional) Date and time in Coordinated Universal Time (UTC)
+    that the classifier was updated. Returned when verbose=`true`. Might not be returned
+    by some requests. Identical to `updated` and retained for backward compatibility.
+    :attr datetime updated: (optional) Date and time in Coordinated Universal Time (UTC)
+    that the classifier was most recently updated. The field matches either `retrained` or
+    `created`.  Returned when verbose=`true`. Might not be returned by some requests.
     """
 
     def __init__(self,
@@ -738,14 +906,24 @@ class Classifier(object):
 
         :param str classifier_id: ID of a classifier identified in the image.
         :param str name: Name of the classifier.
-        :param bool core_ml_enabled: Whether the classifier can be downloaded as a Core ML model after the training status is `ready`.
-        :param str owner: (optional) Unique ID of the account who owns the classifier. Returned when verbose=`true`. Might not be returned by some requests.
+        :param bool core_ml_enabled: Whether the classifier can be downloaded as a Core ML
+        model after the training status is `ready`.
+        :param str owner: (optional) Unique ID of the account who owns the classifier.
+        Returned when verbose=`true`. Might not be returned by some requests.
         :param str status: (optional) Training status of classifier.
-        :param str explanation: (optional) If classifier training has failed, this field may explain why.
-        :param datetime created: (optional) Date and time in Coordinated Universal Time (UTC) that the classifier was created.
+        :param str explanation: (optional) If classifier training has failed, this field
+        may explain why.
+        :param datetime created: (optional) Date and time in Coordinated Universal Time
+        (UTC) that the classifier was created.
         :param list[Class] classes: (optional) Classes that define a classifier.
-        :param datetime retrained: (optional) Date and time in Coordinated Universal Time (UTC) that the classifier was updated. Returned when verbose=`true`. Might not be returned by some requests. Identical to `updated` and retained for backward compatibility.
-        :param datetime updated: (optional) Date and time in Coordinated Universal Time (UTC) that the classifier was most recently updated. The field matches either `retrained` or `created`.  Returned when verbose=`true`. Might not be returned by some requests.
+        :param datetime retrained: (optional) Date and time in Coordinated Universal Time
+        (UTC) that the classifier was updated. Returned when verbose=`true`. Might not be
+        returned by some requests. Identical to `updated` and retained for backward
+        compatibility.
+        :param datetime updated: (optional) Date and time in Coordinated Universal Time
+        (UTC) that the classifier was most recently updated. The field matches either
+        `retrained` or `created`.  Returned when verbose=`true`. Might not be returned by
+        some requests.
         """
         self.classifier_id = classifier_id
         self.name = name
@@ -968,7 +1146,10 @@ class DetectedFaces(object):
 
     :attr int images_processed: (optional) Number of images processed for the API call.
     :attr list[ImageWithFaces] images: The images.
-    :attr list[WarningInfo] warnings: (optional) Information about what might cause less than optimal output. For example, a request sent with a corrupt .zip file and a list of image URLs will still complete, but does not return the expected output. Not returned when there is no warning.
+    :attr list[WarningInfo] warnings: (optional) Information about what might cause less
+    than optimal output. For example, a request sent with a corrupt .zip file and a list
+    of image URLs will still complete, but does not return the expected output. Not
+    returned when there is no warning.
     """
 
     def __init__(self, images, images_processed=None, warnings=None):
@@ -976,8 +1157,12 @@ class DetectedFaces(object):
         Initialize a DetectedFaces object.
 
         :param list[ImageWithFaces] images: The images.
-        :param int images_processed: (optional) Number of images processed for the API call.
-        :param list[WarningInfo] warnings: (optional) Information about what might cause less than optimal output. For example, a request sent with a corrupt .zip file and a list of image URLs will still complete, but does not return the expected output. Not returned when there is no warning.
+        :param int images_processed: (optional) Number of images processed for the API
+        call.
+        :param list[WarningInfo] warnings: (optional) Information about what might cause
+        less than optimal output. For example, a request sent with a corrupt .zip file and
+        a list of image URLs will still complete, but does not return the expected output.
+        Not returned when there is no warning.
         """
         self.images_processed = images_processed
         self.images = images
@@ -1036,7 +1221,8 @@ class ErrorInfo(object):
     large. Not returned when there is no error.
 
     :attr int code: HTTP status code.
-    :attr str description: Human-readable error description. For example, `File size limit exceeded`.
+    :attr str description: Human-readable error description. For example, `File size limit
+    exceeded`.
     :attr str error_id: Codified error string. For example, `limit_exceeded`.
     """
 
@@ -1045,7 +1231,8 @@ class ErrorInfo(object):
         Initialize a ErrorInfo object.
 
         :param int code: HTTP status code.
-        :param str description: Human-readable error description. For example, `File size limit exceeded`.
+        :param str description: Human-readable error description. For example, `File size
+        limit exceeded`.
         :param str error_id: Codified error string. For example, `limit_exceeded`.
         """
         self.code = code
@@ -1106,7 +1293,8 @@ class Face(object):
 
     :attr FaceAge age: (optional) Age information about a face.
     :attr FaceGender gender: (optional) Information about the gender of the face.
-    :attr FaceLocation face_location: (optional) The location of the bounding box around the face.
+    :attr FaceLocation face_location: (optional) The location of the bounding box around
+    the face.
     """
 
     def __init__(self, age=None, gender=None, face_location=None):
@@ -1115,7 +1303,8 @@ class Face(object):
 
         :param FaceAge age: (optional) Age information about a face.
         :param FaceGender gender: (optional) Information about the gender of the face.
-        :param FaceLocation face_location: (optional) The location of the bounding box around the face.
+        :param FaceLocation face_location: (optional) The location of the bounding box
+        around the face.
         """
         self.age = age
         self.gender = gender
@@ -1166,7 +1355,8 @@ class FaceAge(object):
 
     :attr int min: (optional) Estimated minimum age.
     :attr int max: (optional) Estimated maximum age.
-    :attr float score: (optional) Confidence score in the range of 0 to 1. A higher score indicates greater confidence in the estimated value for the property.
+    :attr float score: (optional) Confidence score in the range of 0 to 1. A higher score
+    indicates greater confidence in the estimated value for the property.
     """
 
     def __init__(self, min=None, max=None, score=None):
@@ -1175,7 +1365,8 @@ class FaceAge(object):
 
         :param int min: (optional) Estimated minimum age.
         :param int max: (optional) Estimated maximum age.
-        :param float score: (optional) Confidence score in the range of 0 to 1. A higher score indicates greater confidence in the estimated value for the property.
+        :param float score: (optional) Confidence score in the range of 0 to 1. A higher
+        score indicates greater confidence in the estimated value for the property.
         """
         self.min = min
         self.max = max
@@ -1224,7 +1415,8 @@ class FaceGender(object):
     Information about the gender of the face.
 
     :attr str gender: Gender identified by the face. For example, `MALE` or `FEMALE`.
-    :attr float score: (optional) Confidence score in the range of 0 to 1. A higher score indicates greater confidence in the estimated value for the property.
+    :attr float score: (optional) Confidence score in the range of 0 to 1. A higher score
+    indicates greater confidence in the estimated value for the property.
     """
 
     def __init__(self, gender, score=None):
@@ -1232,7 +1424,8 @@ class FaceGender(object):
         Initialize a FaceGender object.
 
         :param str gender: Gender identified by the face. For example, `MALE` or `FEMALE`.
-        :param float score: (optional) Confidence score in the range of 0 to 1. A higher score indicates greater confidence in the estimated value for the property.
+        :param float score: (optional) Confidence score in the range of 0 to 1. A higher
+        score indicates greater confidence in the estimated value for the property.
         """
         self.gender = gender
         self.score = score
@@ -1358,10 +1551,14 @@ class ImageWithFaces(object):
     Information about faces in the image.
 
     :attr list[Face] faces: Faces detected in the images.
-    :attr str image: (optional) Relative path of the image file if uploaded directly. Not returned when the image is passed by URL.
-    :attr str source_url: (optional) Source of the image before any redirects. Not returned when the image is uploaded.
-    :attr str resolved_url: (optional) Fully resolved URL of the image after redirects are followed. Not returned when the image is uploaded.
-    :attr ErrorInfo error: (optional) Information about what might have caused a failure, such as an image that is too large. Not returned when there is no error.
+    :attr str image: (optional) Relative path of the image file if uploaded directly. Not
+    returned when the image is passed by URL.
+    :attr str source_url: (optional) Source of the image before any redirects. Not
+    returned when the image is uploaded.
+    :attr str resolved_url: (optional) Fully resolved URL of the image after redirects are
+    followed. Not returned when the image is uploaded.
+    :attr ErrorInfo error: (optional) Information about what might have caused a failure,
+    such as an image that is too large. Not returned when there is no error.
     """
 
     def __init__(self,
@@ -1374,10 +1571,14 @@ class ImageWithFaces(object):
         Initialize a ImageWithFaces object.
 
         :param list[Face] faces: Faces detected in the images.
-        :param str image: (optional) Relative path of the image file if uploaded directly. Not returned when the image is passed by URL.
-        :param str source_url: (optional) Source of the image before any redirects. Not returned when the image is uploaded.
-        :param str resolved_url: (optional) Fully resolved URL of the image after redirects are followed. Not returned when the image is uploaded.
-        :param ErrorInfo error: (optional) Information about what might have caused a failure, such as an image that is too large. Not returned when there is no error.
+        :param str image: (optional) Relative path of the image file if uploaded directly.
+        Not returned when the image is passed by URL.
+        :param str source_url: (optional) Source of the image before any redirects. Not
+        returned when the image is uploaded.
+        :param str resolved_url: (optional) Fully resolved URL of the image after
+        redirects are followed. Not returned when the image is uploaded.
+        :param ErrorInfo error: (optional) Information about what might have caused a
+        failure, such as an image that is too large. Not returned when there is no error.
         """
         self.faces = faces
         self.image = image
@@ -1390,7 +1591,7 @@ class ImageWithFaces(object):
         """Initialize a ImageWithFaces object from a json dictionary."""
         args = {}
         if 'faces' in _dict:
-            args['faces'] = [Face._from_dict(x) for x in _dict.get('faces')]
+            args['faces'] = [Face._from_dict(x) for x in (_dict.get('faces'))]
         else:
             raise ValueError(
                 'Required property \'faces\' not present in ImageWithFaces JSON'

--- a/watson_developer_cloud/websocket/recognize_abstract_callback.py
+++ b/watson_developer_cloud/websocket/recognize_abstract_callback.py
@@ -60,3 +60,9 @@ class RecognizeCallback(object):
     Called when the service returns the final hypothesis
     """
         pass
+
+    def on_data(self, data):
+        """
+    Called when the service returns results. The data is returned unparsed.
+    """
+        pass

--- a/watson_developer_cloud/websocket/speech_to_text_websocket_listener.py
+++ b/watson_developer_cloud/websocket/speech_to_text_websocket_listener.py
@@ -138,8 +138,9 @@ class RecognizeListener(object):
 
                     if b_final:
                         self.callback.on_hypothesis(hypothesis)
-                    else:
-                        self.callback.on_transcription(transcripts)
+
+                    self.callback.on_transcription(transcripts)
+                    self.callback.on_data(json_object)
 
         def onClose(self, wasClean, code, reason):
             self.factory.endReactor()


### PR DESCRIPTION
Following codegen and api-definitions were used:
```
https://github.ibm.com/Watson/developer-cloud--api-definitions/tree/a3d247f2d250edf5b9743a41afcfebda52f66cf4
https://github.ibm.com/MIL/watson-swagger-codegen/tree/1b4341039c46d6794f65a12932698cb7aeb1c236
```
Changes:
* Language Translator V3 with unit tests
* Added deprecation for LTV2
* `on_data()` method for recognize with speech to text which would return the unparsed data
