### PR TITLE
docs: fix simple typo, retunred -> returned

### DIFF
--- a/ibm_watson/discovery_v1.py
+++ b/ibm_watson/discovery_v1.py
@@ -1815,7 +1815,7 @@ class DiscoveryV1(BaseService):
                parameter.
         :param bool spelling_suggestions: (optional) When `true` and the
                **natural_language_query** parameter is used, the **natural_languge_query**
-               parameter is spell checked. The most likely correction is retunred in the
+               parameter is spell checked. The most likely correction is returned in the
                **suggested_query** field of the response (if one exists).
                **Important:** this parameter is only valid when using the Cloud Pak
                version of Discovery.


### PR DESCRIPTION
There is a small typo in ibm_watson/discovery_v1.py.

Should read `returned` rather than `retunred`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md