### PR TITLE
fix(docs): Fix generation of docs

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,7 +1,6 @@
 [bumpversion]
 current_version = 2.2.0
 commit = True
-message = [skip ci] Bump version: {current_version} -> {new_version}
 
 [bumpversion:file:watson_developer_cloud/version.py]
 search = __version__ = '{current_version}'

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,8 +34,7 @@ deploy:
     script: docs/publish.sh
     skip_cleanup: true
     on:
-      python: '3.5'
-      branch: master
+      tags: true
   - provider: script
     script: npx semantic-release
     skip_cleanup: true
@@ -49,5 +48,4 @@ deploy:
     repository: https://upload.pypi.org/legacy
     skip_cleanup: true
     on:
-      python: '3.5'
-      branch: master
+      tags: true


### PR DESCRIPTION
Currently, the docs at `http://watson-developer-cloud.github.io/python-sdk/` go to the `master` folder.

This PR would trigger the the doc publish and pypi publish on git tags