### PR TITLE
Allow newer versions of websocket-client

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 requests>=2.0,<3.0
 python_dateutil>=2.5.3
-websocket-client==0.48.0
+websocket-client>=0.48.0


### PR DESCRIPTION
In order to prevent conflicts with other python modules