### PR TITLE
V1.7.1

### DIFF
--- a/examples/tone_analyzer_v3.py
+++ b/examples/tone_analyzer_v3.py
@@ -65,6 +65,7 @@ with open(join(dirname(__file__),
 print(tone)
 print(tone.get_headers())
 print(tone.get_result())
+print(tone.get_status_code())
 tone_analyzer.set_detailed_response(False)
 
 print("\ntone() example 7:\n")

--- a/test/unit/test_watson_service.py
+++ b/test/unit/test_watson_service.py
@@ -26,7 +26,7 @@ class AnyServiceV1(WatsonService):
             username=username,
             password=password,
             use_vcap_services=True,
-            iam_api_key=iam_api_key,
+            iam_apikey=iam_api_key,
             iam_access_token=iam_access_token,
             iam_url=iam_url)
         self.version = version
@@ -107,7 +107,7 @@ def test_iam():
     iam_url = "https://iam.bluemix.net/identity/token"
     service = AnyServiceV1('2017-07-07', username='xxx', password='yyy')
     assert service.token_manager is None
-    service.set_iam_api_key('yyy')
+    service.set_iam_apikey('yyy')
     assert service.token_manager is not None
 
     service.token_manager.token_info = {
@@ -136,14 +136,14 @@ def test_iam():
 def test_when_apikey_is_username():
     service1 = AnyServiceV1('2017-07-07', username='apikey', password='xxxxx')
     assert service1.token_manager is not None
-    assert service1.iam_api_key is 'xxxxx'
+    assert service1.iam_apikey is 'xxxxx'
     assert service1.username is None
     assert service1.password is None
     assert service1.token_manager.iam_url == 'https://iam.bluemix.net/identity/token'
 
     service2 = AnyServiceV1('2017-07-07', username='apikey', password='xxxxx', iam_url='https://iam.stage1.bluemix.net/identity/token')
     assert service2.token_manager is not None
-    assert service2.iam_api_key is 'xxxxx'
+    assert service2.iam_apikey is 'xxxxx'
     assert service2.username is None
     assert service2.password is None
     assert service2.token_manager.iam_url == 'https://iam.stage1.bluemix.net/identity/token'

--- a/watson_developer_cloud/assistant_v1.py
+++ b/watson_developer_cloud/assistant_v1.py
@@ -44,6 +44,7 @@ class AssistantV1(WatsonService):
             iam_api_key=None,
             iam_access_token=None,
             iam_url=None,
+            iam_apikey=None,
     ):
         """
         Construct a new client for the Assistant service.
@@ -75,7 +76,7 @@ class AssistantV1(WatsonService):
                Bluemix, the credentials will be automatically loaded from the
                `VCAP_SERVICES` environment variable.
 
-        :param str iam_api_key: An API key that can be used to request IAM tokens. If
+        :param str iam_api_key(deprecated): Use iam_apikey. An API key that can be used to request IAM tokens. If
                this API key is provided, the SDK will manage the token and handle the
                refreshing.
 
@@ -87,7 +88,6 @@ class AssistantV1(WatsonService):
         :param str iam_url: An optional URL for the IAM service API. Defaults to
                'https://iam.bluemix.net/identity/token'.
         """
-
         WatsonService.__init__(
             self,
             vcap_services_name='conversation',
@@ -95,6 +95,7 @@ class AssistantV1(WatsonService):
             username=username,
             password=password,
             iam_api_key=iam_api_key,
+            iam_apikey=iam_apikey,
             iam_access_token=iam_access_token,
             iam_url=iam_url,
             use_vcap_services=True)

--- a/watson_developer_cloud/conversation_v1.py
+++ b/watson_developer_cloud/conversation_v1.py
@@ -44,6 +44,7 @@ class ConversationV1(WatsonService):
             iam_api_key=None,
             iam_access_token=None,
             iam_url=None,
+            iam_apikey=None,
     ):
         """
         Construct a new client for the Conversation service.
@@ -75,7 +76,7 @@ class ConversationV1(WatsonService):
                Bluemix, the credentials will be automatically loaded from the
                `VCAP_SERVICES` environment variable.
 
-        :param str iam_api_key: An API key that can be used to request IAM tokens. If
+        :param str iam_api_key(deprecated): Use iam_apikey. An API key that can be used to request IAM tokens. If
                this API key is provided, the SDK will manage the token and handle the
                refreshing.
 
@@ -95,6 +96,7 @@ class ConversationV1(WatsonService):
             username=username,
             password=password,
             iam_api_key=iam_api_key,
+            iam_apikey=iam_apikey,
             iam_access_token=iam_access_token,
             iam_url=iam_url,
             use_vcap_services=True)

--- a/watson_developer_cloud/discovery_v1.py
+++ b/watson_developer_cloud/discovery_v1.py
@@ -46,6 +46,7 @@ class DiscoveryV1(WatsonService):
             iam_api_key=None,
             iam_access_token=None,
             iam_url=None,
+            iam_apikey=None,
     ):
         """
         Construct a new client for the Discovery service.
