### PR TITLE
update the readme - add 'url' parameter in Assistant object

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,8 @@ from watson_developer_cloud import ConversationV1
 conversation = ConversationV1(
     username='xxx',
     password='yyy',
-    version='2017-04-21')
+    version='2017-04-21', 
+    url='zzz')
 
 conversation.set_http_config({'timeout': 100})
 response = conversation.message(workspace_id=workspace_id, input={


### PR DESCRIPTION
additional information on the endpoint is needed - I think the default is us-south but recently client have multiple WA account in different regions so better to be precise and add this parameter in the documentation as a reminder 