### PR TITLE
Import the correct class in speaker_text_to_speech example

### DIFF
--- a/examples/speaker_text_to_speech.py
+++ b/examples/speaker_text_to_speech.py
@@ -5,13 +5,13 @@
 # passed in the request. When the service responds with the synthesized
 # audio, the pyaudio would play it in a blocking mode
 
-from ibm_watson import SpeechToTextV1
+from ibm_watson import TextToSpeechV1
 from ibm_watson.websocket import SynthesizeCallback
 import pyaudio
 from ibm_cloud_sdk_core.authenticators import IAMAuthenticator
 
 authenticator = IAMAuthenticator('your_api_key')
-service = SpeechToTextV1(authenticator=authenticator)
+service = TextToSpeechV1(authenticator=authenticator)
 service.set_service_url('https://stream.watsonplatform.net/speech-to-text/api')
 
 class Play(object):


### PR DESCRIPTION
SpeechToTextV1 was used instead of TextToSpeechV1