### PR TITLE
Fix on_close propogation + bump websocket-client

### DIFF
--- a/ibm_watson/websocket/synthesize_listener.py
+++ b/ibm_watson/websocket/synthesize_listener.py
@@ -120,7 +120,7 @@ class SynthesizeListener(object):
         """
         self.callback.on_error(error)
 
-    def on_close(self, ws, **kwargs):
+    def on_close(self, ws, *args, **kwargs):
         """
         Callback executed when websocket connection is closed
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 requests>=2.0,<3.0
 python_dateutil>=2.5.3
-websocket-client==1.1.0
+websocket-client==1.3.0
 ibm_cloud_sdk_core>=3.3.6, == 3.*


### PR DESCRIPTION
Satisfies https://github.com/watson-developer-cloud/python-sdk/issues/810

Also, the websocket client class sends messages to the `on_close` handler that do not match the signature that result in an error:
```
from callback <bound method SynthesizeListener.on_close of
 <ibm_watson.websocket.synthesize_listener.SynthesizeListener object at
 0x123456789>>: on_close() takes 2 positional arguments but 4 were given
```

This PR fixes this issue.