### PR TITLE
fix: lock JWT version to 1.7.1

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -19,3 +19,6 @@ bumpversion>=0.5.3
 
 # Web sockets
 websocket-client==0.48.0
+
+# lock JWT
+PyJWT==1.7.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ requests>=2.0,<3.0
 python_dateutil>=2.5.3
 websocket-client==0.48.0
 ibm_cloud_sdk_core==1.7.3
+PyJWT==1.7.1


### PR DESCRIPTION
related to https://github.com/watson-developer-cloud/python-sdk/issues/769