### PR TITLE
Comment out enableTrace for websocket.

### DIFF
--- a/ibm_watson/websocket/recognize_listener.py
+++ b/ibm_watson/websocket/recognize_listener.py
@@ -53,7 +53,7 @@ class RecognizeListener(object):
         self.isListening = False
         self.verify = verify
 
-        websocket.enableTrace(True)
+        # websocket.enableTrace(True)
 
         self.ws_client = websocket.WebSocketApp(
             self.url,

--- a/ibm_watson/websocket/recognize_listener.py
+++ b/ibm_watson/websocket/recognize_listener.py
@@ -53,8 +53,6 @@ class RecognizeListener(object):
         self.isListening = False
         self.verify = verify
 
-        # websocket.enableTrace(True)
-
         self.ws_client = websocket.WebSocketApp(
             self.url,
             header=self.headers,

--- a/ibm_watson/websocket/synthesize_listener.py
+++ b/ibm_watson/websocket/synthesize_listener.py
@@ -44,8 +44,6 @@ class SynthesizeListener(object):
         self.http_proxy_port = http_proxy_port
         self.verify = verify
 
-        # websocket.enableTrace(True)
-
         self.ws_client = websocket.WebSocketApp(
             self.url,
             header=self.headers,

--- a/ibm_watson/websocket/synthesize_listener.py
+++ b/ibm_watson/websocket/synthesize_listener.py
@@ -44,7 +44,7 @@ class SynthesizeListener(object):
         self.http_proxy_port = http_proxy_port
         self.verify = verify
 
-        websocket.enableTrace(True)
+        # websocket.enableTrace(True)
 
         self.ws_client = websocket.WebSocketApp(
             self.url,


### PR DESCRIPTION
Commented out the websocket.enableTrace(True) lines in the recognize and synthesize listeners.

Commented out instead of removed so that it is easy to find a good place to put this, if needed.