### PR TITLE
handle deserialization of empty responses

### DIFF
--- a/test/unit/test_watson_service.py
+++ b/test/unit/test_watson_service.py
@@ -191,3 +191,16 @@ def test_http_head():
     assert len(responses.calls) == 1
     assert response.headers is not None
     assert response.headers == expectedHeaders
+
+@responses.activate
+def test_response_with_no_body():
+    service = AnyServiceV1('2018-11-20', username='username', password='password')
+    responses.add(responses.GET,
+                  service.default_url,
+                  status=200,
+                  body=None)
+
+    response = service.any_service_call()
+    assert response is not None
+    assert len(responses.calls) == 1
+    assert response.get_result() is None

--- a/watson_developer_cloud/watson_service.py
+++ b/watson_developer_cloud/watson_service.py
@@ -467,7 +467,11 @@ class WatsonService(object):
                 # There is no body content for a HEAD request or a 204 response
                 return DetailedResponse(None, response.headers, response.status_code) if self.detailed_response else None
             if accept_json:
-                response_json = response.json()
+                try:
+                    response_json = response.json()
+                except:
+                    # deserialization fails because there is no text
+                    return DetailedResponse(None, response.headers, response.status_code) if self.detailed_response else None
                 if 'status' in response_json and response_json['status'] \
                         == 'ERROR':
                     status_code = 400


### PR DESCRIPTION
fixes: https://github.com/watson-developer-cloud/python-sdk/issues/599