### PR TITLE
Deprecate CF tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,8 @@ Watson services are migrating to token-based Identity and Access Management (IAM
 - In other instances, you authenticate by providing the **[username and password](#username-and-password)** for the service instance.
 - Visual Recognition uses a form of [API key](#api-key) only with instances created before May 23, 2018. Newer instances of Visual Recognition use IAM.
 
+**Note:** Previously, it was possible to authenticate using a token in a header called `X-Watson-Authorization-Token`. This method is deprecated. The token continues to work with Cloud Foundry services, but is not supported for services that use Identity and Access Management (IAM) authentication. See [here](#iam) for details.
+
 ### Getting credentials
 To find out which authentication to use, view the service credentials. You find the service credentials for authentication the same way for all Watson services:
 

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Watson services are migrating to token-based Identity and Access Management (IAM
 - In other instances, you authenticate by providing the **[username and password](#username-and-password)** for the service instance.
 - Visual Recognition uses a form of [API key](#api-key) only with instances created before May 23, 2018. Newer instances of Visual Recognition use IAM.
 
-**Note:** Previously, it was possible to authenticate using a token in a header called `X-Watson-Authorization-Token`. This method is deprecated. The token continues to work with Cloud Foundry services, but is not supported for services that use Identity and Access Management (IAM) authentication. See [here](#iam) for details.
+**Note:** Authenticating with the X-Watson-Authorization-Token header is deprecated. The token continues to work with Cloud Foundry services, but is not supported for services that use Identity and Access Management (IAM) authentication. See [here](#iam) for details.
 
 ### Getting credentials
 To find out which authentication to use, view the service credentials. You find the service credentials for authentication the same way for all Watson services:

--- a/watson_developer_cloud/watson_service.py
+++ b/watson_developer_cloud/watson_service.py
@@ -20,6 +20,7 @@ import sys
 from requests.structures import CaseInsensitiveDict
 import dateutil.parser as date_parser
 from .iam_token_manager import IAMTokenManager
+import warnings
 
 try:
     from http.cookiejar import CookieJar  # Python 3
@@ -28,6 +29,8 @@ except ImportError:
 from .version import __version__
 
 BEARER = 'Bearer'
+X_WATSON_AUTHORIZATION_TOKEN = 'X-Watson-Authorization-Token'
+AUTH_HEADER_DEPRECATION_MESSAGE = 'Authenticating with the X-Watson-Authorization-Token header is deprecated. The token continues to work with Cloud Foundry services, but is not supported for services that use Identity and Access Management (IAM) authentication.'
 
 # Uncomment this to enable http debugging
 # try:
@@ -400,6 +403,9 @@ class WatsonService(object):
         if accept_json:
             headers['accept'] = 'application/json'
         headers.update(input_headers)
+
+        if X_WATSON_AUTHORIZATION_TOKEN in headers:
+            warnings.warn(AUTH_HEADER_DEPRECATION_MESSAGE)
 
         # Remove keys with None values
         params = _remove_null_values(params)


### PR DESCRIPTION
CF Watson tokens will not be supported in IAM instances. We need to deprecate CF Watson token support in the SDKs once CF goes away.