### PR TITLE
Use new method to avoid deprecation warning of pypandoc

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,10 +33,10 @@ if sys.argv[-1] == 'publish':
 
 # Convert README.md to README.rst for pypi
 try:
-    from pypandoc import convert
+    from pypandoc import convert_file
 
     def read_md(f):
-        return convert(f, 'rst')
+        return convert_file(f, 'rst')
 
     # read_md = lambda f: convert(f, 'rst')
 except:


### PR DESCRIPTION
`DeprecationWarning: Due to possible ambiguity, 'convert()' is deprecated. Use 'convert_file()'  or 'convert_text()'.`