### PR TITLE
fix: return_ did not accept List[str] and was inconsistent with the d…

### DIFF
--- a/ibm_watson/discovery_v1.py
+++ b/ibm_watson/discovery_v1.py
@@ -1722,7 +1722,7 @@ class DiscoveryV1(BaseService):
               passages: bool = None,
               aggregation: str = None,
               count: int = None,
-              return_: str = None,
+              return_: List[str] = None,
               offset: int = None,
               sort: str = None,
               highlight: bool = None,
@@ -1764,8 +1764,8 @@ class DiscoveryV1(BaseService):
                applications to build lists, tables, and time series. For a full list of
                possible aggregations, see the Query reference.
         :param int count: (optional) Number of results to return.
-        :param str return_: (optional) A comma-separated list of the portion of the
-               document hierarchy to return.
+        :param List[str] return_: (optional) A comma-separated list of the portion
+               of the document hierarchy to return.
         :param int offset: (optional) The number of query results to skip at the
                beginning. For example, if the total number of results that are returned is
                10 and the offset is 8, it returns the last two results.
@@ -1845,7 +1845,7 @@ class DiscoveryV1(BaseService):
             'passages': passages,
             'aggregation': aggregation,
             'count': count,
-            'return': return_,
+            'return': convert_list(return_),
             'offset': offset,
             'sort': sort,
             'highlight': highlight,
@@ -2032,7 +2032,7 @@ class DiscoveryV1(BaseService):
                         passages: bool = None,
                         aggregation: str = None,
                         count: int = None,
-                        return_: str = None,
+                        return_: List[str] = None,
                         offset: int = None,
                         sort: str = None,
                         highlight: bool = None,
@@ -2074,7 +2074,7 @@ class DiscoveryV1(BaseService):
                applications to build lists, tables, and time series. For a full list of
                possible aggregations, see the Query reference.
         :param int count: (optional) Number of results to return.
-        :param str return_: (optional) A comma-separated list of the portion of the
+        :param List[str] return_: (optional) A comma-separated list of the portion of the
                document hierarchy to return.
         :param int offset: (optional) The number of query results to skip at the
                beginning. For example, if the total number of results that are returned is
@@ -2150,7 +2150,7 @@ class DiscoveryV1(BaseService):
             'passages': passages,
             'aggregation': aggregation,
             'count': count,
-            'return': return_,
+            'return': convert_list(return_),
             'offset': offset,
             'sort': sort,
             'highlight': highlight,


### PR DESCRIPTION
fix: return_ did not accept List[str] and was inconsistent with the docstring.

The `return_` arg in some of the query defs should accept  a `List[str]` but currently only accepts `str`. The docstrings however specify that the user can provide a comma separated list which is inconsistent and raises errors like below when a return_ arg is specified

```
ERROR:root:Invalid query syntax '(' at index 4 in 'List('
Traceback (most recent call last):
  File "/root/anaconda3/lib/python3.7/site-packages/ibm_cloud_sdk_core/base_service.py", line 157, in send
    response.status_code, error_message, http_response=response)
ibm_cloud_sdk_core.api_exception.ApiException: Error: Invalid query syntax '(' at index 4 in 'List(', Code: 400 , X-global-transaction-id: 606d7d58-4054-4a33-8b9f-3565b9ac3668
Encountered exception: Error: Invalid query syntax '(' at index 4 in 'List(', Code: 400 , X-global-transaction-id: 606d7d58-4054-4a33-8b9f-3565b9ac3668
```

This fix corrects that and allows the user to specify which part of the document hierarchy they require (e.g:  `["result_metadata", "extracted_metadata"]` and the discovery response payload only returns these fields.

Changes were based off the `def query_notices()` function which seems to accept a List[str] argument successfully.