@@ -77,7 +78,7 @@ class DiscoveryV1(WatsonService):
                Bluemix, the credentials will be automatically loaded from the
                `VCAP_SERVICES` environment variable.
 
-        :param str iam_api_key: An API key that can be used to request IAM tokens. If
+        :param str iam_api_key(deprecated): Use iam_apikey. An API key that can be used to request IAM tokens. If
                this API key is provided, the SDK will manage the token and handle the
                refreshing.
 
@@ -97,6 +98,7 @@ class DiscoveryV1(WatsonService):
             username=username,
             password=password,
             iam_api_key=iam_api_key,
+            iam_apikey=iam_apikey,
             iam_access_token=iam_access_token,
             iam_url=iam_url,
             use_vcap_services=True)

--- a/watson_developer_cloud/iam_token_manager.py
+++ b/watson_developer_cloud/iam_token_manager.py
@@ -1,5 +1,6 @@
 import requests
 import time
+from .utils import deprecated
 
 DEFAULT_IAM_URL = 'https://iam.bluemix.net/identity/token'
 CONTENT_TYPE = 'application/x-www-form-urlencoded'
@@ -10,8 +11,8 @@ REQUEST_TOKEN_RESPONSE_TYPE = 'cloud_iam'
 REFRESH_TOKEN_GRANT_TYPE = 'refresh_token'
 
 class IAMTokenManager(object):
-    def __init__(self, iam_api_key=None, iam_access_token=None, iam_url=None):
-        self.iam_api_key = iam_api_key
+    def __init__(self, iam_apikey=None, iam_access_token=None, iam_url=None):
+        self.iam_apikey = iam_apikey
         self.user_access_token = iam_access_token
         self.iam_url = iam_url if iam_url else DEFAULT_IAM_URL
         self.token_info = {
@@ -68,7 +69,7 @@ class IAMTokenManager(object):
         }
         data = {
             'grant_type': REQUEST_TOKEN_GRANT_TYPE,
-            'apikey': self.iam_api_key,
+            'apikey': self.iam_apikey,
             'response_type': REQUEST_TOKEN_RESPONSE_TYPE
         }
         response = self.request(
@@ -105,11 +106,19 @@ class IAMTokenManager(object):
         """
         self.user_access_token = iam_access_token
 
+    @deprecated('Use set_iam_apikey() instead')
     def set_iam_api_key(self, iam_api_key):
         """
         Set the IAM api key
         """
-        self.iam_api_key = iam_api_key
+        self.iam_apikey = iam_api_key
+
+
+    def set_iam_apikey(self, iam_apikey):
+        """
+        Set the IAM api key
+        """
+        self.iam_apikey = iam_apikey
 
     def _is_token_expired(self):
         """

--- a/watson_developer_cloud/language_translator_v2.py
+++ b/watson_developer_cloud/language_translator_v2.py
@@ -52,6 +52,7 @@ class LanguageTranslatorV2(WatsonService):
             iam_api_key=None,
             iam_access_token=None,
             iam_url=None,
+            iam_apikey=None,
     ):
         """
         Construct a new client for the Language Translator service.
@@ -72,7 +73,7 @@ class LanguageTranslatorV2(WatsonService):
                Bluemix, the credentials will be automatically loaded from the
                `VCAP_SERVICES` environment variable.
 
-        :param str iam_api_key: An API key that can be used to request IAM tokens. If
+        :param str iam_api_key(deprecated): Use iam_apikey. An API key that can be used to request IAM tokens. If
                this API key is provided, the SDK will manage the token and handle the
                refreshing.
 
@@ -92,6 +93,7 @@ class LanguageTranslatorV2(WatsonService):
             username=username,
             password=password,
             iam_api_key=iam_api_key,
+            iam_apikey=iam_apikey,
             iam_access_token=iam_access_token,
             iam_url=iam_url,
             use_vcap_services=True)

--- a/watson_developer_cloud/language_translator_v3.py
+++ b/watson_developer_cloud/language_translator_v3.py
@@ -45,6 +45,7 @@ class LanguageTranslatorV3(WatsonService):
             iam_api_key=None,
             iam_access_token=None,
             iam_url=None,
+            iam_apikey=None,
     ):
         """
         Construct a new client for the Language Translator service.
