### PR TITLE
fix(doc): Proper message for older package to migrate to v3.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,19 +36,19 @@ Python client library to quickly get started with the various [Watson APIs][wdc]
 * You need an [IBM Cloud][ibm-cloud-onboarding] account.
 
 ## Installation
-Note: We are moving to `ibm-watson`. All versions prior to v3.0.0 can still be found in `watson-developer-cloud`
-
 To install, use `pip` or `easy_install`:
 
 ```bash
-pip install --upgrade watson-developer-cloud
+pip install --upgrade ibm-watson
 ```
 
 or
 
 ```bash
-easy_install --upgrade watson-developer-cloud
+easy_install --upgrade ibm-watson
 ```
+
+Note: To install a version of the SDK before 3.0.0, use `pip install --upgrade watson-developer-cloud`
 
 Note the following:
 


### PR DESCRIPTION
We want users to move to the new package ie `ibm-watson`. So, we describe to install the new version and put in a note for the older version.