### PR TITLE
ci(release): change release commit messages to include skip c_i

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,6 +1,7 @@
 [bumpversion]
 current_version = 5.2.2
 commit = True
+message = Bump version: {current_version} → {new_version} [skip ci]
 
 [bumpversion:file:ibm_watson/version.py]
 search = __version__ = '{current_version}'

--- a/.releaserc
+++ b/.releaserc
@@ -10,12 +10,6 @@
         "prepareCmd": "bumpversion --allow-dirty --current-version ${lastRelease.version} --new-version ${nextRelease.version} patch"
       }
     ],
-    [
-      "@semantic-release/git", 
-      {
-        "message": "chore(release): ${nextRelease.version} release notes\n\n${nextRelease.notes}"
-      }
-    ],
     "@semantic-release/github"
   ]
 }


### PR DESCRIPTION
This PR should stop double GHA release builds from triggering by appending [skip ci] to their commit messsages