### PR TITLE
docs: document correct service method for http configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ For more information, follow the [MIGRATION-V4](https://github.com/watson-develo
 To move from v3.x to v4.0, refer to the [MIGRATION-V4](https://github.com/watson-developer-cloud/python-sdk/blob/master/MIGRATION-V4.md).
 
 ## Configuring the http client (Supported from v1.1.0)
-To set client configs like timeout use the `with_http_config()` function and pass it a dictionary of configs. For example for a Assistant service instance
+To set client configs like timeout use the `set_http_config()` function and pass it a dictionary of configs. For example for a Assistant service instance
 
 ```python
 from ibm_watson import AssistantV1


### PR DESCRIPTION
The function `with_http_config` is defined and used in the unit tests in the core but is not a method on the service client. It should not be documented - the correct method is `set_http_config`