### PR TITLE
fix: stt-websocket times out causes excessive arguments error

### DIFF
--- a/ibm_watson/websocket/recognize_listener.py
+++ b/ibm_watson/websocket/recognize_listener.py
@@ -220,7 +220,7 @@ class RecognizeListener(object):
         """
         self.callback.on_error(error)
 
-    def on_close(self, ws):
+    def on_close(self, ws, *args):
         """
         Callback executed when websocket connection is closed
 


### PR DESCRIPTION
The on_close function received excessive arguments when the STT websocket connection timed out.
```
error from callback <bound method RecognizeListener.on_close of <ibm_watson.websocket.recognize_listener.Rec
ognizeListener object at 0x000001AA24166280>>: on_close() takes 2 positional arguments but 4 were given
  File "C:\Users\.env\lib\site-packages\websocket\_app.py", line 407, in _callback
    callback(self, *args)
```