@@ -76,7 +77,7 @@ class LanguageTranslatorV3(WatsonService):
                Bluemix, the credentials will be automatically loaded from the
                `VCAP_SERVICES` environment variable.
 
-        :param str iam_api_key: An API key that can be used to request IAM tokens. If
+        :param str iam_api_key(deprecated): Use iam_apikey. An API key that can be used to request IAM tokens. If
                this API key is provided, the SDK will manage the token and handle the
                refreshing.
 
@@ -96,6 +97,7 @@ class LanguageTranslatorV3(WatsonService):
             username=username,
             password=password,
             iam_api_key=iam_api_key,
+            iam_apikey=iam_apikey,
             iam_access_token=iam_access_token,
             iam_url=iam_url,
             use_vcap_services=True)

--- a/watson_developer_cloud/natural_language_classifier_v1.py
+++ b/watson_developer_cloud/natural_language_classifier_v1.py
@@ -44,6 +44,7 @@ class NaturalLanguageClassifierV1(WatsonService):
             iam_api_key=None,
             iam_access_token=None,
             iam_url=None,
+            iam_apikey=None,
     ):
         """
         Construct a new client for the Natural Language Classifier service.
@@ -64,7 +65,7 @@ class NaturalLanguageClassifierV1(WatsonService):
                Bluemix, the credentials will be automatically loaded from the
                `VCAP_SERVICES` environment variable.
 
-        :param str iam_api_key: An API key that can be used to request IAM tokens. If
+        :param str iam_api_key(deprecated): Use iam_apikey. An API key that can be used to request IAM tokens. If
                this API key is provided, the SDK will manage the token and handle the
                refreshing.
 
@@ -84,6 +85,7 @@ class NaturalLanguageClassifierV1(WatsonService):
             username=username,
             password=password,
             iam_api_key=iam_api_key,
+            iam_apikey=iam_apikey,
             iam_access_token=iam_access_token,
             iam_url=iam_url,
             use_vcap_services=True)

--- a/watson_developer_cloud/natural_language_understanding_v1.py
+++ b/watson_developer_cloud/natural_language_understanding_v1.py
@@ -48,6 +48,7 @@ class NaturalLanguageUnderstandingV1(WatsonService):
             iam_api_key=None,
             iam_access_token=None,
             iam_url=None,
+            iam_apikey=None,
     ):
         """
         Construct a new client for the Natural Language Understanding service.
@@ -79,7 +80,7 @@ class NaturalLanguageUnderstandingV1(WatsonService):
                Bluemix, the credentials will be automatically loaded from the
                `VCAP_SERVICES` environment variable.
 
