### PR TITLE
fix: Default timeout for requests.request()

### DIFF
--- a/watson_developer_cloud/watson_service.py
+++ b/watson_developer_cloud/watson_service.py
@@ -446,6 +446,9 @@ class WatsonService(object):
             else:
                 params['api_key'] = self.api_key
 
+        # Use a one minute timeout when our caller doesn't give a timeout.
+        # http://docs.python-requests.org/en/master/user/quickstart/#timeouts
+        kwargs = dict({"timeout": 60}, **kwargs)
         kwargs = dict(kwargs, **self.http_config)
 
         if self.verify is not None:


### PR DESCRIPTION
This avoids a hard-to-diagnose hang condition when a request never gets a response (which often means a network level failure occurred).
Strongly recommended by Python Requests for production use. See: http://docs.python-requests.org/en/master/user/quickstart/#timeouts