### PR TITLE
fix(semrelease): remove semantic git step

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,7 +1,6 @@
 [bumpversion]
 current_version = 4.0.3
 commit = True
-message = [skip ci] Bump version: {current_version} -> {new_version}
 
 [bumpversion:file:ibm_watson/version.py]
 search = __version__ = '{current_version}'

--- a/.releaserc
+++ b/.releaserc
@@ -4,7 +4,6 @@
   "debug": true,
   "prepare": [
     "@semantic-release/changelog",
-    "@semantic-release/git",
     {
       "path": "@semantic-release/exec",
       "cmd": "bumpversion --current-version ${lastRelease.version} --new-version ${nextRelease.version} patch"

--- a/.releaserc
+++ b/.releaserc
@@ -3,11 +3,11 @@
   "verifyConditions": ["@semantic-release/changelog", "@semantic-release/github"],
   "debug": true,
   "prepare": [
-    "@semantic-release/changelog",
     {
       "path": "@semantic-release/exec",
       "cmd": "bumpversion --current-version ${lastRelease.version} --new-version ${nextRelease.version} patch"
-    }
+    },
+    "@semantic-release/git",
   ],
   "publish": [
     {


### PR DESCRIPTION
With this PR, a release should be done to `pypi` but a commit of bumpversion will have to manually be added to master