-        :param str iam_api_key: An API key that can be used to request IAM tokens. If
+        :param str iam_api_key(deprecated): An API key that can be used to request IAM tokens. If
                this API key is provided, the SDK will manage the token and handle the
                refreshing.
 
@@ -99,6 +100,7 @@ class NaturalLanguageUnderstandingV1(WatsonService):
             username=username,
             password=password,
             iam_api_key=iam_api_key,
+            iam_apikey=iam_apikey,
             iam_access_token=iam_access_token,
             iam_url=iam_url,
             use_vcap_services=True)

--- a/watson_developer_cloud/personality_insights_v3.py
+++ b/watson_developer_cloud/personality_insights_v3.py
@@ -57,6 +57,7 @@ class PersonalityInsightsV3(WatsonService):
             iam_api_key=None,
             iam_access_token=None,
             iam_url=None,
+            iam_apikey=None,
     ):
         """
         Construct a new client for the Personality Insights service.
@@ -88,7 +89,7 @@ class PersonalityInsightsV3(WatsonService):
                Bluemix, the credentials will be automatically loaded from the
                `VCAP_SERVICES` environment variable.
 
-        :param str iam_api_key: An API key that can be used to request IAM tokens. If
+        :param str iam_api_key(deprecated): Use iam_apikey. An API key that can be used to request IAM tokens. If
                this API key is provided, the SDK will manage the token and handle the
                refreshing.
 
@@ -108,6 +109,7 @@ class PersonalityInsightsV3(WatsonService):
             username=username,
             password=password,
             iam_api_key=iam_api_key,
+            iam_apikey=iam_apikey,
             iam_access_token=iam_access_token,
             iam_url=iam_url,
             use_vcap_services=True)

--- a/watson_developer_cloud/speech_to_text_v1.py
+++ b/watson_developer_cloud/speech_to_text_v1.py
@@ -90,6 +90,7 @@ class SpeechToTextV1(WatsonService):
             iam_api_key=None,
             iam_access_token=None,
             iam_url=None,
+            iam_apikey=None,
     ):
         """
         Construct a new client for the Speech to Text service.
@@ -110,7 +111,7 @@ class SpeechToTextV1(WatsonService):
                Bluemix, the credentials will be automatically loaded from the
                `VCAP_SERVICES` environment variable.
 
-        :param str iam_api_key: An API key that can be used to request IAM tokens. If
+        :param str iam_api_key(deprecated): Use iam_apikey. An API key that can be used to request IAM tokens. If
                this API key is provided, the SDK will manage the token and handle the
                refreshing.
 
@@ -130,6 +131,7 @@ class SpeechToTextV1(WatsonService):
             username=username,
             password=password,
             iam_api_key=iam_api_key,
+            iam_apikey=iam_apikey,
             iam_access_token=iam_access_token,
             iam_url=iam_url,
             use_vcap_services=True)

--- a/watson_developer_cloud/text_to_speech_v1.py
+++ b/watson_developer_cloud/text_to_speech_v1.py
@@ -86,6 +86,7 @@ class TextToSpeechV1(WatsonService):
             iam_api_key=None,
             iam_access_token=None,
             iam_url=None,
+            iam_apikey=None,
     ):
         """
         Construct a new client for the Text to Speech service.
@@ -106,7 +107,7 @@ class TextToSpeechV1(WatsonService):
                Bluemix, the credentials will be automatically loaded from the
                `VCAP_SERVICES` environment variable.
 
-        :param str iam_api_key: An API key that can be used to request IAM tokens. If
+        :param str iam_api_key(deprecated): Use iam_apikey. An API key that can be used to request IAM tokens. If
                this API key is provided, the SDK will manage the token and handle the
                refreshing.
 
@@ -126,6 +127,7 @@ class TextToSpeechV1(WatsonService):
             username=username,
             password=password,
             iam_api_key=iam_api_key,
+            iam_apikey=iam_apikey,
             iam_access_token=iam_access_token,
             iam_url=iam_url,
             use_vcap_services=True)

--- a/watson_developer_cloud/tone_analyzer_v3.py
+++ b/watson_developer_cloud/tone_analyzer_v3.py
@@ -49,6 +49,7 @@ class ToneAnalyzerV3(WatsonService):
             iam_api_key=None,
             iam_access_token=None,
             iam_url=None,
+            iam_apikey=None,
     ):
         """
         Construct a new client for the Tone Analyzer service.
