### PR TITLE
Travis CI: Add Python 3.7 to the testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,13 @@
 language: python
-sudo: required
-dist: trusty
 python:
 - '2.7'
 - '3.4'
 - '3.5'
 - '3.6'
+matrix:
+  include:
+    - python: '3.7'
+      dist: xenial  # required for Python >= 3.7 (travis-ci/travis-ci#9069)
 cache: pip
 before_install:
 - '[ "${TRAVIS_PULL_REQUEST}" = "false" ] && openssl aes-256-cbc -K $encrypted_cebf25e6c525_key


### PR DESCRIPTION
Also Travis CI is deprecating the keyword 'sudo' https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration