### PR TITLE
IAM token instead of Username and Password

### DIFF
--- a/examples/microphone-speech-to-text.py
+++ b/examples/microphone-speech-to-text.py
@@ -36,9 +36,8 @@ audio_source = AudioSource(q, True, True)
 
 # initialize speech to text service
 speech_to_text = SpeechToTextV1(
-    username='YOUR SERVICE USERNAME',
-    password='YOUR SERVICE PASSWORD',
-    url='https://stream.watsonplatform.net/speech-to-text/api')
+    iam_apikey='{YOUR_IAM_API_KEY}',
+    url='{YOUR_GATEWAY_URL}')
 
 # define callback for the speech to text service
 class MyRecognizeCallback(RecognizeCallback):


### PR DESCRIPTION
I could not find a way to get Username and Password. But the new IAM tokens should work

These changes I'm proposing are from the official documentation reference at:
https://www.ibm.com/watson/developercloud/speech-to-text/api/v1/python.html?python#authentication