@@ -80,7 +81,7 @@ class ToneAnalyzerV3(WatsonService):
                Bluemix, the credentials will be automatically loaded from the
                `VCAP_SERVICES` environment variable.
 
-        :param str iam_api_key: An API key that can be used to request IAM tokens. If
+        :param str iam_api_key(deprecated): Use iam_apikey. An API key that can be used to request IAM tokens. If
                this API key is provided, the SDK will manage the token and handle the
                refreshing.
 
@@ -100,6 +101,7 @@ class ToneAnalyzerV3(WatsonService):
             username=username,
             password=password,
             iam_api_key=iam_api_key,
+            iam_apikey=iam_apikey,
             iam_access_token=iam_access_token,
             iam_url=iam_url,
             use_vcap_services=True)

--- a/watson_developer_cloud/visual_recognition_v3.py
+++ b/watson_developer_cloud/visual_recognition_v3.py
@@ -43,6 +43,7 @@ class VisualRecognitionV3(WatsonService):
             iam_api_key=None,
             iam_access_token=None,
             iam_url=None,
+            iam_apikey=None,
     ):
         """
         Construct a new client for the Visual Recognition service.
@@ -64,7 +65,7 @@ class VisualRecognitionV3(WatsonService):
 
         :param str api_key: The API Key used to authenticate.
 
-        :param str iam_api_key: An API key that can be used to request IAM tokens. If
+        :param str iam_api_key(deprecated): Use iam_apikey. An API key that can be used to request IAM tokens. If
                this API key is provided, the SDK will manage the token and handle the
                refreshing.
 
@@ -83,6 +84,7 @@ class VisualRecognitionV3(WatsonService):
             url=url,
             api_key=api_key,
             iam_api_key=iam_api_key,
+            iam_apikey=iam_apikey,
             iam_access_token=iam_access_token,
             iam_url=iam_url,
             use_vcap_services=True)

--- a/watson_developer_cloud/watson_service.py
+++ b/watson_developer_cloud/watson_service.py
@@ -177,10 +177,12 @@ class DetailedResponse(object):
 
     :param Response response: Either json response or http Response as requested.
     :param dict headers: A dict of response headers
+    :param str status_code: HTTP response code
     """
-    def __init__(self, response=None, headers=None):
+    def __init__(self, response=None, headers=None, status_code=None):
         self.result = response
         self.headers = headers
+        self.status_code = status_code
 
     def get_result(self):
         return self.result
@@ -188,12 +190,17 @@ class DetailedResponse(object):
     def get_headers(self):
         return self.headers
 
+    def get_status_code(self):
+        return self.status_code
+
     def _to_dict(self):
         _dict = {}
         if hasattr(self, 'result') and self.result is not None:
             _dict['result'] = self.result if isinstance(self.result, dict) else 'HTTP response'
         if hasattr(self, 'headers') and self.headers is not None:
             _dict['headers'] = self.headers
+        if hasattr(self, 'status_code') and self.status_code is not None:
+            _dict['status_code'] = self.status_code
         return _dict
 
     def __str__(self):
@@ -442,7 +449,7 @@ class WatsonService(object):
 
         if 200 <= response.status_code <= 299:
             if response.status_code == 204:
-                return DetailedResponse(None, response.headers) if self.detailed_response else None
+                return DetailedResponse(None, response.headers, response.status_code) if self.detailed_response else None
             if accept_json:
                 response_json = response.json()
                 if 'status' in response_json and response_json['status'] \
