### PR TITLE
fix(FileWithMetadata): Temporary changes for vr4

### DIFF
--- a/ibm_watson/visual_recognition_v4.py
+++ b/ibm_watson/visual_recognition_v4.py
@@ -2457,7 +2457,7 @@ class FileWithMetadata():
         """Return a json dictionary representing this model."""
         _dict = {}
         if hasattr(self, 'data') and self.data is not None:
-            _dict['data'] = self.data._to_dict()
+            _dict['data'] = self.data.__str__()
         if hasattr(self, 'filename') and self.filename is not None:
             _dict['filename'] = self.filename
         if hasattr(self, 'content_type') and self.content_type is not None:


### PR DESCRIPTION
This gets the `__str__ ()`, Did a test and it print this:

```
print(FileWithMetadata(giraffe_info))

output
{
  "data": "<_io.BufferedReader name='examples/../resources/South_Africa_Luca_Galuzzi_2004.jpeg'>"
}
```