@@ -455,8 +462,8 @@ class WatsonService(object):
                     if error_message == 'invalid-api-key':
                         status_code = 401
                     raise WatsonApiException(status_code, error_message, httpResponse=response)
-                return DetailedResponse(response_json, response.headers) if self.detailed_response else response_json
-            return DetailedResponse(response, response.headers) if self.detailed_response else response
+                return DetailedResponse(response_json, response.headers, response.status_code) if self.detailed_response else response_json
+            return DetailedResponse(response, response.headers, response.status_code) if self.detailed_response else response
         else:
             if response.status_code == 401:
                 error_message = 'Unauthorized: Access is denied due to ' \


### PR DESCRIPTION
* `DetailedResponse` now also returns HTTP status code
* `iam_api_key` renamed to `iam_apikey`
fixes: https://github.com/watson-developer-cloud/python-sdk/issues/520

****************************************************************************
Would add a `Upcoming major release` information in the `Changelog` which are:

GENERAL CHANGES FOR ALL SERVICES:
    *  `DetailedResponse` is now the default response which contains the result, headers and HTTP status code
    * `iam_api_key` renamed to `iam_apikey`

PERSONALITY INSIGHTS:
* `profile` method parameter reordering:
```py
	    def profile(self,
                content,
                content_type,
                accept=None,
                content_language=None,
                accept_language=None,
                raw_scores=None,
                csv_headers=None,
                consumption_preferences=None,
                **kwargs):
```


VISUAL RECOGNITION:
* `classify` would no longer support the `parameters` keyword, the new interface is:
```py
    def classify(self,
                 images_file=None,
                 accept_language=None,
                 url=None,
                 threshold=None,
                 owners=None,
                 classifier_ids=None,
                 images_file_content_type=None,
                 images_filename=None,
                 **kwargs):
```

* `detect_faces` would no longer support the `parameters` keyword, the new interface is:
```py
    def detect_faces(self,
                     images_file=None,
                     url=None,
                     images_file_content_type=None,
                     images_filename=None,
                     **kwargs):
```

SPEECH TO TEXT:
* `recognize` parameter reordering and `version` parameter renamed to `base_model_version`
```py
    def recognize(self,
                  audio,
                  content_type,
                  model=None,
                  customization_id=None,
                  acoustic_customization_id=None,
                  base_model_version=None,
                  customization_weight=None,
                  inactivity_timeout=None,
                  keywords=None,
                  keywords_threshold=None,
                  max_alternatives=None,
                  word_alternatives_threshold=None,
                  word_confidence=None,
                  timestamps=None,
                  profanity_filter=None,
                  smart_formatting=None,
                  speaker_labels=None,
                  **kwargs):
```

* `create_job`, parameter reordering and `version` parameter renamed to `base_model_version`
```py
    def create_job(self,
                   audio,
                   content_type,
                   model=None,
                   callback_url=None,
                   events=None,
                   user_token=None,
                   results_ttl=None,
                   customization_id=None,
                   acoustic_customization_id=None,
                   base_model_version=None,
                   customization_weight=None,
                   inactivity_timeout=None,
                   keywords=None,
                   keywords_threshold=None,
                   max_alternatives=None,
                   word_alternatives_threshold=None,
                   word_confidence=None,
                   timestamps=None,
                   profanity_filter=None,
                   smart_formatting=None,
                   speaker_labels=None,
                   **kwargs):
```

* `add_corpus` no longer supports `corpus_file_content_type`
```py
    def add_corpus(self,
                   customization_id,
                   corpus_name,
                   corpus_file,
                   allow_overwrite=None,
                   corpus_filename=None,
                   **kwargs):
```

* `add_word` 
```py
    def add_word(self,
                 customization_id,
                 word_name,
                 word=None,
                 sounds_like=None,
                 display_as=None,
                 **kwargs):
```

* `recognize_using_websocket`
    * `audio` is of type `AudioSource`
    * `recognize_callback`’s `on_transcription ()` and `on_hypothesis ()` results swapped with each other