### PR TITLE
Regenerated discovery_v2 artifacts from OpenAPI definition

### DIFF
--- a/ibm_watson/discovery_v2.py
+++ b/ibm_watson/discovery_v2.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 
-# (C) Copyright IBM Corp. 2019, 2021.
+# (C) Copyright IBM Corp. 2022.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# IBM OpenAPI SDK Code Generator Version: 3.38.0-07189efd-20210827-205025
+# IBM OpenAPI SDK Code Generator Version: 3.53.0-9710cac3-20220713-193508
 """
 IBM Watson&trade; Discovery is a cognitive search and content analytics engine that you
 can add to applications to identify patterns, trends and actionable insights to drive
@@ -64,7 +64,7 @@ class DiscoveryV2(BaseService):
                Specify dates in YYYY-MM-DD format. The current version is `2020-08-30`.
 
         :param Authenticator authenticator: The authenticator specifies the authentication mechanism.
-               Get up to date information from https://github.com/IBM/python-sdk-core/blob/master/README.md
+               Get up to date information from https://github.com/IBM/python-sdk-core/blob/main/README.md
                about initializing the authenticator of your choice.
         """
         if version is None:
@@ -77,6 +77,288 @@ class DiscoveryV2(BaseService):
                              authenticator=authenticator)
         self.version = version
         self.configure_service(service_name)
+
+    #########################
+    # Projects
+    #########################
+
+    def list_projects(self, **kwargs) -> DetailedResponse:
+        """
+        List projects.
+
+        Lists existing projects for this instance.
+
+        :param dict headers: A `dict` containing the request headers
+        :return: A `DetailedResponse` containing the result, headers and HTTP status code.
+        :rtype: DetailedResponse with `dict` result representing a `ListProjectsResponse` object
+        """
+
+        headers = {}
+        sdk_headers = get_sdk_headers(service_name=self.DEFAULT_SERVICE_NAME,
+                                      service_version='V2',
+                                      operation_id='list_projects')
+        headers.update(sdk_headers)
+
+        params = {'version': self.version}
+
+        if 'headers' in kwargs:
+            headers.update(kwargs.get('headers'))
+            del kwargs['headers']
+        headers['Accept'] = 'application/json'
+
+        url = '/v2/projects'
+        request = self.prepare_request(method='GET',
+                                       url=url,
+                                       headers=headers,
+                                       params=params)
+
+        response = self.send(request, **kwargs)
+        return response
+
+    def create_project(self,
+                       name: str,
+                       type: str,
+                       *,
+                       default_query_parameters: 'DefaultQueryParams' = None,
+                       **kwargs) -> DetailedResponse:
+        """
+        Create a project.
+
+        Create a new project for this instance.
+
+        :param str name: The human readable name of this project.
+        :param str type: The type of project.
+               The `content_intelligence` type is a *Document Retrieval for Contracts*
+               project and the `other` type is a *Custom* project.
+               The `content_mining` and `content_intelligence` types are available with
+               Premium plan managed deployments and installed deployments only.
+        :param DefaultQueryParams default_query_parameters: (optional) Default
+               query parameters for this project.
+        :param dict headers: A `dict` containing the request headers
+        :return: A `DetailedResponse` containing the result, headers and HTTP status code.
+        :rtype: DetailedResponse with `dict` result representing a `ProjectDetails` object
+        """
+
+        if name is None:
+            raise ValueError('name must be provided')
+        if type is None:
+            raise ValueError('type must be provided')
+        if default_query_parameters is not None:
+            default_query_parameters = convert_model(default_query_parameters)
+        headers = {}
+        sdk_headers = get_sdk_headers(service_name=self.DEFAULT_SERVICE_NAME,
+                                      service_version='V2',
+                                      operation_id='create_project')
+        headers.update(sdk_headers)
+
+        params = {'version': self.version}
+
+        data = {
+            'name': name,
+            'type': type,
+            'default_query_parameters': default_query_parameters
+        }
+        data = {k: v for (k, v) in data.items() if v is not None}
+        data = json.dumps(data)
+        headers['content-type'] = 'application/json'
+
+        if 'headers' in kwargs:
+            headers.update(kwargs.get('headers'))
+            del kwargs['headers']
+        headers['Accept'] = 'application/json'
+
+        url = '/v2/projects'
+        request = self.prepare_request(method='POST',
+                                       url=url,
+                                       headers=headers,
+                                       params=params,
+                                       data=data)
+
+        response = self.send(request, **kwargs)
+        return response
+
+    def get_project(self, project_id: str, **kwargs) -> DetailedResponse:
+        """
+        Get project.
+
+        Get details on the specified project.
+
+        :param str project_id: The ID of the project. This information can be found
+               from the *Integrate and Deploy* page in Discovery.
+        :param dict headers: A `dict` containing the request headers
+        :return: A `DetailedResponse` containing the result, headers and HTTP status code.
+        :rtype: DetailedResponse with `dict` result representing a `ProjectDetails` object
+        """
+
+        if project_id is None:
+            raise ValueError('project_id must be provided')
+        headers = {}
+        sdk_headers = get_sdk_headers(service_name=self.DEFAULT_SERVICE_NAME,
+                                      service_version='V2',
+                                      operation_id='get_project')
+        headers.update(sdk_headers)
+
+        params = {'version': self.version}
+
+        if 'headers' in kwargs:
+            headers.update(kwargs.get('headers'))
+            del kwargs['headers']
+        headers['Accept'] = 'application/json'
+
+        path_param_keys = ['project_id']
+        path_param_values = self.encode_path_vars(project_id)
+        path_param_dict = dict(zip(path_param_keys, path_param_values))
+        url = '/v2/projects/{project_id}'.format(**path_param_dict)
+        request = self.prepare_request(method='GET',
+                                       url=url,
+                                       headers=headers,
+                                       params=params)
+
+        response = self.send(request, **kwargs)
+        return response
+
+    def update_project(self,
+                       project_id: str,
+                       *,
+                       name: str = None,
+                       **kwargs) -> DetailedResponse:
+        """
+        Update a project.
+
+        Update the specified project's name.
+
+        :param str project_id: The ID of the project. This information can be found
+               from the *Integrate and Deploy* page in Discovery.
+        :param str name: (optional) The new name to give this project.
+        :param dict headers: A `dict` containing the request headers
+        :return: A `DetailedResponse` containing the result, headers and HTTP status code.
+        :rtype: DetailedResponse with `dict` result representing a `ProjectDetails` object
+        """
+
+        if project_id is None:
+            raise ValueError('project_id must be provided')
+        headers = {}
+        sdk_headers = get_sdk_headers(service_name=self.DEFAULT_SERVICE_NAME,
+                                      service_version='V2',
+                                      operation_id='update_project')
+        headers.update(sdk_headers)
+
+        params = {'version': self.version}
+
+        data = {'name': name}
+        data = {k: v for (k, v) in data.items() if v is not None}
+        data = json.dumps(data)
+        headers['content-type'] = 'application/json'
+
+        if 'headers' in kwargs:
+            headers.update(kwargs.get('headers'))
+            del kwargs['headers']
+        headers['Accept'] = 'application/json'
+
+        path_param_keys = ['project_id']
+        path_param_values = self.encode_path_vars(project_id)
+        path_param_dict = dict(zip(path_param_keys, path_param_values))
+        url = '/v2/projects/{project_id}'.format(**path_param_dict)
+        request = self.prepare_request(method='POST',
+                                       url=url,
+                                       headers=headers,
+                                       params=params,
+                                       data=data)
+
+        response = self.send(request, **kwargs)
+        return response
+
+    def delete_project(self, project_id: str, **kwargs) -> DetailedResponse:
+        """
+        Delete a project.
+
+        Deletes the specified project.
+        **Important:** Deleting a project deletes everything that is part of the specified
+        project, including all collections.
+
+        :param str project_id: The ID of the project. This information can be found
+               from the *Integrate and Deploy* page in Discovery.
+        :param dict headers: A `dict` containing the request headers
+        :return: A `DetailedResponse` containing the result, headers and HTTP status code.
+        :rtype: DetailedResponse
+        """
+
+        if project_id is None:
+            raise ValueError('project_id must be provided')
+        headers = {}
+        sdk_headers = get_sdk_headers(service_name=self.DEFAULT_SERVICE_NAME,
+                                      service_version='V2',
+                                      operation_id='delete_project')
+        headers.update(sdk_headers)
+
+        params = {'version': self.version}
+
+        if 'headers' in kwargs:
+            headers.update(kwargs.get('headers'))
+            del kwargs['headers']
+
+        path_param_keys = ['project_id']
+        path_param_values = self.encode_path_vars(project_id)
+        path_param_dict = dict(zip(path_param_keys, path_param_values))
+        url = '/v2/projects/{project_id}'.format(**path_param_dict)
+        request = self.prepare_request(method='DELETE',
+                                       url=url,
+                                       headers=headers,
+                                       params=params)
+
+        response = self.send(request, **kwargs)
+        return response
+
+    def list_fields(self,
+                    project_id: str,
+                    *,
+                    collection_ids: List[str] = None,
+                    **kwargs) -> DetailedResponse:
+        """
+        List fields.
+
+        Gets a list of the unique fields (and their types) stored in the specified
+        collections.
+
+        :param str project_id: The ID of the project. This information can be found
+               from the *Integrate and Deploy* page in Discovery.
+        :param List[str] collection_ids: (optional) Comma separated list of the
+               collection IDs. If this parameter is not specified, all collections in the
+               project are used.
+        :param dict headers: A `dict` containing the request headers
+        :return: A `DetailedResponse` containing the result, headers and HTTP status code.
+        :rtype: DetailedResponse with `dict` result representing a `ListFieldsResponse` object
+        """
+
+        if project_id is None:
+            raise ValueError('project_id must be provided')
+        headers = {}
+        sdk_headers = get_sdk_headers(service_name=self.DEFAULT_SERVICE_NAME,
+                                      service_version='V2',
+                                      operation_id='list_fields')
+        headers.update(sdk_headers)
+
+        params = {
+            'version': self.version,
+            'collection_ids': convert_list(collection_ids)
+        }
+
+        if 'headers' in kwargs:
+            headers.update(kwargs.get('headers'))
+            del kwargs['headers']
+        headers['Accept'] = 'application/json'
+
+        path_param_keys = ['project_id']
+        path_param_values = self.encode_path_vars(project_id)
+        path_param_dict = dict(zip(path_param_keys, path_param_values))
+        url = '/v2/projects/{project_id}/fields'.format(**path_param_dict)
+        request = self.prepare_request(method='GET',
+                                       url=url,
+                                       headers=headers,
+                                       params=params)
+
+        response = self.send(request, **kwargs)
+        return response
 
     #########################
     # Collections
@@ -107,6 +389,7 @@ class DiscoveryV2(BaseService):
 
         if 'headers' in kwargs:
             headers.update(kwargs.get('headers'))
+            del kwargs['headers']
         headers['Accept'] = 'application/json'
 
         path_param_keys = ['project_id']
@@ -128,6 +411,8 @@ class DiscoveryV2(BaseService):
                           description: str = None,
                           language: str = None,
                           enrichments: List['CollectionEnrichment'] = None,
+                          smart_document_understanding:
+                          'CollectionDetailsSmartDocumentUnderstanding' = None,
                           **kwargs) -> DetailedResponse:
         """
         Create a collection.
@@ -138,9 +423,20 @@ class DiscoveryV2(BaseService):
                from the *Integrate and Deploy* page in Discovery.
         :param str name: The name of the collection.
         :param str description: (optional) A description of the collection.
-        :param str language: (optional) The language of the collection.
+        :param str language: (optional) The language of the collection. For a list
+               of supported languages, see the [product
+               documentation](/docs/discovery-data?topic=discovery-data-language-support).
         :param List[CollectionEnrichment] enrichments: (optional) An array of
-               enrichments that are applied to this collection.
+               enrichments that are applied to this collection. To get a list of
+               enrichments that are available for a project, use the [List
+               enrichments](#listenrichments) method.
+               If no enrichments are specified when the collection is created, the default
+               enrichments for the project type are applied. For more information about
+               project default settings, see the [product
+               documentation](/docs/discovery-data?topic=discovery-data-project-defaults).
+        :param CollectionDetailsSmartDocumentUnderstanding
+               smart_document_understanding: (optional) An object that describes the Smart
+               Document Understanding model for a collection.
         :param dict headers: A `dict` containing the request headers
         :return: A `DetailedResponse` containing the result, headers and HTTP status code.
         :rtype: DetailedResponse with `dict` result representing a `CollectionDetails` object
@@ -152,6 +448,9 @@ class DiscoveryV2(BaseService):
             raise ValueError('name must be provided')
         if enrichments is not None:
             enrichments = [convert_model(x) for x in enrichments]
+        if smart_document_understanding is not None:
+            smart_document_understanding = convert_model(
+                smart_document_understanding)
         headers = {}
         sdk_headers = get_sdk_headers(service_name=self.DEFAULT_SERVICE_NAME,
                                       service_version='V2',
@@ -164,7 +463,8 @@ class DiscoveryV2(BaseService):
             'name': name,
             'description': description,
             'language': language,
-            'enrichments': enrichments
+            'enrichments': enrichments,
+            'smart_document_understanding': smart_document_understanding
         }
         data = {k: v for (k, v) in data.items() if v is not None}
         data = json.dumps(data)
@@ -172,6 +472,7 @@ class DiscoveryV2(BaseService):
 
         if 'headers' in kwargs:
             headers.update(kwargs.get('headers'))
+            del kwargs['headers']
         headers['Accept'] = 'application/json'
 
         path_param_keys = ['project_id']
@@ -216,6 +517,7 @@ class DiscoveryV2(BaseService):
 
         if 'headers' in kwargs:
             headers.update(kwargs.get('headers'))
+            del kwargs['headers']
         headers['Accept'] = 'application/json'
 
         path_param_keys = ['project_id', 'collection_id']
@@ -247,8 +549,8 @@ class DiscoveryV2(BaseService):
         :param str project_id: The ID of the project. This information can be found
                from the *Integrate and Deploy* page in Discovery.
         :param str collection_id: The ID of the collection.
-        :param str name: (optional) The name of the collection.
-        :param str description: (optional) A description of the collection.
+        :param str name: (optional) The new name of the collection.
+        :param str description: (optional) The new description of the collection.
         :param List[CollectionEnrichment] enrichments: (optional) An array of
                enrichments that are applied to this collection.
         :param dict headers: A `dict` containing the request headers
@@ -281,6 +583,7 @@ class DiscoveryV2(BaseService):
 
         if 'headers' in kwargs:
             headers.update(kwargs.get('headers'))
+            del kwargs['headers']
         headers['Accept'] = 'application/json'
 
         path_param_keys = ['project_id', 'collection_id']
@@ -327,6 +630,7 @@ class DiscoveryV2(BaseService):
 
         if 'headers' in kwargs:
             headers.update(kwargs.get('headers'))
+            del kwargs['headers']
 
         path_param_keys = ['project_id', 'collection_id']
         path_param_values = self.encode_path_vars(project_id, collection_id)
@@ -342,241 +646,69 @@ class DiscoveryV2(BaseService):
         return response
 
     #########################
-    # Queries
+    # Documents
     #########################
 
-    def query(self,
-              project_id: str,
-              *,
-              collection_ids: List[str] = None,
-              filter: str = None,
-              query: str = None,
-              natural_language_query: str = None,
-              aggregation: str = None,
-              count: int = None,
-              return_: List[str] = None,
-              offset: int = None,
-              sort: str = None,
-              highlight: bool = None,
-              spelling_suggestions: bool = None,
-              table_results: 'QueryLargeTableResults' = None,
-              suggested_refinements: 'QueryLargeSuggestedRefinements' = None,
-              passages: 'QueryLargePassages' = None,
-              **kwargs) -> DetailedResponse:
+    def list_documents(self,
+                       project_id: str,
+                       collection_id: str,
+                       *,
+                       count: int = None,
+                       status: str = None,
+                       has_notices: bool = None,
+                       is_parent: bool = None,
+                       parent_document_id: str = None,
+                       sha256: str = None,
+                       **kwargs) -> DetailedResponse:
         """
-        Query a project.
+        List documents.
 
-        By using this method, you can construct queries. For details, see the [Discovery
-        documentation](https://cloud.ibm.com/docs/discovery-data?topic=discovery-data-query-concepts).
-        The default query parameters are defined by the settings for this project, see the
-        [Discovery
-        documentation](https://cloud.ibm.com/docs/discovery-data?topic=discovery-data-project-defaults)
-        for an overview of the standard default settings, and see [the Projects API
-        documentation](#create-project) for details about how to set custom default query
-        settings.
-
-        :param str project_id: The ID of the project. This information can be found
-               from the *Integrate and Deploy* page in Discovery.
-        :param List[str] collection_ids: (optional) A comma-separated list of
-               collection IDs to be queried against.
-        :param str filter: (optional) A cacheable query that excludes documents
-               that don't mention the query content. Filter searches are better for
-               metadata-type searches and for assessing the concepts in the data set.
-        :param str query: (optional) A query search returns all documents in your
-               data set with full enrichments and full text, but with the most relevant
-               documents listed first. Use a query search when you want to find the most
-               relevant search results.
-        :param str natural_language_query: (optional) A natural language query that
-               returns relevant documents by utilizing training data and natural language
-               understanding.
-        :param str aggregation: (optional) An aggregation search that returns an
-               exact answer by combining query search with filters. Useful for
-               applications to build lists, tables, and time series. For a full list of
-               possible aggregations, see the Query reference.
-        :param int count: (optional) Number of results to return.
-        :param List[str] return_: (optional) A list of the fields in the document
-               hierarchy to return. If this parameter is an empty list, then all fields
-               are returned.
-        :param int offset: (optional) The number of query results to skip at the
-               beginning. For example, if the total number of results that are returned is
-               10 and the offset is 8, it returns the last two results.
-        :param str sort: (optional) A comma-separated list of fields in the
-               document to sort on. You can optionally specify a sort direction by
-               prefixing the field with `-` for descending or `+` for ascending. Ascending
-               is the default sort direction if no prefix is specified.
-        :param bool highlight: (optional) When `true`, a highlight field is
-               returned for each result which contains the fields which match the query
-               with `<em></em>` tags around the matching query terms.
-        :param bool spelling_suggestions: (optional) When `true` and the
-               **natural_language_query** parameter is used, the
-               **natural_language_query** parameter is spell checked. The most likely
-               correction is returned in the **suggested_query** field of the response (if
-               one exists).
-        :param QueryLargeTableResults table_results: (optional) Configuration for
-               table retrieval.
-        :param QueryLargeSuggestedRefinements suggested_refinements: (optional)
-               Configuration for suggested refinements. Available with Premium plans only.
-        :param QueryLargePassages passages: (optional) Configuration for passage
-               retrieval.
-        :param dict headers: A `dict` containing the request headers
-        :return: A `DetailedResponse` containing the result, headers and HTTP status code.
-        :rtype: DetailedResponse with `dict` result representing a `QueryResponse` object
-        """
-
-        if project_id is None:
-            raise ValueError('project_id must be provided')
-        if table_results is not None:
-            table_results = convert_model(table_results)
-        if suggested_refinements is not None:
-            suggested_refinements = convert_model(suggested_refinements)
-        if passages is not None:
-            passages = convert_model(passages)
-        headers = {}
-        sdk_headers = get_sdk_headers(service_name=self.DEFAULT_SERVICE_NAME,
-                                      service_version='V2',
-                                      operation_id='query')
-        headers.update(sdk_headers)
-
-        params = {'version': self.version}
-
-        data = {
-            'collection_ids': collection_ids,
-            'filter': filter,
-            'query': query,
-            'natural_language_query': natural_language_query,
-            'aggregation': aggregation,
-            'count': count,
-            'return': return_,
-            'offset': offset,
-            'sort': sort,
-            'highlight': highlight,
-            'spelling_suggestions': spelling_suggestions,
-            'table_results': table_results,
-            'suggested_refinements': suggested_refinements,
-            'passages': passages
-        }
-        data = {k: v for (k, v) in data.items() if v is not None}
-        data = json.dumps(data)
-        headers['content-type'] = 'application/json'
-
-        if 'headers' in kwargs:
-            headers.update(kwargs.get('headers'))
-        headers['Accept'] = 'application/json'
-
-        path_param_keys = ['project_id']
-        path_param_values = self.encode_path_vars(project_id)
-        path_param_dict = dict(zip(path_param_keys, path_param_values))
-        url = '/v2/projects/{project_id}/query'.format(**path_param_dict)
-        request = self.prepare_request(method='POST',
-                                       url=url,
-                                       headers=headers,
-                                       params=params,
-                                       data=data)
-
-        response = self.send(request, **kwargs)
-        return response
-
-    def get_autocompletion(self,
-                           project_id: str,
-                           prefix: str,
-                           *,
-                           collection_ids: List[str] = None,
-                           field: str = None,
-                           count: int = None,
-                           **kwargs) -> DetailedResponse:
-        """
-        Get Autocomplete Suggestions.
-
-        Returns completion query suggestions for the specified prefix.
-
-        :param str project_id: The ID of the project. This information can be found
-               from the *Integrate and Deploy* page in Discovery.
-        :param str prefix: The prefix to use for autocompletion. For example, the
-               prefix `Ho` could autocomplete to `hot`, `housing`, or `how`.
-        :param List[str] collection_ids: (optional) Comma separated list of the
-               collection IDs. If this parameter is not specified, all collections in the
-               project are used.
-        :param str field: (optional) The field in the result documents that
-               autocompletion suggestions are identified from.
-        :param int count: (optional) The number of autocompletion suggestions to
-               return.
-        :param dict headers: A `dict` containing the request headers
-        :return: A `DetailedResponse` containing the result, headers and HTTP status code.
-        :rtype: DetailedResponse with `dict` result representing a `Completions` object
-        """
-
-        if project_id is None:
-            raise ValueError('project_id must be provided')
-        if prefix is None:
-            raise ValueError('prefix must be provided')
-        headers = {}
-        sdk_headers = get_sdk_headers(service_name=self.DEFAULT_SERVICE_NAME,
-                                      service_version='V2',
-                                      operation_id='get_autocompletion')
-        headers.update(sdk_headers)
-
-        params = {
-            'version': self.version,
-            'prefix': prefix,
-            'collection_ids': convert_list(collection_ids),
-            'field': field,
-            'count': count
-        }
-
-        if 'headers' in kwargs:
-            headers.update(kwargs.get('headers'))
-        headers['Accept'] = 'application/json'
-
-        path_param_keys = ['project_id']
-        path_param_values = self.encode_path_vars(project_id)
-        path_param_dict = dict(zip(path_param_keys, path_param_values))
-        url = '/v2/projects/{project_id}/autocompletion'.format(
-            **path_param_dict)
-        request = self.prepare_request(method='GET',
-                                       url=url,
-                                       headers=headers,
-                                       params=params)
-
-        response = self.send(request, **kwargs)
-        return response
-
-    def query_collection_notices(self,
-                                 project_id: str,
-                                 collection_id: str,
-                                 *,
-                                 filter: str = None,
-                                 query: str = None,
-                                 natural_language_query: str = None,
-                                 count: int = None,
-                                 offset: int = None,
-                                 **kwargs) -> DetailedResponse:
-        """
-        Query collection notices.
-
-        Finds collection-level notices (errors and warnings) that are generated when
-        documents are ingested.
+        Lists the documents in the specified collection. The list includes only the
+        document ID of each document and returns information for up to 10,000 documents.
+        **Note**: This method is available only from Cloud Pak for Data version 4.0.9 and
+        later installed instances and from Plus and Enterprise plan IBM Cloud-managed
+        instances.
 
         :param str project_id: The ID of the project. This information can be found
                from the *Integrate and Deploy* page in Discovery.
         :param str collection_id: The ID of the collection.
-        :param str filter: (optional) A cacheable query that excludes documents
-               that don't mention the query content. Filter searches are better for
-               metadata-type searches and for assessing the concepts in the data set.
-        :param str query: (optional) A query search returns all documents in your
-               data set with full enrichments and full text, but with the most relevant
-               documents listed first.
-        :param str natural_language_query: (optional) A natural language query that
-               returns relevant documents by utilizing training data and natural language
-               understanding.
-        :param int count: (optional) Number of results to return. The maximum for
-               the **count** and **offset** values together in any one query is **10000**.
-        :param int offset: (optional) The number of query results to skip at the
-               beginning. For example, if the total number of results that are returned is
-               10 and the offset is 8, it returns the last two results. The maximum for
-               the **count** and **offset** values together in any one query is **10000**.
+        :param int count: (optional) The maximum number of documents to return. Up
+               to 1,000 documents are returned by default. The maximum number allowed is
+               10,000.
+        :param str status: (optional) Filters the documents to include only
+               documents with the specified ingestion status. The options include:
+               * `available`: Ingestion is finished and the document is indexed.
+               * `failed`: Ingestion is finished, but the document is not indexed because
+               of an error.
+               * `pending`: The document is uploaded, but the ingestion process is not
+               started.
+               * `processing`: Ingestion is in progress.
+               You can specify one status value or add a comma-separated list of more than
+               one status value. For example, `available,failed`.
+        :param bool has_notices: (optional) If set to `true`, only documents that
+               have notices, meaning documents for which warnings or errors were generated
+               during the ingestion, are returned. If set to `false`, only documents that
+               don't have notices are returned. If unspecified, no filter based on notices
+               is applied.
+               Notice details are not available in the result, but you can use the [Query
+               collection notices](#querycollectionnotices) method to find details by
+               adding the parameter `query=notices.document_id:{document-id}`.
+        :param bool is_parent: (optional) If set to `true`, only parent documents,
+               meaning documents that were split during the ingestion process and resulted
+               in two or more child documents, are returned. If set to `false`, only child
+               documents are returned. If unspecified, no filter based on the parent or
+               child relationship is applied.
+               CSV files, for example, are split into separate documents per line and JSON
+               files are split into separate documents per object.
+        :param str parent_document_id: (optional) Filters the documents to include
+               only child documents that were generated when the specified parent document
+               was processed.
+        :param str sha256: (optional) Filters the documents to include only
+               documents with the specified SHA-256 hash. Format the hash as a hexadecimal
+               string.
         :param dict headers: A `dict` containing the request headers
         :return: A `DetailedResponse` containing the result, headers and HTTP status code.
-        :rtype: DetailedResponse with `dict` result representing a `QueryNoticesResponse` object
+        :rtype: DetailedResponse with `dict` result representing a `ListDocumentsResponse` object
         """
 
         if project_id is None:
@@ -586,26 +718,28 @@ class DiscoveryV2(BaseService):
         headers = {}
         sdk_headers = get_sdk_headers(service_name=self.DEFAULT_SERVICE_NAME,
                                       service_version='V2',
-                                      operation_id='query_collection_notices')
+                                      operation_id='list_documents')
         headers.update(sdk_headers)
 
         params = {
             'version': self.version,
-            'filter': filter,
-            'query': query,
-            'natural_language_query': natural_language_query,
             'count': count,
-            'offset': offset
+            'status': status,
+            'has_notices': has_notices,
+            'is_parent': is_parent,
+            'parent_document_id': parent_document_id,
+            'sha256': sha256
         }
 
         if 'headers' in kwargs:
             headers.update(kwargs.get('headers'))
+            del kwargs['headers']
         headers['Accept'] = 'application/json'
 
         path_param_keys = ['project_id', 'collection_id']
         path_param_values = self.encode_path_vars(project_id, collection_id)
         path_param_dict = dict(zip(path_param_keys, path_param_values))
-        url = '/v2/projects/{project_id}/collections/{collection_id}/notices'.format(
+        url = '/v2/projects/{project_id}/collections/{collection_id}/documents'.format(
             **path_param_dict)
         request = self.prepare_request(method='GET',
                                        url=url,
@@ -614,175 +748,6 @@ class DiscoveryV2(BaseService):
 
         response = self.send(request, **kwargs)
         return response
-
-    def query_notices(self,
-                      project_id: str,
-                      *,
-                      filter: str = None,
-                      query: str = None,
-                      natural_language_query: str = None,
-                      count: int = None,
-                      offset: int = None,
-                      **kwargs) -> DetailedResponse:
-        """
-        Query project notices.
-
-        Finds project-level notices (errors and warnings). Currently, project-level
-        notices are generated by relevancy training.
-
-        :param str project_id: The ID of the project. This information can be found
-               from the *Integrate and Deploy* page in Discovery.
-        :param str filter: (optional) A cacheable query that excludes documents
-               that don't mention the query content. Filter searches are better for
-               metadata-type searches and for assessing the concepts in the data set.
-        :param str query: (optional) A query search returns all documents in your
-               data set with full enrichments and full text, but with the most relevant
-               documents listed first.
-        :param str natural_language_query: (optional) A natural language query that
-               returns relevant documents by utilizing training data and natural language
-               understanding.
-        :param int count: (optional) Number of results to return. The maximum for
-               the **count** and **offset** values together in any one query is **10000**.
-        :param int offset: (optional) The number of query results to skip at the
-               beginning. For example, if the total number of results that are returned is
-               10 and the offset is 8, it returns the last two results. The maximum for
-               the **count** and **offset** values together in any one query is **10000**.
-        :param dict headers: A `dict` containing the request headers
-        :return: A `DetailedResponse` containing the result, headers and HTTP status code.
-        :rtype: DetailedResponse with `dict` result representing a `QueryNoticesResponse` object
-        """
-
-        if project_id is None:
-            raise ValueError('project_id must be provided')
-        headers = {}
-        sdk_headers = get_sdk_headers(service_name=self.DEFAULT_SERVICE_NAME,
-                                      service_version='V2',
-                                      operation_id='query_notices')
-        headers.update(sdk_headers)
-
-        params = {
-            'version': self.version,
-            'filter': filter,
-            'query': query,
-            'natural_language_query': natural_language_query,
-            'count': count,
-            'offset': offset
-        }
-
-        if 'headers' in kwargs:
-            headers.update(kwargs.get('headers'))
-        headers['Accept'] = 'application/json'
-
-        path_param_keys = ['project_id']
-        path_param_values = self.encode_path_vars(project_id)
-        path_param_dict = dict(zip(path_param_keys, path_param_values))
-        url = '/v2/projects/{project_id}/notices'.format(**path_param_dict)
-        request = self.prepare_request(method='GET',
-                                       url=url,
-                                       headers=headers,
-                                       params=params)
-
-        response = self.send(request, **kwargs)
-        return response
-
-    def list_fields(self,
-                    project_id: str,
-                    *,
-                    collection_ids: List[str] = None,
-                    **kwargs) -> DetailedResponse:
-        """
-        List fields.
-
-        Gets a list of the unique fields (and their types) stored in the the specified
-        collections.
-
-        :param str project_id: The ID of the project. This information can be found
-               from the *Integrate and Deploy* page in Discovery.
-        :param List[str] collection_ids: (optional) Comma separated list of the
-               collection IDs. If this parameter is not specified, all collections in the
-               project are used.
-        :param dict headers: A `dict` containing the request headers
-        :return: A `DetailedResponse` containing the result, headers and HTTP status code.
-        :rtype: DetailedResponse with `dict` result representing a `ListFieldsResponse` object
-        """
-
-        if project_id is None:
-            raise ValueError('project_id must be provided')
-        headers = {}
-        sdk_headers = get_sdk_headers(service_name=self.DEFAULT_SERVICE_NAME,
-                                      service_version='V2',
-                                      operation_id='list_fields')
-        headers.update(sdk_headers)
-
-        params = {
-            'version': self.version,
-            'collection_ids': convert_list(collection_ids)
-        }
-
-        if 'headers' in kwargs:
-            headers.update(kwargs.get('headers'))
-        headers['Accept'] = 'application/json'
-
-        path_param_keys = ['project_id']
-        path_param_values = self.encode_path_vars(project_id)
-        path_param_dict = dict(zip(path_param_keys, path_param_values))
-        url = '/v2/projects/{project_id}/fields'.format(**path_param_dict)
-        request = self.prepare_request(method='GET',
-                                       url=url,
-                                       headers=headers,
-                                       params=params)
-
-        response = self.send(request, **kwargs)
-        return response
-
-    #########################
-    # Component settings
-    #########################
-
-    def get_component_settings(self, project_id: str,
-                               **kwargs) -> DetailedResponse:
-        """
-        List component settings.
-
-        Returns default configuration settings for components.
-
-        :param str project_id: The ID of the project. This information can be found
-               from the *Integrate and Deploy* page in Discovery.
-        :param dict headers: A `dict` containing the request headers
-        :return: A `DetailedResponse` containing the result, headers and HTTP status code.
-        :rtype: DetailedResponse with `dict` result representing a `ComponentSettingsResponse` object
-        """
-
-        if project_id is None:
-            raise ValueError('project_id must be provided')
-        headers = {}
-        sdk_headers = get_sdk_headers(service_name=self.DEFAULT_SERVICE_NAME,
-                                      service_version='V2',
-                                      operation_id='get_component_settings')
-        headers.update(sdk_headers)
-
-        params = {'version': self.version}
-
-        if 'headers' in kwargs:
-            headers.update(kwargs.get('headers'))
-        headers['Accept'] = 'application/json'
-
-        path_param_keys = ['project_id']
-        path_param_values = self.encode_path_vars(project_id)
-        path_param_dict = dict(zip(path_param_keys, path_param_values))
-        url = '/v2/projects/{project_id}/component_settings'.format(
-            **path_param_dict)
-        request = self.prepare_request(method='GET',
-                                       url=url,
-                                       headers=headers,
-                                       params=params)
-
-        response = self.send(request, **kwargs)
-        return response
-
-    #########################
-    # Documents
-    #########################
 
     def add_document(self,
                      project_id: str,
@@ -799,42 +764,48 @@ class DiscoveryV2(BaseService):
 
         Add a document to a collection with optional metadata.
         Returns immediately after the system has accepted the document for processing.
-          * The user must provide document content, metadata, or both. If the request is
-        missing both document content and metadata, it is rejected.
+        This operation works with a file upload collection. It cannot be used to modify a
+        collection that crawls an external data source.
+         * For a list of supported file types, see the [product
+        documentation](/docs/discovery-data?topic=discovery-data-collections#supportedfiletypes).
+         * You must provide document content, metadata, or both. If the request is missing
+        both document content and metadata, it is rejected.
           * You can set the **Content-Type** parameter on the **file** part to indicate
         the media type of the document. If the **Content-Type** parameter is missing or is
         one of the generic media types (for example, `application/octet-stream`), then the
         service attempts to automatically detect the document's media type.
-          * The following field names are reserved and are filtered out if present after
-        normalization: `id`, `score`, `highlight`, and any field with the prefix of: `_`,
-        `+`, or `-`
-          * Fields with empty name values after normalization are filtered out before
-        indexing.
-          * Fields that contain the following characters after normalization are filtered
-        out before indexing: `#` and `,`
-          If the document is uploaded to a collection that shares its data with another
+         *  If the document is uploaded to a collection that shares its data with another
         collection, the **X-Watson-Discovery-Force** header must be set to `true`.
-        **Note:** You can assign an ID to a document that you add by appending the ID to
-        the endpoint
+         * In curl requests only, you can assign an ID to a document that you add by
+        appending the ID to the endpoint
         (`/v2/projects/{project_id}/collections/{collection_id}/documents/{document_id}`).
         If a document already exists with the specified ID, it is replaced.
-        **Note:** This operation works with a file upload collection. It cannot be used to
-        modify a collection that crawls an external data source.
+        For more information about how certain file types and field names are handled when
+        a file is added to a collection, see the [product
+        documentation](/docs/discovery-data?topic=discovery-data-index-overview#field-name-limits).
 
         :param str project_id: The ID of the project. This information can be found
                from the *Integrate and Deploy* page in Discovery.
         :param str collection_id: The ID of the collection.
-        :param BinaryIO file: (optional) The content of the document to ingest. For
-               maximum supported file size limits, see [the
+        :param BinaryIO file: (optional) When adding a document, the content of the
+               document to ingest. For maximum supported file size limits, see [the
                documentation](https://cloud.ibm.com/docs/discovery-data?topic=discovery-data-collections#collections-doc-limits).
+               When analyzing a document, the content of the document to analyze but not
+               ingest. Only the `application/json` content type is supported currently.
+               For maximum supported file size limits, see [the product
+               documentation](/docs/discovery-data?topic=discovery-data-analyzeapi#analyzeapi-limits).
         :param str filename: (optional) The filename for file.
         :param str file_content_type: (optional) The content type of file.
-        :param str metadata: (optional) The maximum supported metadata file size is
-               1 MB. Metadata parts larger than 1 MB are rejected.
-               Example:  ``` {
-                 "Creator": "Johnny Appleseed",
-                 "Subject": "Apples"
-               } ```.
+        :param str metadata: (optional) Add information about the file that you
+               want to include in the response.
+               The maximum supported metadata file size is 1 MB. Metadata parts larger
+               than 1 MB are rejected.
+               Example:
+                ```
+                {
+                 "filename": "favorites2.json",
+                 "file_type": "json"
+                }.
         :param bool x_watson_discovery_force: (optional) When `true`, the uploaded
                document is added to the collection even if the data for that collection is
                shared with other collections.
@@ -861,13 +832,14 @@ class DiscoveryV2(BaseService):
                 filename = basename(file.name)
             if not filename:
                 raise ValueError('filename must be provided')
-            form_data.append(('file', (filename, file, file_content_type or
-                                       'application/octet-stream')))
+            form_data.append(('file', (filename, file, file_content_type
+                                       or 'application/octet-stream')))
         if metadata:
             form_data.append(('metadata', (None, metadata, 'text/plain')))
 
         if 'headers' in kwargs:
             headers.update(kwargs.get('headers'))
+            del kwargs['headers']
         headers['Accept'] = 'application/json'
 
         path_param_keys = ['project_id', 'collection_id']
@@ -880,6 +852,59 @@ class DiscoveryV2(BaseService):
                                        headers=headers,
                                        params=params,
                                        files=form_data)
+
+        response = self.send(request, **kwargs)
+        return response
+
+    def get_document(self, project_id: str, collection_id: str,
+                     document_id: str, **kwargs) -> DetailedResponse:
+        """
+        Get document details.
+
+        Get details about a specific document, whether the document is added by uploading
+        a file or by crawling an external data source.
+        **Note**: This method is available only from Cloud Pak for Data version 4.0.9 and
+        later installed instances and from Plus and Enterprise plan IBM Cloud-managed
+        instances.
+
+        :param str project_id: The ID of the project. This information can be found
+               from the *Integrate and Deploy* page in Discovery.
+        :param str collection_id: The ID of the collection.
+        :param str document_id: The ID of the document.
+        :param dict headers: A `dict` containing the request headers
+        :return: A `DetailedResponse` containing the result, headers and HTTP status code.
+        :rtype: DetailedResponse with `dict` result representing a `DocumentDetails` object
+        """
+
+        if project_id is None:
+            raise ValueError('project_id must be provided')
+        if collection_id is None:
+            raise ValueError('collection_id must be provided')
+        if document_id is None:
+            raise ValueError('document_id must be provided')
+        headers = {}
+        sdk_headers = get_sdk_headers(service_name=self.DEFAULT_SERVICE_NAME,
+                                      service_version='V2',
+                                      operation_id='get_document')
+        headers.update(sdk_headers)
+
+        params = {'version': self.version}
+
+        if 'headers' in kwargs:
+            headers.update(kwargs.get('headers'))
+            del kwargs['headers']
+        headers['Accept'] = 'application/json'
+
+        path_param_keys = ['project_id', 'collection_id', 'document_id']
+        path_param_values = self.encode_path_vars(project_id, collection_id,
+                                                  document_id)
+        path_param_dict = dict(zip(path_param_keys, path_param_values))
+        url = '/v2/projects/{project_id}/collections/{collection_id}/documents/{document_id}'.format(
+            **path_param_dict)
+        request = self.prepare_request(method='GET',
+                                       url=url,
+                                       headers=headers,
+                                       params=params)
 
         response = self.send(request, **kwargs)
         return response
@@ -898,33 +923,42 @@ class DiscoveryV2(BaseService):
         """
         Update a document.
 
-        Replace an existing document or add a document with a specified **document_id**.
+        Replace an existing document or add a document with a specified document ID.
         Starts ingesting a document with optional metadata.
+        This operation works with a file upload collection. It cannot be used to modify a
+        collection that crawls an external data source.
         If the document is uploaded to a collection that shares its data with another
         collection, the **X-Watson-Discovery-Force** header must be set to `true`.
-        **Note:** When uploading a new document with this method it automatically replaces
-        any document stored with the same **document_id** if it exists.
-        **Note:** This operation only works on collections created to accept direct file
-        uploads. It cannot be used to modify a collection that connects to an external
-        source such as Microsoft SharePoint.
-        **Note:** If an uploaded document is segmented, all segments are overwritten, even
-        if the updated version of the document has fewer segments.
+        **Notes:**
+         * Uploading a new document with this method automatically replaces any existing
+        document stored with the same document ID.
+         * If an uploaded document is split into child documents during ingestion, all
+        existing child documents are overwritten, even if the updated version of the
+        document has fewer child documents.
 
         :param str project_id: The ID of the project. This information can be found
                from the *Integrate and Deploy* page in Discovery.
         :param str collection_id: The ID of the collection.
         :param str document_id: The ID of the document.
-        :param BinaryIO file: (optional) The content of the document to ingest. For
-               maximum supported file size limits, see [the
+        :param BinaryIO file: (optional) When adding a document, the content of the
+               document to ingest. For maximum supported file size limits, see [the
                documentation](https://cloud.ibm.com/docs/discovery-data?topic=discovery-data-collections#collections-doc-limits).
+               When analyzing a document, the content of the document to analyze but not
+               ingest. Only the `application/json` content type is supported currently.
+               For maximum supported file size limits, see [the product
+               documentation](/docs/discovery-data?topic=discovery-data-analyzeapi#analyzeapi-limits).
         :param str filename: (optional) The filename for file.
         :param str file_content_type: (optional) The content type of file.
-        :param str metadata: (optional) The maximum supported metadata file size is
-               1 MB. Metadata parts larger than 1 MB are rejected.
-               Example:  ``` {
-                 "Creator": "Johnny Appleseed",
-                 "Subject": "Apples"
-               } ```.
+        :param str metadata: (optional) Add information about the file that you
+               want to include in the response.
+               The maximum supported metadata file size is 1 MB. Metadata parts larger
+               than 1 MB are rejected.
+               Example:
+                ```
+                {
+                 "filename": "favorites2.json",
+                 "file_type": "json"
+                }.
         :param bool x_watson_discovery_force: (optional) When `true`, the uploaded
                document is added to the collection even if the data for that collection is
                shared with other collections.
@@ -953,13 +987,14 @@ class DiscoveryV2(BaseService):
                 filename = basename(file.name)
             if not filename:
                 raise ValueError('filename must be provided')
-            form_data.append(('file', (filename, file, file_content_type or
-                                       'application/octet-stream')))
+            form_data.append(('file', (filename, file, file_content_type
+                                       or 'application/octet-stream')))
         if metadata:
             form_data.append(('metadata', (None, metadata, 'text/plain')))
 
         if 'headers' in kwargs:
             headers.update(kwargs.get('headers'))
+            del kwargs['headers']
         headers['Accept'] = 'application/json'
 
         path_param_keys = ['project_id', 'collection_id', 'document_id']
@@ -1024,6 +1059,7 @@ class DiscoveryV2(BaseService):
 
         if 'headers' in kwargs:
             headers.update(kwargs.get('headers'))
+            del kwargs['headers']
         headers['Accept'] = 'application/json'
 
         path_param_keys = ['project_id', 'collection_id', 'document_id']
@@ -1033,6 +1069,764 @@ class DiscoveryV2(BaseService):
         url = '/v2/projects/{project_id}/collections/{collection_id}/documents/{document_id}'.format(
             **path_param_dict)
         request = self.prepare_request(method='DELETE',
+                                       url=url,
+                                       headers=headers,
+                                       params=params)
+
+        response = self.send(request, **kwargs)
+        return response
+
+    #########################
+    # Queries
+    #########################
+
+    def query(self,
+              project_id: str,
+              *,
+              collection_ids: List[str] = None,
+              filter: str = None,
+              query: str = None,
+              natural_language_query: str = None,
+              aggregation: str = None,
+              count: int = None,
+              return_: List[str] = None,
+              offset: int = None,
+              sort: str = None,
+              highlight: bool = None,
+              spelling_suggestions: bool = None,
+              table_results: 'QueryLargeTableResults' = None,
+              suggested_refinements: 'QueryLargeSuggestedRefinements' = None,
+              passages: 'QueryLargePassages' = None,
+              similar: 'QueryLargeSimilar' = None,
+              **kwargs) -> DetailedResponse:
+        """
+        Query a project.
+
+        Search your data by submitting queries that are written in natural language or
+        formatted in the Discovery Query Language. For more information, see the
+        [Discovery
+        documentation](https://cloud.ibm.com/docs/discovery-data?topic=discovery-data-query-concepts).
+        The default query parameters differ by project type. For more information about
+        the project default settings, see the [Discovery
+        documentation](https://cloud.ibm.com/docs/discovery-data?topic=discovery-data-query-defaults).
+        See [the Projects API documentation](#create-project) for details about how to set
+        custom default query settings.
+        The length of the UTF-8 encoding of the POST body cannot exceed 10,000 bytes,
+        which is roughly equivalent to 10,000 characters in English.
+
+        :param str project_id: The ID of the project. This information can be found
+               from the *Integrate and Deploy* page in Discovery.
+        :param List[str] collection_ids: (optional) A comma-separated list of
+               collection IDs to be queried against.
+        :param str filter: (optional) Searches for documents that match the
+               Discovery Query Language criteria that is specified as input. Filter calls
+               are cached and are faster than query calls because the results are not
+               ordered by relevance. When used with the **aggregation**, **query**, or
+               **natural_language_query** parameters, the **filter** parameter runs first.
+               This parameter is useful for limiting results to those that contain
+               specific metadata values.
+        :param str query: (optional) A query search that is written in the
+               Discovery Query Language and returns all matching documents in your data
+               set with full enrichments and full text, and with the most relevant
+               documents listed first. Use a query search when you want to find the most
+               relevant search results.
+        :param str natural_language_query: (optional) A natural language query that
+               returns relevant documents by using training data and natural language
+               understanding.
+        :param str aggregation: (optional) An aggregation search that returns an
+               exact answer by combining query search with filters. Useful for
+               applications to build lists, tables, and time series. For more information
+               about the supported types of aggregations, see the [Discovery
+               documentation](https://cloud.ibm.com/docs/discovery-data?topic=discovery-data-query-aggregations).
+        :param int count: (optional) Number of results to return.
+        :param List[str] return_: (optional) A list of the fields in the document
+               hierarchy to return. You can specify both root-level (`text`) and nested
+               (`extracted_metadata.filename`) fields. If this parameter is an empty list,
+               then all fields are returned.
+        :param int offset: (optional) The number of query results to skip at the
+               beginning. For example, if the total number of results that are returned is
+               10 and the offset is 8, it returns the last two results.
+        :param str sort: (optional) A comma-separated list of fields in the
+               document to sort on. You can optionally specify a sort direction by
+               prefixing the field with `-` for descending or `+` for ascending. Ascending
+               is the default sort direction if no prefix is specified.
+        :param bool highlight: (optional) When `true`, a highlight field is
+               returned for each result that contains fields that match the query. The
+               matching query terms are emphasized with surrounding `<em></em>` tags. This
+               parameter is ignored if **passages.enabled** and **passages.per_document**
+               are `true`, in which case passages are returned for each document instead
+               of highlights.
+        :param bool spelling_suggestions: (optional) When `true` and the
+               **natural_language_query** parameter is used, the
+               **natural_language_query** parameter is spell checked. The most likely
+               correction is returned in the **suggested_query** field of the response (if
+               one exists).
+        :param QueryLargeTableResults table_results: (optional) Configuration for
+               table retrieval.
+        :param QueryLargeSuggestedRefinements suggested_refinements: (optional)
+               Configuration for suggested refinements.
+               **Note**: The **suggested_refinements** parameter that identified dynamic
+               facets from the data is deprecated.
+        :param QueryLargePassages passages: (optional) Configuration for passage
+               retrieval.
+        :param QueryLargeSimilar similar: (optional) Finds results from documents
+               that are similar to documents of interest. Use this parameter to add a
+               *More like these* function to your search. You can include this parameter
+               with or without a **query**, **filter** or **natural_language_query**
+               parameter.
+        :param dict headers: A `dict` containing the request headers
+        :return: A `DetailedResponse` containing the result, headers and HTTP status code.
+        :rtype: DetailedResponse with `dict` result representing a `QueryResponse` object
+        """
+
+        if project_id is None:
+            raise ValueError('project_id must be provided')
+        if table_results is not None:
+            table_results = convert_model(table_results)
+        if suggested_refinements is not None:
+            suggested_refinements = convert_model(suggested_refinements)
+        if passages is not None:
+            passages = convert_model(passages)
+        if similar is not None:
+            similar = convert_model(similar)
+        headers = {}
+        sdk_headers = get_sdk_headers(service_name=self.DEFAULT_SERVICE_NAME,
+                                      service_version='V2',
+                                      operation_id='query')
+        headers.update(sdk_headers)
+
+        params = {'version': self.version}
+
+        data = {
+            'collection_ids': collection_ids,
+            'filter': filter,
+            'query': query,
+            'natural_language_query': natural_language_query,
+            'aggregation': aggregation,
+            'count': count,
+            'return': return_,
+            'offset': offset,
+            'sort': sort,
+            'highlight': highlight,
+            'spelling_suggestions': spelling_suggestions,
+            'table_results': table_results,
+            'suggested_refinements': suggested_refinements,
+            'passages': passages,
+            'similar': similar
+        }
+        data = {k: v for (k, v) in data.items() if v is not None}
+        data = json.dumps(data)
+        headers['content-type'] = 'application/json'
+
+        if 'headers' in kwargs:
+            headers.update(kwargs.get('headers'))
+            del kwargs['headers']
+        headers['Accept'] = 'application/json'
+
+        path_param_keys = ['project_id']
+        path_param_values = self.encode_path_vars(project_id)
+        path_param_dict = dict(zip(path_param_keys, path_param_values))
+        url = '/v2/projects/{project_id}/query'.format(**path_param_dict)
+        request = self.prepare_request(method='POST',
+                                       url=url,
+                                       headers=headers,
+                                       params=params,
+                                       data=data)
+
+        response = self.send(request, **kwargs)
+        return response
+
+    def get_autocompletion(self,
+                           project_id: str,
+                           prefix: str,
+                           *,
+                           collection_ids: List[str] = None,
+                           field: str = None,
+                           count: int = None,
+                           **kwargs) -> DetailedResponse:
+        """
+        Get Autocomplete Suggestions.
+
+        Returns completion query suggestions for the specified prefix.
+
+        :param str project_id: The ID of the project. This information can be found
+               from the *Integrate and Deploy* page in Discovery.
+        :param str prefix: The prefix to use for autocompletion. For example, the
+               prefix `Ho` could autocomplete to `hot`, `housing`, or `how`.
+        :param List[str] collection_ids: (optional) Comma separated list of the
+               collection IDs. If this parameter is not specified, all collections in the
+               project are used.
+        :param str field: (optional) The field in the result documents that
+               autocompletion suggestions are identified from.
+        :param int count: (optional) The number of autocompletion suggestions to
+               return.
+        :param dict headers: A `dict` containing the request headers
+        :return: A `DetailedResponse` containing the result, headers and HTTP status code.
+        :rtype: DetailedResponse with `dict` result representing a `Completions` object
+        """
+
+        if project_id is None:
+            raise ValueError('project_id must be provided')
+        if prefix is None:
+            raise ValueError('prefix must be provided')
+        headers = {}
+        sdk_headers = get_sdk_headers(service_name=self.DEFAULT_SERVICE_NAME,
+                                      service_version='V2',
+                                      operation_id='get_autocompletion')
+        headers.update(sdk_headers)
+
+        params = {
+            'version': self.version,
+            'prefix': prefix,
+            'collection_ids': convert_list(collection_ids),
+            'field': field,
+            'count': count
+        }
+
+        if 'headers' in kwargs:
+            headers.update(kwargs.get('headers'))
+            del kwargs['headers']
+        headers['Accept'] = 'application/json'
+
+        path_param_keys = ['project_id']
+        path_param_values = self.encode_path_vars(project_id)
+        path_param_dict = dict(zip(path_param_keys, path_param_values))
+        url = '/v2/projects/{project_id}/autocompletion'.format(
+            **path_param_dict)
+        request = self.prepare_request(method='GET',
+                                       url=url,
+                                       headers=headers,
+                                       params=params)
+
+        response = self.send(request, **kwargs)
+        return response
+
+    def query_collection_notices(self,
+                                 project_id: str,
+                                 collection_id: str,
+                                 *,
+                                 filter: str = None,
+                                 query: str = None,
+                                 natural_language_query: str = None,
+                                 count: int = None,
+                                 offset: int = None,
+                                 **kwargs) -> DetailedResponse:
+        """
+        Query collection notices.
+
+        Finds collection-level notices (errors and warnings) that are generated when
+        documents are ingested.
+
+        :param str project_id: The ID of the project. This information can be found
+               from the *Integrate and Deploy* page in Discovery.
+        :param str collection_id: The ID of the collection.
+        :param str filter: (optional) Searches for documents that match the
+               Discovery Query Language criteria that is specified as input. Filter calls
+               are cached and are faster than query calls because the results are not
+               ordered by relevance. When used with the `aggregation`, `query`, or
+               `natural_language_query` parameters, the `filter` parameter runs first.
+               This parameter is useful for limiting results to those that contain
+               specific metadata values.
+        :param str query: (optional) A query search that is written in the
+               Discovery Query Language and returns all matching documents in your data
+               set with full enrichments and full text, and with the most relevant
+               documents listed first.
+        :param str natural_language_query: (optional) A natural language query that
+               returns relevant documents by using training data and natural language
+               understanding.
+        :param int count: (optional) Number of results to return. The maximum for
+               the **count** and **offset** values together in any one query is
+               **10,000**.
+        :param int offset: (optional) The number of query results to skip at the
+               beginning. For example, if the total number of results that are returned is
+               10 and the offset is 8, it returns the last two results. The maximum for
+               the **count** and **offset** values together in any one query is **10000**.
+        :param dict headers: A `dict` containing the request headers
+        :return: A `DetailedResponse` containing the result, headers and HTTP status code.
+        :rtype: DetailedResponse with `dict` result representing a `QueryNoticesResponse` object
+        """
+
+        if project_id is None:
+            raise ValueError('project_id must be provided')
+        if collection_id is None:
+            raise ValueError('collection_id must be provided')
+        headers = {}
+        sdk_headers = get_sdk_headers(service_name=self.DEFAULT_SERVICE_NAME,
+                                      service_version='V2',
+                                      operation_id='query_collection_notices')
+        headers.update(sdk_headers)
+
+        params = {
+            'version': self.version,
+            'filter': filter,
+            'query': query,
+            'natural_language_query': natural_language_query,
+            'count': count,
+            'offset': offset
+        }
+
+        if 'headers' in kwargs:
+            headers.update(kwargs.get('headers'))
+            del kwargs['headers']
+        headers['Accept'] = 'application/json'
+
+        path_param_keys = ['project_id', 'collection_id']
+        path_param_values = self.encode_path_vars(project_id, collection_id)
+        path_param_dict = dict(zip(path_param_keys, path_param_values))
+        url = '/v2/projects/{project_id}/collections/{collection_id}/notices'.format(
+            **path_param_dict)
+        request = self.prepare_request(method='GET',
+                                       url=url,
+                                       headers=headers,
+                                       params=params)
+
+        response = self.send(request, **kwargs)
+        return response
+
+    def query_notices(self,
+                      project_id: str,
+                      *,
+                      filter: str = None,
+                      query: str = None,
+                      natural_language_query: str = None,
+                      count: int = None,
+                      offset: int = None,
+                      **kwargs) -> DetailedResponse:
+        """
+        Query project notices.
+
+        Finds project-level notices (errors and warnings). Currently, project-level
+        notices are generated by relevancy training.
+
+        :param str project_id: The ID of the project. This information can be found
+               from the *Integrate and Deploy* page in Discovery.
+        :param str filter: (optional) Searches for documents that match the
+               Discovery Query Language criteria that is specified as input. Filter calls
+               are cached and are faster than query calls because the results are not
+               ordered by relevance. When used with the `aggregation`, `query`, or
+               `natural_language_query` parameters, the `filter` parameter runs first.
+               This parameter is useful for limiting results to those that contain
+               specific metadata values.
+        :param str query: (optional) A query search that is written in the
+               Discovery Query Language and returns all matching documents in your data
+               set with full enrichments and full text, and with the most relevant
+               documents listed first.
+        :param str natural_language_query: (optional) A natural language query that
+               returns relevant documents by using training data and natural language
+               understanding.
+        :param int count: (optional) Number of results to return. The maximum for
+               the **count** and **offset** values together in any one query is
+               **10,000**.
+        :param int offset: (optional) The number of query results to skip at the
+               beginning. For example, if the total number of results that are returned is
+               10 and the offset is 8, it returns the last two results. The maximum for
+               the **count** and **offset** values together in any one query is **10000**.
+        :param dict headers: A `dict` containing the request headers
+        :return: A `DetailedResponse` containing the result, headers and HTTP status code.
+        :rtype: DetailedResponse with `dict` result representing a `QueryNoticesResponse` object
+        """
+
+        if project_id is None:
+            raise ValueError('project_id must be provided')
+        headers = {}
+        sdk_headers = get_sdk_headers(service_name=self.DEFAULT_SERVICE_NAME,
+                                      service_version='V2',
+                                      operation_id='query_notices')
+        headers.update(sdk_headers)
+
+        params = {
+            'version': self.version,
+            'filter': filter,
+            'query': query,
+            'natural_language_query': natural_language_query,
+            'count': count,
+            'offset': offset
+        }
+
+        if 'headers' in kwargs:
+            headers.update(kwargs.get('headers'))
+            del kwargs['headers']
+        headers['Accept'] = 'application/json'
+
+        path_param_keys = ['project_id']
+        path_param_values = self.encode_path_vars(project_id)
+        path_param_dict = dict(zip(path_param_keys, path_param_values))
+        url = '/v2/projects/{project_id}/notices'.format(**path_param_dict)
+        request = self.prepare_request(method='GET',
+                                       url=url,
+                                       headers=headers,
+                                       params=params)
+
+        response = self.send(request, **kwargs)
+        return response
+
+    #########################
+    # Query modifications
+    #########################
+
+    def get_stopword_list(self, project_id: str, collection_id: str,
+                          **kwargs) -> DetailedResponse:
+        """
+        Get a custom stop words list.
+
+        Returns the custom stop words list that is used by the collection. For information
+        about the default stop words lists that are applied to queries, see [the product
+        documentation](/docs/discovery-data?topic=discovery-data-stopwords).
+
+        :param str project_id: The ID of the project. This information can be found
+               from the *Integrate and Deploy* page in Discovery.
+        :param str collection_id: The ID of the collection.
+        :param dict headers: A `dict` containing the request headers
+        :return: A `DetailedResponse` containing the result, headers and HTTP status code.
+        :rtype: DetailedResponse with `dict` result representing a `StopWordList` object
+        """
+
+        if project_id is None:
+            raise ValueError('project_id must be provided')
+        if collection_id is None:
+            raise ValueError('collection_id must be provided')
+        headers = {}
+        sdk_headers = get_sdk_headers(service_name=self.DEFAULT_SERVICE_NAME,
+                                      service_version='V2',
+                                      operation_id='get_stopword_list')
+        headers.update(sdk_headers)
+
+        params = {'version': self.version}
+
+        if 'headers' in kwargs:
+            headers.update(kwargs.get('headers'))
+            del kwargs['headers']
+        headers['Accept'] = 'application/json'
+
+        path_param_keys = ['project_id', 'collection_id']
+        path_param_values = self.encode_path_vars(project_id, collection_id)
+        path_param_dict = dict(zip(path_param_keys, path_param_values))
+        url = '/v2/projects/{project_id}/collections/{collection_id}/stopwords'.format(
+            **path_param_dict)
+        request = self.prepare_request(method='GET',
+                                       url=url,
+                                       headers=headers,
+                                       params=params)
+
+        response = self.send(request, **kwargs)
+        return response
+
+    def create_stopword_list(self,
+                             project_id: str,
+                             collection_id: str,
+                             *,
+                             stopwords: List[str] = None,
+                             **kwargs) -> DetailedResponse:
+        """
+        Create a custom stop words list.
+
+        Adds a list of custom stop words. Stop words are words that you want the service
+        to ignore when they occur in a query because they're not useful in distinguishing
+        the semantic meaning of the query. The stop words list cannot contain more than 1
+        million characters.
+        A default stop words list is used by all collections. The default list is applied
+        both at indexing time and at query time. A custom stop words list that you add is
+        used at query time only.
+        The custom stop words list replaces the default stop words list. Therefore, if you
+        want to keep the stop words that were used when the collection was indexed, get
+        the default stop words list for the language of the collection first and edit it
+        to create your custom list. For information about the default stop words lists per
+        language, see [the product
+        documentation](/docs/discovery-data?topic=discovery-data-stopwords).
+
+        :param str project_id: The ID of the project. This information can be found
+               from the *Integrate and Deploy* page in Discovery.
+        :param str collection_id: The ID of the collection.
+        :param List[str] stopwords: (optional) List of stop words.
+        :param dict headers: A `dict` containing the request headers
+        :return: A `DetailedResponse` containing the result, headers and HTTP status code.
+        :rtype: DetailedResponse with `dict` result representing a `StopWordList` object
+        """
+
+        if project_id is None:
+            raise ValueError('project_id must be provided')
+        if collection_id is None:
+            raise ValueError('collection_id must be provided')
+        headers = {}
+        sdk_headers = get_sdk_headers(service_name=self.DEFAULT_SERVICE_NAME,
+                                      service_version='V2',
+                                      operation_id='create_stopword_list')
+        headers.update(sdk_headers)
+
+        params = {'version': self.version}
+
+        data = {'stopwords': stopwords}
+        data = {k: v for (k, v) in data.items() if v is not None}
+        data = json.dumps(data)
+        headers['content-type'] = 'application/json'
+
+        if 'headers' in kwargs:
+            headers.update(kwargs.get('headers'))
+            del kwargs['headers']
+        headers['Accept'] = 'application/json'
+
+        path_param_keys = ['project_id', 'collection_id']
+        path_param_values = self.encode_path_vars(project_id, collection_id)
+        path_param_dict = dict(zip(path_param_keys, path_param_values))
+        url = '/v2/projects/{project_id}/collections/{collection_id}/stopwords'.format(
+            **path_param_dict)
+        request = self.prepare_request(method='POST',
+                                       url=url,
+                                       headers=headers,
+                                       params=params,
+                                       data=data)
+
+        response = self.send(request, **kwargs)
+        return response
+
+    def delete_stopword_list(self, project_id: str, collection_id: str,
+                             **kwargs) -> DetailedResponse:
+        """
+        Delete a custom stop words list.
+
+        Deletes a custom stop words list to stop using it in queries against the
+        collection. After a custom stop words list is deleted, the default stop words list
+        is used.
+
+        :param str project_id: The ID of the project. This information can be found
+               from the *Integrate and Deploy* page in Discovery.
+        :param str collection_id: The ID of the collection.
+        :param dict headers: A `dict` containing the request headers
+        :return: A `DetailedResponse` containing the result, headers and HTTP status code.
+        :rtype: DetailedResponse
+        """
+
+        if project_id is None:
+            raise ValueError('project_id must be provided')
+        if collection_id is None:
+            raise ValueError('collection_id must be provided')
+        headers = {}
+        sdk_headers = get_sdk_headers(service_name=self.DEFAULT_SERVICE_NAME,
+                                      service_version='V2',
+                                      operation_id='delete_stopword_list')
+        headers.update(sdk_headers)
+
+        params = {'version': self.version}
+
+        if 'headers' in kwargs:
+            headers.update(kwargs.get('headers'))
+            del kwargs['headers']
+
+        path_param_keys = ['project_id', 'collection_id']
+        path_param_values = self.encode_path_vars(project_id, collection_id)
+        path_param_dict = dict(zip(path_param_keys, path_param_values))
+        url = '/v2/projects/{project_id}/collections/{collection_id}/stopwords'.format(
+            **path_param_dict)
+        request = self.prepare_request(method='DELETE',
+                                       url=url,
+                                       headers=headers,
+                                       params=params)
+
+        response = self.send(request, **kwargs)
+        return response
+
+    def list_expansions(self, project_id: str, collection_id: str,
+                        **kwargs) -> DetailedResponse:
+        """
+        Get the expansion list.
+
+        Returns the current expansion list for the specified collection. If an expansion
+        list is not specified, an empty expansions array is returned.
+
+        :param str project_id: The ID of the project. This information can be found
+               from the *Integrate and Deploy* page in Discovery.
+        :param str collection_id: The ID of the collection.
+        :param dict headers: A `dict` containing the request headers
+        :return: A `DetailedResponse` containing the result, headers and HTTP status code.
+        :rtype: DetailedResponse with `dict` result representing a `Expansions` object
+        """
+
+        if project_id is None:
+            raise ValueError('project_id must be provided')
+        if collection_id is None:
+            raise ValueError('collection_id must be provided')
+        headers = {}
+        sdk_headers = get_sdk_headers(service_name=self.DEFAULT_SERVICE_NAME,
+                                      service_version='V2',
+                                      operation_id='list_expansions')
+        headers.update(sdk_headers)
+
+        params = {'version': self.version}
+
+        if 'headers' in kwargs:
+            headers.update(kwargs.get('headers'))
+            del kwargs['headers']
+        headers['Accept'] = 'application/json'
+
+        path_param_keys = ['project_id', 'collection_id']
+        path_param_values = self.encode_path_vars(project_id, collection_id)
+        path_param_dict = dict(zip(path_param_keys, path_param_values))
+        url = '/v2/projects/{project_id}/collections/{collection_id}/expansions'.format(
+            **path_param_dict)
+        request = self.prepare_request(method='GET',
+                                       url=url,
+                                       headers=headers,
+                                       params=params)
+
+        response = self.send(request, **kwargs)
+        return response
+
+    def create_expansions(self, project_id: str, collection_id: str,
+                          expansions: List['Expansion'],
+                          **kwargs) -> DetailedResponse:
+        """
+        Create or update an expansion list.
+
+        Creates or replaces the expansion list for this collection. An expansion list
+        introduces alternative wording for key terms that are mentioned in your
+        collection. By identifying synonyms or common misspellings, you expand the scope
+        of a query beyond exact matches. The maximum number of expanded terms allowed per
+        collection is 5,000.
+
+        :param str project_id: The ID of the project. This information can be found
+               from the *Integrate and Deploy* page in Discovery.
+        :param str collection_id: The ID of the collection.
+        :param List[Expansion] expansions: An array of query expansion definitions.
+                Each object in the **expansions** array represents a term or set of terms
+               that will be expanded into other terms. Each expansion object can be
+               configured as `bidirectional` or `unidirectional`.
+               * **Bidirectional**: Each entry in the `expanded_terms` list expands to
+               include all expanded terms. For example, a query for `ibm` expands to `ibm
+               OR international business machines OR big blue`.
+               * **Unidirectional**: The terms in `input_terms` in the query are replaced
+               by the terms in `expanded_terms`. For example, a query for the often
+               misused term `on premise` is converted to `on premises OR on-premises` and
+               does not contain the original term. If you want an input term to be
+               included in the query, then repeat the input term in the expanded terms
+               list.
+        :param dict headers: A `dict` containing the request headers
+        :return: A `DetailedResponse` containing the result, headers and HTTP status code.
+        :rtype: DetailedResponse with `dict` result representing a `Expansions` object
+        """
+
+        if project_id is None:
+            raise ValueError('project_id must be provided')
+        if collection_id is None:
+            raise ValueError('collection_id must be provided')
+        if expansions is None:
+            raise ValueError('expansions must be provided')
+        expansions = [convert_model(x) for x in expansions]
+        headers = {}
+        sdk_headers = get_sdk_headers(service_name=self.DEFAULT_SERVICE_NAME,
+                                      service_version='V2',
+                                      operation_id='create_expansions')
+        headers.update(sdk_headers)
+
+        params = {'version': self.version}
+
+        data = {'expansions': expansions}
+        data = {k: v for (k, v) in data.items() if v is not None}
+        data = json.dumps(data)
+        headers['content-type'] = 'application/json'
+
+        if 'headers' in kwargs:
+            headers.update(kwargs.get('headers'))
+            del kwargs['headers']
+        headers['Accept'] = 'application/json'
+
+        path_param_keys = ['project_id', 'collection_id']
+        path_param_values = self.encode_path_vars(project_id, collection_id)
+        path_param_dict = dict(zip(path_param_keys, path_param_values))
+        url = '/v2/projects/{project_id}/collections/{collection_id}/expansions'.format(
+            **path_param_dict)
+        request = self.prepare_request(method='POST',
+                                       url=url,
+                                       headers=headers,
+                                       params=params,
+                                       data=data)
+
+        response = self.send(request, **kwargs)
+        return response
+
+    def delete_expansions(self, project_id: str, collection_id: str,
+                          **kwargs) -> DetailedResponse:
+        """
+        Delete the expansion list.
+
+        Removes the expansion information for this collection. To disable query expansion
+        for a collection, delete the expansion list.
+
+        :param str project_id: The ID of the project. This information can be found
+               from the *Integrate and Deploy* page in Discovery.
+        :param str collection_id: The ID of the collection.
+        :param dict headers: A `dict` containing the request headers
+        :return: A `DetailedResponse` containing the result, headers and HTTP status code.
+        :rtype: DetailedResponse
+        """
+
+        if project_id is None:
+            raise ValueError('project_id must be provided')
+        if collection_id is None:
+            raise ValueError('collection_id must be provided')
+        headers = {}
+        sdk_headers = get_sdk_headers(service_name=self.DEFAULT_SERVICE_NAME,
+                                      service_version='V2',
+                                      operation_id='delete_expansions')
+        headers.update(sdk_headers)
+
+        params = {'version': self.version}
+
+        if 'headers' in kwargs:
+            headers.update(kwargs.get('headers'))
+            del kwargs['headers']
+
+        path_param_keys = ['project_id', 'collection_id']
+        path_param_values = self.encode_path_vars(project_id, collection_id)
+        path_param_dict = dict(zip(path_param_keys, path_param_values))
+        url = '/v2/projects/{project_id}/collections/{collection_id}/expansions'.format(
+            **path_param_dict)
+        request = self.prepare_request(method='DELETE',
+                                       url=url,
+                                       headers=headers,
+                                       params=params)
+
+        response = self.send(request, **kwargs)
+        return response
+
+    #########################
+    # Component settings
+    #########################
+
+    def get_component_settings(self, project_id: str,
+                               **kwargs) -> DetailedResponse:
+        """
+        List component settings.
+
+        Returns default configuration settings for components.
+
+        :param str project_id: The ID of the project. This information can be found
+               from the *Integrate and Deploy* page in Discovery.
+        :param dict headers: A `dict` containing the request headers
+        :return: A `DetailedResponse` containing the result, headers and HTTP status code.
+        :rtype: DetailedResponse with `dict` result representing a `ComponentSettingsResponse` object
+        """
+
+        if project_id is None:
+            raise ValueError('project_id must be provided')
+        headers = {}
+        sdk_headers = get_sdk_headers(service_name=self.DEFAULT_SERVICE_NAME,
+                                      service_version='V2',
+                                      operation_id='get_component_settings')
+        headers.update(sdk_headers)
+
+        params = {'version': self.version}
+
+        if 'headers' in kwargs:
+            headers.update(kwargs.get('headers'))
+            del kwargs['headers']
+        headers['Accept'] = 'application/json'
+
+        path_param_keys = ['project_id']
+        path_param_values = self.encode_path_vars(project_id)
+        path_param_dict = dict(zip(path_param_keys, path_param_values))
+        url = '/v2/projects/{project_id}/component_settings'.format(
+            **path_param_dict)
+        request = self.prepare_request(method='GET',
                                        url=url,
                                        headers=headers,
                                        params=params)
@@ -1070,6 +1864,7 @@ class DiscoveryV2(BaseService):
 
         if 'headers' in kwargs:
             headers.update(kwargs.get('headers'))
+            del kwargs['headers']
         headers['Accept'] = 'application/json'
 
         path_param_keys = ['project_id']
@@ -1111,6 +1906,7 @@ class DiscoveryV2(BaseService):
 
         if 'headers' in kwargs:
             headers.update(kwargs.get('headers'))
+            del kwargs['headers']
 
         path_param_keys = ['project_id']
         path_param_values = self.encode_path_vars(project_id)
@@ -1176,6 +1972,7 @@ class DiscoveryV2(BaseService):
 
         if 'headers' in kwargs:
             headers.update(kwargs.get('headers'))
+            del kwargs['headers']
         headers['Accept'] = 'application/json'
 
         path_param_keys = ['project_id']
@@ -1222,6 +2019,7 @@ class DiscoveryV2(BaseService):
 
         if 'headers' in kwargs:
             headers.update(kwargs.get('headers'))
+            del kwargs['headers']
         headers['Accept'] = 'application/json'
 
         path_param_keys = ['project_id', 'query_id']
@@ -1291,6 +2089,7 @@ class DiscoveryV2(BaseService):
 
         if 'headers' in kwargs:
             headers.update(kwargs.get('headers'))
+            del kwargs['headers']
         headers['Accept'] = 'application/json'
 
         path_param_keys = ['project_id', 'query_id']
@@ -1337,6 +2136,7 @@ class DiscoveryV2(BaseService):
 
         if 'headers' in kwargs:
             headers.update(kwargs.get('headers'))
+            del kwargs['headers']
 
         path_param_keys = ['project_id', 'query_id']
         path_param_values = self.encode_path_vars(project_id, query_id)
@@ -1352,93 +2152,12 @@ class DiscoveryV2(BaseService):
         return response
 
     #########################
-    # analyze
-    #########################
-
-    def analyze_document(self,
-                         project_id: str,
-                         collection_id: str,
-                         *,
-                         file: BinaryIO = None,
-                         filename: str = None,
-                         file_content_type: str = None,
-                         metadata: str = None,
-                         **kwargs) -> DetailedResponse:
-        """
-        Analyze a Document.
-
-        Process a document and return it for realtime use. Supports JSON files only.
-        The document is processed according to the collection's configuration settings but
-        is not stored in the collection.
-        **Note:** This method is supported on installed instances of Discovery only.
-
-        :param str project_id: The ID of the project. This information can be found
-               from the *Integrate and Deploy* page in Discovery.
-        :param str collection_id: The ID of the collection.
-        :param BinaryIO file: (optional) The content of the document to ingest. For
-               maximum supported file size limits, see [the
-               documentation](https://cloud.ibm.com/docs/discovery-data?topic=discovery-data-collections#collections-doc-limits).
-        :param str filename: (optional) The filename for file.
-        :param str file_content_type: (optional) The content type of file.
-        :param str metadata: (optional) The maximum supported metadata file size is
-               1 MB. Metadata parts larger than 1 MB are rejected.
-               Example:  ``` {
-                 "Creator": "Johnny Appleseed",
-                 "Subject": "Apples"
-               } ```.
-        :param dict headers: A `dict` containing the request headers
-        :return: A `DetailedResponse` containing the result, headers and HTTP status code.
-        :rtype: DetailedResponse with `dict` result representing a `AnalyzedDocument` object
-        """
-
-        if project_id is None:
-            raise ValueError('project_id must be provided')
-        if collection_id is None:
-            raise ValueError('collection_id must be provided')
-        headers = {}
-        sdk_headers = get_sdk_headers(service_name=self.DEFAULT_SERVICE_NAME,
-                                      service_version='V2',
-                                      operation_id='analyze_document')
-        headers.update(sdk_headers)
-
-        params = {'version': self.version}
-
-        form_data = []
-        if file:
-            if not filename and hasattr(file, 'name'):
-                filename = basename(file.name)
-            if not filename:
-                raise ValueError('filename must be provided')
-            form_data.append(('file', (filename, file, file_content_type or
-                                       'application/octet-stream')))
-        if metadata:
-            form_data.append(('metadata', (None, metadata, 'text/plain')))
-
-        if 'headers' in kwargs:
-            headers.update(kwargs.get('headers'))
-        headers['Accept'] = 'application/json'
-
-        path_param_keys = ['project_id', 'collection_id']
-        path_param_values = self.encode_path_vars(project_id, collection_id)
-        path_param_dict = dict(zip(path_param_keys, path_param_values))
-        url = '/v2/projects/{project_id}/collections/{collection_id}/analyze'.format(
-            **path_param_dict)
-        request = self.prepare_request(method='POST',
-                                       url=url,
-                                       headers=headers,
-                                       params=params,
-                                       files=form_data)
-
-        response = self.send(request, **kwargs)
-        return response
-
-    #########################
-    # enrichments
+    # Enrichments
     #########################
 
     def list_enrichments(self, project_id: str, **kwargs) -> DetailedResponse:
         """
-        List Enrichments.
+        List enrichments.
 
         Lists the enrichments available to this project. The *Part of Speech* and
         *Sentiment of Phrases* enrichments might be listed, but are reserved for internal
@@ -1463,6 +2182,7 @@ class DiscoveryV2(BaseService):
 
         if 'headers' in kwargs:
             headers.update(kwargs.get('headers'))
+            del kwargs['headers']
         headers['Accept'] = 'application/json'
 
         path_param_keys = ['project_id']
@@ -1486,13 +2206,20 @@ class DiscoveryV2(BaseService):
         """
         Create an enrichment.
 
-        Create an enrichment for use with the specified project.
+        Create an enrichment for use with the specified project. To apply the enrichment
+        to a collection in the project, use the [Collections
+        API](/apidocs/discovery-data#createcollection).
 
         :param str project_id: The ID of the project. This information can be found
                from the *Integrate and Deploy* page in Discovery.
         :param CreateEnrichment enrichment: Information about a specific
                enrichment.
-        :param BinaryIO file: (optional) The enrichment file to upload.
+        :param BinaryIO file: (optional) The enrichment file to upload. Expected
+               file types per enrichment are as follows:
+               * CSV for `dictionary`
+               * PEAR for `uima_annotator` and `rule_based` (Explorer)
+               * ZIP for `watson_knowledge_studio_model` and `rule_based` (Studio Advanced
+               Rule Editor).
         :param dict headers: A `dict` containing the request headers
         :return: A `DetailedResponse` containing the result, headers and HTTP status code.
         :rtype: DetailedResponse with `dict` result representing a `Enrichment` object
@@ -1514,10 +2241,12 @@ class DiscoveryV2(BaseService):
         form_data.append(
             ('enrichment', (None, json.dumps(enrichment), 'application/json')))
         if file:
-            form_data.append(('file', (None, file, 'application/octet-stream')))
+            form_data.append(
+                ('file', (None, file, 'application/octet-stream')))
 
         if 'headers' in kwargs:
             headers.update(kwargs.get('headers'))
+            del kwargs['headers']
         headers['Accept'] = 'application/json'
 
         path_param_keys = ['project_id']
@@ -1562,6 +2291,7 @@ class DiscoveryV2(BaseService):
 
         if 'headers' in kwargs:
             headers.update(kwargs.get('headers'))
+            del kwargs['headers']
         headers['Accept'] = 'application/json'
 
         path_param_keys = ['project_id', 'enrichment_id']
@@ -1620,6 +2350,7 @@ class DiscoveryV2(BaseService):
 
         if 'headers' in kwargs:
             headers.update(kwargs.get('headers'))
+            del kwargs['headers']
         headers['Accept'] = 'application/json'
 
         path_param_keys = ['project_id', 'enrichment_id']
@@ -1666,6 +2397,7 @@ class DiscoveryV2(BaseService):
 
         if 'headers' in kwargs:
             headers.update(kwargs.get('headers'))
+            del kwargs['headers']
 
         path_param_keys = ['project_id', 'enrichment_id']
         path_param_values = self.encode_path_vars(project_id, enrichment_id)
@@ -1681,33 +2413,44 @@ class DiscoveryV2(BaseService):
         return response
 
     #########################
-    # projects
+    # Document classifiers
     #########################
 
-    def list_projects(self, **kwargs) -> DetailedResponse:
+    def list_document_classifiers(self, project_id: str,
+                                  **kwargs) -> DetailedResponse:
         """
-        List projects.
+        List document classifiers.
 
-        Lists existing projects for this instance.
+        Get a list of the document classifiers in a project. Returns only the name and
+        classifier ID of each document classifier.
 
+        :param str project_id: The ID of the project. This information can be found
+               from the *Integrate and Deploy* page in Discovery.
         :param dict headers: A `dict` containing the request headers
         :return: A `DetailedResponse` containing the result, headers and HTTP status code.
-        :rtype: DetailedResponse with `dict` result representing a `ListProjectsResponse` object
+        :rtype: DetailedResponse with `dict` result representing a `DocumentClassifiers` object
         """
 
+        if project_id is None:
+            raise ValueError('project_id must be provided')
         headers = {}
         sdk_headers = get_sdk_headers(service_name=self.DEFAULT_SERVICE_NAME,
                                       service_version='V2',
-                                      operation_id='list_projects')
+                                      operation_id='list_document_classifiers')
         headers.update(sdk_headers)
 
         params = {'version': self.version}
 
         if 'headers' in kwargs:
             headers.update(kwargs.get('headers'))
+            del kwargs['headers']
         headers['Accept'] = 'application/json'
 
-        url = '/v2/projects'
+        path_param_keys = ['project_id']
+        path_param_values = self.encode_path_vars(project_id)
+        path_param_dict = dict(zip(path_param_keys, path_param_values))
+        url = '/v2/projects/{project_id}/document_classifiers'.format(
+            **path_param_dict)
         request = self.prepare_request(method='GET',
                                        url=url,
                                        headers=headers,
@@ -1716,98 +2459,122 @@ class DiscoveryV2(BaseService):
         response = self.send(request, **kwargs)
         return response
 
-    def create_project(self,
-                       name: str,
-                       type: str,
-                       *,
-                       default_query_parameters: 'DefaultQueryParams' = None,
-                       **kwargs) -> DetailedResponse:
+    def create_document_classifier(self,
+                                   project_id: str,
+                                   training_data: BinaryIO,
+                                   classifier: 'CreateDocumentClassifier',
+                                   *,
+                                   test_data: BinaryIO = None,
+                                   **kwargs) -> DetailedResponse:
         """
-        Create a Project.
+        Create a document classifier.
 
-        Create a new project for this instance.
-
-        :param str name: The human readable name of this project.
-        :param str type: The type of project.
-               The `content_intelligence` type is a *Document Retrieval for Contracts*
-               project and the `other` type is a *Custom* project.
-               The `content_mining` and `content_intelligence` types are available with
-               Premium plan managed deployments and installed deployments only.
-        :param DefaultQueryParams default_query_parameters: (optional) Default
-               query parameters for this project.
-        :param dict headers: A `dict` containing the request headers
-        :return: A `DetailedResponse` containing the result, headers and HTTP status code.
-        :rtype: DetailedResponse with `dict` result representing a `ProjectDetails` object
-        """
-
-        if name is None:
-            raise ValueError('name must be provided')
-        if type is None:
-            raise ValueError('type must be provided')
-        if default_query_parameters is not None:
-            default_query_parameters = convert_model(default_query_parameters)
-        headers = {}
-        sdk_headers = get_sdk_headers(service_name=self.DEFAULT_SERVICE_NAME,
-                                      service_version='V2',
-                                      operation_id='create_project')
-        headers.update(sdk_headers)
-
-        params = {'version': self.version}
-
-        data = {
-            'name': name,
-            'type': type,
-            'default_query_parameters': default_query_parameters
-        }
-        data = {k: v for (k, v) in data.items() if v is not None}
-        data = json.dumps(data)
-        headers['content-type'] = 'application/json'
-
-        if 'headers' in kwargs:
-            headers.update(kwargs.get('headers'))
-        headers['Accept'] = 'application/json'
-
-        url = '/v2/projects'
-        request = self.prepare_request(method='POST',
-                                       url=url,
-                                       headers=headers,
-                                       params=params,
-                                       data=data)
-
-        response = self.send(request, **kwargs)
-        return response
-
-    def get_project(self, project_id: str, **kwargs) -> DetailedResponse:
-        """
-        Get project.
-
-        Get details on the specified project.
+        Create a document classifier. You can use the API to create a document classifier
+        in any project type. After you create a document classifier, you can use the
+        Enrichments API to create a classifier enrichment, and then the Collections API to
+        apply the enrichment to a collection in the project.
+        **Note:** This method is supported on installed instances (IBM Cloud Pak for Data)
+        or IBM Cloud-managed Premium or Enterprise plan instances.
 
         :param str project_id: The ID of the project. This information can be found
                from the *Integrate and Deploy* page in Discovery.
+        :param BinaryIO training_data: The training data CSV file to upload. The
+               CSV file must have headers. The file must include a field that contains the
+               text you want to classify and a field that contains the classification
+               labels that you want to use to classify your data. If you want to specify
+               multiple values in a single field, use a semicolon as the value separator.
+               For a sample file, see [the product
+               documentation](https://cloud.ibm.com/docs/discovery-data?topic=discovery-data-cm-doc-classifier).
+        :param CreateDocumentClassifier classifier: An object that manages the
+               settings and data that is required to train a document classification
+               model.
+        :param BinaryIO test_data: (optional) The CSV with test data to upload. The
+               column values in the test file must be the same as the column values in the
+               training data file. If no test data is provided, the training data is split
+               into two separate groups of training and test data.
         :param dict headers: A `dict` containing the request headers
         :return: A `DetailedResponse` containing the result, headers and HTTP status code.
-        :rtype: DetailedResponse with `dict` result representing a `ProjectDetails` object
+        :rtype: DetailedResponse with `dict` result representing a `DocumentClassifier` object
         """
 
         if project_id is None:
             raise ValueError('project_id must be provided')
+        if training_data is None:
+            raise ValueError('training_data must be provided')
+        if classifier is None:
+            raise ValueError('classifier must be provided')
         headers = {}
-        sdk_headers = get_sdk_headers(service_name=self.DEFAULT_SERVICE_NAME,
-                                      service_version='V2',
-                                      operation_id='get_project')
+        sdk_headers = get_sdk_headers(
+            service_name=self.DEFAULT_SERVICE_NAME,
+            service_version='V2',
+            operation_id='create_document_classifier')
         headers.update(sdk_headers)
 
         params = {'version': self.version}
 
+        form_data = []
+        form_data.append(('training_data', (None, training_data, 'text/csv')))
+        form_data.append(
+            ('classifier', (None, json.dumps(classifier), 'application/json')))
+        if test_data:
+            form_data.append(('test_data', (None, test_data, 'text/csv')))
+
         if 'headers' in kwargs:
             headers.update(kwargs.get('headers'))
+            del kwargs['headers']
         headers['Accept'] = 'application/json'
 
         path_param_keys = ['project_id']
         path_param_values = self.encode_path_vars(project_id)
         path_param_dict = dict(zip(path_param_keys, path_param_values))
-        url = '/v2/projects/{project_id}'.format(**path_param_dict)
+        url = '/v2/projects/{project_id}/document_classifiers'.format(
+            **path_param_dict)
+        request = self.prepare_request(method='POST',
+                                       url=url,
+                                       headers=headers,
+                                       params=params,
+                                       files=form_data)
+
+        response = self.send(request, **kwargs)
+        return response
+
+    def get_document_classifier(self, project_id: str, classifier_id: str,
+                                **kwargs) -> DetailedResponse:
+        """
+        Get a document classifier.
+
+        Get details about a specific document classifier.
+
+        :param str project_id: The ID of the project. This information can be found
+               from the *Integrate and Deploy* page in Discovery.
+        :param str classifier_id: The ID of the classifier.
+        :param dict headers: A `dict` containing the request headers
+        :return: A `DetailedResponse` containing the result, headers and HTTP status code.
+        :rtype: DetailedResponse with `dict` result representing a `DocumentClassifier` object
+        """
+
+        if project_id is None:
+            raise ValueError('project_id must be provided')
+        if classifier_id is None:
+            raise ValueError('classifier_id must be provided')
+        headers = {}
+        sdk_headers = get_sdk_headers(service_name=self.DEFAULT_SERVICE_NAME,
+                                      service_version='V2',
+                                      operation_id='get_document_classifier')
+        headers.update(sdk_headers)
+
+        params = {'version': self.version}
+
+        if 'headers' in kwargs:
+            headers.update(kwargs.get('headers'))
+            del kwargs['headers']
+        headers['Accept'] = 'application/json'
+
+        path_param_keys = ['project_id', 'classifier_id']
+        path_param_values = self.encode_path_vars(project_id, classifier_id)
+        path_param_dict = dict(zip(path_param_keys, path_param_values))
+        url = '/v2/projects/{project_id}/document_classifiers/{classifier_id}'.format(
+            **path_param_dict)
         request = self.prepare_request(method='GET',
                                        url=url,
                                        headers=headers,
@@ -1816,66 +2583,95 @@ class DiscoveryV2(BaseService):
         response = self.send(request, **kwargs)
         return response
 
-    def update_project(self,
-                       project_id: str,
-                       *,
-                       name: str = None,
-                       **kwargs) -> DetailedResponse:
+    def update_document_classifier(self,
+                                   project_id: str,
+                                   classifier_id: str,
+                                   classifier: 'UpdateDocumentClassifier',
+                                   *,
+                                   training_data: BinaryIO = None,
+                                   test_data: BinaryIO = None,
+                                   **kwargs) -> DetailedResponse:
         """
-        Update a project.
+        Update a document classifier.
 
-        Update the specified project's name.
+        Update the document classifier name or description, update the training data, or
+        add or update the test data.
 
         :param str project_id: The ID of the project. This information can be found
                from the *Integrate and Deploy* page in Discovery.
-        :param str name: (optional) The new name to give this project.
+        :param str classifier_id: The ID of the classifier.
+        :param UpdateDocumentClassifier classifier: An object that contains a new
+               name or description for a document classifier, updated training data, or
+               new or updated test data.
+        :param BinaryIO training_data: (optional) The training data CSV file to
+               upload. The CSV file must have headers. The file must include a field that
+               contains the text you want to classify and a field that contains the
+               classification labels that you want to use to classify your data. If you
+               want to specify multiple values in a single column, use a semicolon as the
+               value separator. For a sample file, see [the product
+               documentation](https://cloud.ibm.com/docs/discovery-data?topic=discovery-data-cm-doc-classifier).
+        :param BinaryIO test_data: (optional) The CSV with test data to upload. The
+               column values in the test file must be the same as the column values in the
+               training data file. If no test data is provided, the training data is split
+               into two separate groups of training and test data.
         :param dict headers: A `dict` containing the request headers
         :return: A `DetailedResponse` containing the result, headers and HTTP status code.
-        :rtype: DetailedResponse with `dict` result representing a `ProjectDetails` object
+        :rtype: DetailedResponse with `dict` result representing a `DocumentClassifier` object
         """
 
         if project_id is None:
             raise ValueError('project_id must be provided')
+        if classifier_id is None:
+            raise ValueError('classifier_id must be provided')
+        if classifier is None:
+            raise ValueError('classifier must be provided')
         headers = {}
-        sdk_headers = get_sdk_headers(service_name=self.DEFAULT_SERVICE_NAME,
-                                      service_version='V2',
-                                      operation_id='update_project')
+        sdk_headers = get_sdk_headers(
+            service_name=self.DEFAULT_SERVICE_NAME,
+            service_version='V2',
+            operation_id='update_document_classifier')
         headers.update(sdk_headers)
 
         params = {'version': self.version}
 
-        data = {'name': name}
-        data = {k: v for (k, v) in data.items() if v is not None}
-        data = json.dumps(data)
-        headers['content-type'] = 'application/json'
+        form_data = []
+        form_data.append(
+            ('classifier', (None, json.dumps(classifier), 'application/json')))
+        if training_data:
+            form_data.append(
+                ('training_data', (None, training_data, 'text/csv')))
+        if test_data:
+            form_data.append(('test_data', (None, test_data, 'text/csv')))
 
         if 'headers' in kwargs:
             headers.update(kwargs.get('headers'))
+            del kwargs['headers']
         headers['Accept'] = 'application/json'
 
-        path_param_keys = ['project_id']
-        path_param_values = self.encode_path_vars(project_id)
+        path_param_keys = ['project_id', 'classifier_id']
+        path_param_values = self.encode_path_vars(project_id, classifier_id)
         path_param_dict = dict(zip(path_param_keys, path_param_values))
-        url = '/v2/projects/{project_id}'.format(**path_param_dict)
+        url = '/v2/projects/{project_id}/document_classifiers/{classifier_id}'.format(
+            **path_param_dict)
         request = self.prepare_request(method='POST',
                                        url=url,
                                        headers=headers,
                                        params=params,
-                                       data=data)
+                                       files=form_data)
 
         response = self.send(request, **kwargs)
         return response
 
-    def delete_project(self, project_id: str, **kwargs) -> DetailedResponse:
+    def delete_document_classifier(self, project_id: str, classifier_id: str,
+                                   **kwargs) -> DetailedResponse:
         """
-        Delete a project.
+        Delete a document classifier.
 
-        Deletes the specified project.
-        **Important:** Deleting a project deletes everything that is part of the specified
-        project, including all collections.
+        Deletes an existing document classifier from the specified project.
 
         :param str project_id: The ID of the project. This information can be found
                from the *Integrate and Deploy* page in Discovery.
+        :param str classifier_id: The ID of the classifier.
         :param dict headers: A `dict` containing the request headers
         :return: A `DetailedResponse` containing the result, headers and HTTP status code.
         :rtype: DetailedResponse
@@ -1883,21 +2679,26 @@ class DiscoveryV2(BaseService):
 
         if project_id is None:
             raise ValueError('project_id must be provided')
+        if classifier_id is None:
+            raise ValueError('classifier_id must be provided')
         headers = {}
-        sdk_headers = get_sdk_headers(service_name=self.DEFAULT_SERVICE_NAME,
-                                      service_version='V2',
-                                      operation_id='delete_project')
+        sdk_headers = get_sdk_headers(
+            service_name=self.DEFAULT_SERVICE_NAME,
+            service_version='V2',
+            operation_id='delete_document_classifier')
         headers.update(sdk_headers)
 
         params = {'version': self.version}
 
         if 'headers' in kwargs:
             headers.update(kwargs.get('headers'))
+            del kwargs['headers']
 
-        path_param_keys = ['project_id']
-        path_param_values = self.encode_path_vars(project_id)
+        path_param_keys = ['project_id', 'classifier_id']
+        path_param_values = self.encode_path_vars(project_id, classifier_id)
         path_param_dict = dict(zip(path_param_keys, path_param_values))
-        url = '/v2/projects/{project_id}'.format(**path_param_dict)
+        url = '/v2/projects/{project_id}/document_classifiers/{classifier_id}'.format(
+            **path_param_dict)
         request = self.prepare_request(method='DELETE',
                                        url=url,
                                        headers=headers,
@@ -1907,7 +2708,420 @@ class DiscoveryV2(BaseService):
         return response
 
     #########################
-    # userData
+    # Document classifier models
+    #########################
+
+    def list_document_classifier_models(self, project_id: str,
+                                        classifier_id: str,
+                                        **kwargs) -> DetailedResponse:
+        """
+        List document classifier models.
+
+        Get a list of the document classifier models in a project. Returns only the name
+        and model ID of each document classifier model.
+
+        :param str project_id: The ID of the project. This information can be found
+               from the *Integrate and Deploy* page in Discovery.
+        :param str classifier_id: The ID of the classifier.
+        :param dict headers: A `dict` containing the request headers
+        :return: A `DetailedResponse` containing the result, headers and HTTP status code.
+        :rtype: DetailedResponse with `dict` result representing a `DocumentClassifierModels` object
+        """
+
+        if project_id is None:
+            raise ValueError('project_id must be provided')
+        if classifier_id is None:
+            raise ValueError('classifier_id must be provided')
+        headers = {}
+        sdk_headers = get_sdk_headers(
+            service_name=self.DEFAULT_SERVICE_NAME,
+            service_version='V2',
+            operation_id='list_document_classifier_models')
+        headers.update(sdk_headers)
+
+        params = {'version': self.version}
+
+        if 'headers' in kwargs:
+            headers.update(kwargs.get('headers'))
+            del kwargs['headers']
+        headers['Accept'] = 'application/json'
+
+        path_param_keys = ['project_id', 'classifier_id']
+        path_param_values = self.encode_path_vars(project_id, classifier_id)
+        path_param_dict = dict(zip(path_param_keys, path_param_values))
+        url = '/v2/projects/{project_id}/document_classifiers/{classifier_id}/models'.format(
+            **path_param_dict)
+        request = self.prepare_request(method='GET',
+                                       url=url,
+                                       headers=headers,
+                                       params=params)
+
+        response = self.send(request, **kwargs)
+        return response
+
+    def create_document_classifier_model(
+            self,
+            project_id: str,
+            classifier_id: str,
+            name: str,
+            *,
+            description: str = None,
+            learning_rate: float = None,
+            l1_regularization_strengths: List[float] = None,
+            l2_regularization_strengths: List[float] = None,
+            training_max_steps: int = None,
+            improvement_ratio: float = None,
+            **kwargs) -> DetailedResponse:
+        """
+        Create a document classifier model.
+
+        Create a document classifier model by training a model that uses the data and
+        classifier settings defined in the specified document classifier.
+        **Note:** This method is supported on installed intances (IBM Cloud Pak for Data)
+        or IBM Cloud-managed Premium or Enterprise plan instances.
+
+        :param str project_id: The ID of the project. This information can be found
+               from the *Integrate and Deploy* page in Discovery.
+        :param str classifier_id: The ID of the classifier.
+        :param str name: The name of the document classifier model.
+        :param str description: (optional) A description of the document classifier
+               model.
+        :param float learning_rate: (optional) A tuning parameter in an
+               optimization algorithm that determines the step size at each iteration of
+               the training process. It influences how much of any newly acquired
+               information overrides the existing information, and therefore is said to
+               represent the speed at which a machine learning model learns. The default
+               value is `0.1`.
+        :param List[float] l1_regularization_strengths: (optional) Avoids
+               overfitting by shrinking the coefficient of less important features to
+               zero, which removes some features altogether. You can specify many values
+               for hyper-parameter optimization. The default value is `[0.000001]`.
+        :param List[float] l2_regularization_strengths: (optional) A method you can
+               apply to avoid overfitting your model on the training data. You can specify
+               many values for hyper-parameter optimization. The default value is
+               `[0.000001]`.
+        :param int training_max_steps: (optional) Maximum number of training steps
+               to complete. This setting is useful if you need the training process to
+               finish in a specific time frame to fit into an automated process. The
+               default value is ten million.
+        :param float improvement_ratio: (optional) Stops the training run early if
+               the improvement ratio is not met by the time the process reaches a certain
+               point. The default value is `0.00001`.
+        :param dict headers: A `dict` containing the request headers
+        :return: A `DetailedResponse` containing the result, headers and HTTP status code.
+        :rtype: DetailedResponse with `dict` result representing a `DocumentClassifierModel` object
+        """
+
+        if project_id is None:
+            raise ValueError('project_id must be provided')
+        if classifier_id is None:
+            raise ValueError('classifier_id must be provided')
+        if name is None:
+            raise ValueError('name must be provided')
+        headers = {}
+        sdk_headers = get_sdk_headers(
+            service_name=self.DEFAULT_SERVICE_NAME,
+            service_version='V2',
+            operation_id='create_document_classifier_model')
+        headers.update(sdk_headers)
+
+        params = {'version': self.version}
+
+        data = {
+            'name': name,
+            'description': description,
+            'learning_rate': learning_rate,
+            'l1_regularization_strengths': l1_regularization_strengths,
+            'l2_regularization_strengths': l2_regularization_strengths,
+            'training_max_steps': training_max_steps,
+            'improvement_ratio': improvement_ratio
+        }
+        data = {k: v for (k, v) in data.items() if v is not None}
+        data = json.dumps(data)
+        headers['content-type'] = 'application/json'
+
+        if 'headers' in kwargs:
+            headers.update(kwargs.get('headers'))
+            del kwargs['headers']
+        headers['Accept'] = 'application/json'
+
+        path_param_keys = ['project_id', 'classifier_id']
+        path_param_values = self.encode_path_vars(project_id, classifier_id)
+        path_param_dict = dict(zip(path_param_keys, path_param_values))
+        url = '/v2/projects/{project_id}/document_classifiers/{classifier_id}/models'.format(
+            **path_param_dict)
+        request = self.prepare_request(method='POST',
+                                       url=url,
+                                       headers=headers,
+                                       params=params,
+                                       data=data)
+
+        response = self.send(request, **kwargs)
+        return response
+
+    def get_document_classifier_model(self, project_id: str,
+                                      classifier_id: str, model_id: str,
+                                      **kwargs) -> DetailedResponse:
+        """
+        Get a document classifier model.
+
+        Get details about a specific document classifier model.
+
+        :param str project_id: The ID of the project. This information can be found
+               from the *Integrate and Deploy* page in Discovery.
+        :param str classifier_id: The ID of the classifier.
+        :param str model_id: The ID of the classifier model.
+        :param dict headers: A `dict` containing the request headers
+        :return: A `DetailedResponse` containing the result, headers and HTTP status code.
+        :rtype: DetailedResponse with `dict` result representing a `DocumentClassifierModel` object
+        """
+
+        if project_id is None:
+            raise ValueError('project_id must be provided')
+        if classifier_id is None:
+            raise ValueError('classifier_id must be provided')
+        if model_id is None:
+            raise ValueError('model_id must be provided')
+        headers = {}
+        sdk_headers = get_sdk_headers(
+            service_name=self.DEFAULT_SERVICE_NAME,
+            service_version='V2',
+            operation_id='get_document_classifier_model')
+        headers.update(sdk_headers)
+
+        params = {'version': self.version}
+
+        if 'headers' in kwargs:
+            headers.update(kwargs.get('headers'))
+            del kwargs['headers']
+        headers['Accept'] = 'application/json'
+
+        path_param_keys = ['project_id', 'classifier_id', 'model_id']
+        path_param_values = self.encode_path_vars(project_id, classifier_id,
+                                                  model_id)
+        path_param_dict = dict(zip(path_param_keys, path_param_values))
+        url = '/v2/projects/{project_id}/document_classifiers/{classifier_id}/models/{model_id}'.format(
+            **path_param_dict)
+        request = self.prepare_request(method='GET',
+                                       url=url,
+                                       headers=headers,
+                                       params=params)
+
+        response = self.send(request, **kwargs)
+        return response
+
+    def update_document_classifier_model(self,
+                                         project_id: str,
+                                         classifier_id: str,
+                                         model_id: str,
+                                         *,
+                                         name: str = None,
+                                         description: str = None,
+                                         **kwargs) -> DetailedResponse:
+        """
+        Update a document classifier model.
+
+        Update the document classifier model name or description.
+
+        :param str project_id: The ID of the project. This information can be found
+               from the *Integrate and Deploy* page in Discovery.
+        :param str classifier_id: The ID of the classifier.
+        :param str model_id: The ID of the classifier model.
+        :param str name: (optional) A new name for the enrichment.
+        :param str description: (optional) A new description for the enrichment.
+        :param dict headers: A `dict` containing the request headers
+        :return: A `DetailedResponse` containing the result, headers and HTTP status code.
+        :rtype: DetailedResponse with `dict` result representing a `DocumentClassifierModel` object
+        """
+
+        if project_id is None:
+            raise ValueError('project_id must be provided')
+        if classifier_id is None:
+            raise ValueError('classifier_id must be provided')
+        if model_id is None:
+            raise ValueError('model_id must be provided')
+        headers = {}
+        sdk_headers = get_sdk_headers(
+            service_name=self.DEFAULT_SERVICE_NAME,
+            service_version='V2',
+            operation_id='update_document_classifier_model')
+        headers.update(sdk_headers)
+
+        params = {'version': self.version}
+
+        data = {'name': name, 'description': description}
+        data = {k: v for (k, v) in data.items() if v is not None}
+        data = json.dumps(data)
+        headers['content-type'] = 'application/json'
+
+        if 'headers' in kwargs:
+            headers.update(kwargs.get('headers'))
+            del kwargs['headers']
+        headers['Accept'] = 'application/json'
+
+        path_param_keys = ['project_id', 'classifier_id', 'model_id']
+        path_param_values = self.encode_path_vars(project_id, classifier_id,
+                                                  model_id)
+        path_param_dict = dict(zip(path_param_keys, path_param_values))
+        url = '/v2/projects/{project_id}/document_classifiers/{classifier_id}/models/{model_id}'.format(
+            **path_param_dict)
+        request = self.prepare_request(method='POST',
+                                       url=url,
+                                       headers=headers,
+                                       params=params,
+                                       data=data)
+
+        response = self.send(request, **kwargs)
+        return response
+
+    def delete_document_classifier_model(self, project_id: str,
+                                         classifier_id: str, model_id: str,
+                                         **kwargs) -> DetailedResponse:
+        """
+        Delete a document classifier model.
+
+        Deletes an existing document classifier model from the specified project.
+
+        :param str project_id: The ID of the project. This information can be found
+               from the *Integrate and Deploy* page in Discovery.
+        :param str classifier_id: The ID of the classifier.
+        :param str model_id: The ID of the classifier model.
+        :param dict headers: A `dict` containing the request headers
+        :return: A `DetailedResponse` containing the result, headers and HTTP status code.
+        :rtype: DetailedResponse
+        """
+
+        if project_id is None:
+            raise ValueError('project_id must be provided')
+        if classifier_id is None:
+            raise ValueError('classifier_id must be provided')
+        if model_id is None:
+            raise ValueError('model_id must be provided')
+        headers = {}
+        sdk_headers = get_sdk_headers(
+            service_name=self.DEFAULT_SERVICE_NAME,
+            service_version='V2',
+            operation_id='delete_document_classifier_model')
+        headers.update(sdk_headers)
+
+        params = {'version': self.version}
+
+        if 'headers' in kwargs:
+            headers.update(kwargs.get('headers'))
+            del kwargs['headers']
+
+        path_param_keys = ['project_id', 'classifier_id', 'model_id']
+        path_param_values = self.encode_path_vars(project_id, classifier_id,
+                                                  model_id)
+        path_param_dict = dict(zip(path_param_keys, path_param_values))
+        url = '/v2/projects/{project_id}/document_classifiers/{classifier_id}/models/{model_id}'.format(
+            **path_param_dict)
+        request = self.prepare_request(method='DELETE',
+                                       url=url,
+                                       headers=headers,
+                                       params=params)
+
+        response = self.send(request, **kwargs)
+        return response
+
+    #########################
+    # Analyze
+    #########################
+
+    def analyze_document(self,
+                         project_id: str,
+                         collection_id: str,
+                         *,
+                         file: BinaryIO = None,
+                         filename: str = None,
+                         file_content_type: str = None,
+                         metadata: str = None,
+                         **kwargs) -> DetailedResponse:
+        """
+        Analyze a Document.
+
+        Process a document and return it for realtime use. Supports JSON files only.
+        The file is not stored in the collection, but is processed according to the
+        collection's configuration settings. To get results, enrichments must be applied
+        to a field in the collection that also exists in the file that you want to
+        analyze. For example, to analyze text in a `Quote` field, you must apply
+        enrichments to the `Quote` field in the collection configuration. Then, when you
+        analyze the file, the text in the `Quote` field is analyzed and results are
+        written to a field named `enriched_Quote`.
+        **Note:** This method is supported with Enterprise plan deployments and installed
+        deployments only.
+
+        :param str project_id: The ID of the project. This information can be found
+               from the *Integrate and Deploy* page in Discovery.
+        :param str collection_id: The ID of the collection.
+        :param BinaryIO file: (optional) When adding a document, the content of the
+               document to ingest. For maximum supported file size limits, see [the
+               documentation](https://cloud.ibm.com/docs/discovery-data?topic=discovery-data-collections#collections-doc-limits).
+               When analyzing a document, the content of the document to analyze but not
+               ingest. Only the `application/json` content type is supported currently.
+               For maximum supported file size limits, see [the product
+               documentation](/docs/discovery-data?topic=discovery-data-analyzeapi#analyzeapi-limits).
+        :param str filename: (optional) The filename for file.
+        :param str file_content_type: (optional) The content type of file.
+        :param str metadata: (optional) Add information about the file that you
+               want to include in the response.
+               The maximum supported metadata file size is 1 MB. Metadata parts larger
+               than 1 MB are rejected.
+               Example:
+                ```
+                {
+                 "filename": "favorites2.json",
+                 "file_type": "json"
+                }.
+        :param dict headers: A `dict` containing the request headers
+        :return: A `DetailedResponse` containing the result, headers and HTTP status code.
+        :rtype: DetailedResponse with `dict` result representing a `AnalyzedDocument` object
+        """
+
+        if project_id is None:
+            raise ValueError('project_id must be provided')
+        if collection_id is None:
+            raise ValueError('collection_id must be provided')
+        headers = {}
+        sdk_headers = get_sdk_headers(service_name=self.DEFAULT_SERVICE_NAME,
+                                      service_version='V2',
+                                      operation_id='analyze_document')
+        headers.update(sdk_headers)
+
+        params = {'version': self.version}
+
+        form_data = []
+        if file:
+            if not filename and hasattr(file, 'name'):
+                filename = basename(file.name)
+            if not filename:
+                raise ValueError('filename must be provided')
+            form_data.append(('file', (filename, file, file_content_type
+                                       or 'application/octet-stream')))
+        if metadata:
+            form_data.append(('metadata', (None, metadata, 'text/plain')))
+
+        if 'headers' in kwargs:
+            headers.update(kwargs.get('headers'))
+            del kwargs['headers']
+        headers['Accept'] = 'application/json'
+
+        path_param_keys = ['project_id', 'collection_id']
+        path_param_values = self.encode_path_vars(project_id, collection_id)
+        path_param_dict = dict(zip(path_param_keys, path_param_values))
+        url = '/v2/projects/{project_id}/collections/{collection_id}/analyze'.format(
+            **path_param_dict)
+        request = self.prepare_request(method='POST',
+                                       url=url,
+                                       headers=headers,
+                                       params=params,
+                                       files=form_data)
+
+        response = self.send(request, **kwargs)
+        return response
+
+    #########################
+    # User data
     #########################
 
     def delete_user_data(self, customer_id: str, **kwargs) -> DetailedResponse:
@@ -1941,6 +3155,7 @@ class DiscoveryV2(BaseService):
 
         if 'headers' in kwargs:
             headers.update(kwargs.get('headers'))
+            del kwargs['headers']
 
         url = '/v2/user_data'
         request = self.prepare_request(method='DELETE',
@@ -1956,7 +3171,6 @@ class AddDocumentEnums:
     """
     Enums for add_document parameters.
     """
-
     class FileContentType(str, Enum):
         """
         The content type of file.
@@ -1973,7 +3187,6 @@ class UpdateDocumentEnums:
     """
     Enums for update_document parameters.
     """
-
     class FileContentType(str, Enum):
         """
         The content type of file.
@@ -1990,7 +3203,6 @@ class AnalyzeDocumentEnums:
     """
     Enums for analyze_document parameters.
     """
-
     class FileContentType(str, Enum):
         """
         The content type of file.
@@ -2011,12 +3223,12 @@ class AnalyzeDocumentEnums:
 class AnalyzedDocument():
     """
     An object that contains the converted document and any identified enrichments.
+    Root-level fields from the original file are returned also.
 
-    :attr List[Notice] notices: (optional) Array of document results that match the
-          query.
+    :attr List[Notice] notices: (optional) Array of notices that are triggered when
+          the files are processed.
     :attr AnalyzedResult result: (optional) Result of the document analysis.
     """
-
     def __init__(self,
                  *,
                  notices: List['Notice'] = None,
@@ -2024,8 +3236,8 @@ class AnalyzedDocument():
         """
         Initialize a AnalyzedDocument object.
 
-        :param List[Notice] notices: (optional) Array of document results that
-               match the query.
+        :param List[Notice] notices: (optional) Array of notices that are triggered
+               when the files are processed.
         :param AnalyzedResult result: (optional) Result of the document analysis.
         """
         self.notices = notices
@@ -2080,7 +3292,7 @@ class AnalyzedResult():
     """
     Result of the document analysis.
 
-    :attr dict metadata: (optional) Metadata of the document.
+    :attr dict metadata: (optional) Metadata that was specified with the request.
     """
 
     # The set of defined properties for the class
@@ -2090,7 +3302,8 @@ class AnalyzedResult():
         """
         Initialize a AnalyzedResult object.
 
-        :param dict metadata: (optional) Metadata of the document.
+        :param dict metadata: (optional) Metadata that was specified with the
+               request.
         :param **kwargs: (optional) Any additional properties.
         """
         self.metadata = metadata
@@ -2104,7 +3317,8 @@ class AnalyzedResult():
         if 'metadata' in _dict:
             args['metadata'] = _dict.get('metadata')
         args.update(
-            {k: v for (k, v) in _dict.items() if k not in cls._properties})
+            {k: v
+             for (k, v) in _dict.items() if k not in cls._properties})
         return cls(**args)
 
     @classmethod
@@ -2167,6 +3381,167 @@ class AnalyzedResult():
         return not self == other
 
 
+class ClassifierFederatedModel():
+    """
+    An object with details for creating federated document classifier models.
+
+    :attr str field: Name of the field that contains the values from which multiple
+          classifier models are defined. For example, you can specify a field that lists
+          product lines to create a separate model per product line.
+    """
+    def __init__(self, field: str) -> None:
+        """
+        Initialize a ClassifierFederatedModel object.
+
+        :param str field: Name of the field that contains the values from which
+               multiple classifier models are defined. For example, you can specify a
+               field that lists product lines to create a separate model per product line.
+        """
+        self.field = field
+
+    @classmethod
+    def from_dict(cls, _dict: Dict) -> 'ClassifierFederatedModel':
+        """Initialize a ClassifierFederatedModel object from a json dictionary."""
+        args = {}
+        if 'field' in _dict:
+            args['field'] = _dict.get('field')
+        else:
+            raise ValueError(
+                'Required property \'field\' not present in ClassifierFederatedModel JSON'
+            )
+        return cls(**args)
+
+    @classmethod
+    def _from_dict(cls, _dict):
+        """Initialize a ClassifierFederatedModel object from a json dictionary."""
+        return cls.from_dict(_dict)
+
+    def to_dict(self) -> Dict:
+        """Return a json dictionary representing this model."""
+        _dict = {}
+        if hasattr(self, 'field') and self.field is not None:
+            _dict['field'] = self.field
+        return _dict
+
+    def _to_dict(self):
+        """Return a json dictionary representing this model."""
+        return self.to_dict()
+
+    def __str__(self) -> str:
+        """Return a `str` version of this ClassifierFederatedModel object."""
+        return json.dumps(self.to_dict(), indent=2)
+
+    def __eq__(self, other: 'ClassifierFederatedModel') -> bool:
+        """Return `true` when self and other are equal, false otherwise."""
+        if not isinstance(other, self.__class__):
+            return False
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other: 'ClassifierFederatedModel') -> bool:
+        """Return `true` when self and other are not equal, false otherwise."""
+        return not self == other
+
+
+class ClassifierModelEvaluation():
+    """
+    An object that contains information about a trained document classifier model.
+
+    :attr ModelEvaluationMicroAverage micro_average: A micro-average aggregates the
+          contributions of all classes to compute the average metric. Classes refers to
+          the classification labels that are specified in the **answer_field**.
+    :attr ModelEvaluationMacroAverage macro_average: A macro-average computes metric
+          independently for each class and then takes the average. Class refers to the
+          classification label that is specified in the **answer_field**.
+    :attr List[PerClassModelEvaluation] per_class: An array of evaluation metrics,
+          one set of metrics for each class, where class refers to the classification
+          label that is specified in the **answer_field**.
+    """
+    def __init__(self, micro_average: 'ModelEvaluationMicroAverage',
+                 macro_average: 'ModelEvaluationMacroAverage',
+                 per_class: List['PerClassModelEvaluation']) -> None:
+        """
+        Initialize a ClassifierModelEvaluation object.
+
+        :param ModelEvaluationMicroAverage micro_average: A micro-average
+               aggregates the contributions of all classes to compute the average metric.
+               Classes refers to the classification labels that are specified in the
+               **answer_field**.
+        :param ModelEvaluationMacroAverage macro_average: A macro-average computes
+               metric independently for each class and then takes the average. Class
+               refers to the classification label that is specified in the
+               **answer_field**.
+        :param List[PerClassModelEvaluation] per_class: An array of evaluation
+               metrics, one set of metrics for each class, where class refers to the
+               classification label that is specified in the **answer_field**.
+        """
+        self.micro_average = micro_average
+        self.macro_average = macro_average
+        self.per_class = per_class
+
+    @classmethod
+    def from_dict(cls, _dict: Dict) -> 'ClassifierModelEvaluation':
+        """Initialize a ClassifierModelEvaluation object from a json dictionary."""
+        args = {}
+        if 'micro_average' in _dict:
+            args['micro_average'] = ModelEvaluationMicroAverage.from_dict(
+                _dict.get('micro_average'))
+        else:
+            raise ValueError(
+                'Required property \'micro_average\' not present in ClassifierModelEvaluation JSON'
+            )
+        if 'macro_average' in _dict:
+            args['macro_average'] = ModelEvaluationMacroAverage.from_dict(
+                _dict.get('macro_average'))
+        else:
+            raise ValueError(
+                'Required property \'macro_average\' not present in ClassifierModelEvaluation JSON'
+            )
+        if 'per_class' in _dict:
+            args['per_class'] = [
+                PerClassModelEvaluation.from_dict(x)
+                for x in _dict.get('per_class')
+            ]
+        else:
+            raise ValueError(
+                'Required property \'per_class\' not present in ClassifierModelEvaluation JSON'
+            )
+        return cls(**args)
+
+    @classmethod
+    def _from_dict(cls, _dict):
+        """Initialize a ClassifierModelEvaluation object from a json dictionary."""
+        return cls.from_dict(_dict)
+
+    def to_dict(self) -> Dict:
+        """Return a json dictionary representing this model."""
+        _dict = {}
+        if hasattr(self, 'micro_average') and self.micro_average is not None:
+            _dict['micro_average'] = self.micro_average.to_dict()
+        if hasattr(self, 'macro_average') and self.macro_average is not None:
+            _dict['macro_average'] = self.macro_average.to_dict()
+        if hasattr(self, 'per_class') and self.per_class is not None:
+            _dict['per_class'] = [x.to_dict() for x in self.per_class]
+        return _dict
+
+    def _to_dict(self):
+        """Return a json dictionary representing this model."""
+        return self.to_dict()
+
+    def __str__(self) -> str:
+        """Return a `str` version of this ClassifierModelEvaluation object."""
+        return json.dumps(self.to_dict(), indent=2)
+
+    def __eq__(self, other: 'ClassifierModelEvaluation') -> bool:
+        """Return `true` when self and other are equal, false otherwise."""
+        if not isinstance(other, self.__class__):
+            return False
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other: 'ClassifierModelEvaluation') -> bool:
+        """Return `true` when self and other are not equal, false otherwise."""
+        return not self == other
+
+
 class Collection():
     """
     A collection for storing documents.
@@ -2174,7 +3549,6 @@ class Collection():
     :attr str collection_id: (optional) The unique identifier of the collection.
     :attr str name: (optional) The name of the collection.
     """
-
     def __init__(self, *, collection_id: str = None, name: str = None) -> None:
         """
         Initialize a Collection object.
@@ -2236,27 +3610,51 @@ class CollectionDetails():
     :attr str name: The name of the collection.
     :attr str description: (optional) A description of the collection.
     :attr datetime created: (optional) The date that the collection was created.
-    :attr str language: (optional) The language of the collection.
+    :attr str language: (optional) The language of the collection. For a list of
+          supported languages, see the [product
+          documentation](/docs/discovery-data?topic=discovery-data-language-support).
     :attr List[CollectionEnrichment] enrichments: (optional) An array of enrichments
-          that are applied to this collection.
+          that are applied to this collection. To get a list of enrichments that are
+          available for a project, use the [List enrichments](#listenrichments) method.
+          If no enrichments are specified when the collection is created, the default
+          enrichments for the project type are applied. For more information about project
+          default settings, see the [product
+          documentation](/docs/discovery-data?topic=discovery-data-project-defaults).
+    :attr CollectionDetailsSmartDocumentUnderstanding smart_document_understanding:
+          (optional) An object that describes the Smart Document Understanding model for a
+          collection.
     """
-
-    def __init__(self,
-                 name: str,
-                 *,
-                 collection_id: str = None,
-                 description: str = None,
-                 created: datetime = None,
-                 language: str = None,
-                 enrichments: List['CollectionEnrichment'] = None) -> None:
+    def __init__(
+        self,
+        name: str,
+        *,
+        collection_id: str = None,
+        description: str = None,
+        created: datetime = None,
+        language: str = None,
+        enrichments: List['CollectionEnrichment'] = None,
+        smart_document_understanding:
+        'CollectionDetailsSmartDocumentUnderstanding' = None
+    ) -> None:
         """
         Initialize a CollectionDetails object.
 
         :param str name: The name of the collection.
         :param str description: (optional) A description of the collection.
-        :param str language: (optional) The language of the collection.
+        :param str language: (optional) The language of the collection. For a list
+               of supported languages, see the [product
+               documentation](/docs/discovery-data?topic=discovery-data-language-support).
         :param List[CollectionEnrichment] enrichments: (optional) An array of
-               enrichments that are applied to this collection.
+               enrichments that are applied to this collection. To get a list of
+               enrichments that are available for a project, use the [List
+               enrichments](#listenrichments) method.
+               If no enrichments are specified when the collection is created, the default
+               enrichments for the project type are applied. For more information about
+               project default settings, see the [product
+               documentation](/docs/discovery-data?topic=discovery-data-project-defaults).
+        :param CollectionDetailsSmartDocumentUnderstanding
+               smart_document_understanding: (optional) An object that describes the Smart
+               Document Understanding model for a collection.
         """
         self.collection_id = collection_id
         self.name = name
@@ -2264,6 +3662,7 @@ class CollectionDetails():
         self.created = created
         self.language = language
         self.enrichments = enrichments
+        self.smart_document_understanding = smart_document_understanding
 
     @classmethod
     def from_dict(cls, _dict: Dict) -> 'CollectionDetails':
@@ -2288,6 +3687,10 @@ class CollectionDetails():
                 CollectionEnrichment.from_dict(x)
                 for x in _dict.get('enrichments')
             ]
+        if 'smart_document_understanding' in _dict:
+            args[
+                'smart_document_understanding'] = CollectionDetailsSmartDocumentUnderstanding.from_dict(
+                    _dict.get('smart_document_understanding'))
         return cls(**args)
 
     @classmethod
@@ -2311,6 +3714,11 @@ class CollectionDetails():
             _dict['language'] = self.language
         if hasattr(self, 'enrichments') and self.enrichments is not None:
             _dict['enrichments'] = [x.to_dict() for x in self.enrichments]
+        if hasattr(self, 'smart_document_understanding'
+                   ) and self.smart_document_understanding is not None:
+            _dict[
+                'smart_document_understanding'] = self.smart_document_understanding.to_dict(
+                )
         return _dict
 
     def _to_dict(self):
@@ -2332,17 +3740,128 @@ class CollectionDetails():
         return not self == other
 
 
+class CollectionDetailsSmartDocumentUnderstanding():
+    """
+    An object that describes the Smart Document Understanding model for a collection.
+
+    :attr bool enabled: (optional) When `true`, smart document understanding
+          conversion is enabled for the collection.
+    :attr str model: (optional) Specifies the type of Smart Document Understanding
+          (SDU) model that is enabled for the collection. The following types of models
+          are supported:
+           * `custom`: A user-trained model is applied.
+           * `pre_trained`: A pretrained model is applied. This type of model is applied
+          automatically to *Document Retrieval for Contracts* projects.
+           * `text_extraction`: An SDU model that extracts text and metadata from the
+          content. This model is enabled in collections by default regardless of the types
+          of documents in the collection (as long as the service plan supports SDU
+          models).
+          You can apply user-trained or pretrained models to collections from the
+          *Identify fields* page of the product user interface. For more information, see
+          [the product
+          documentation](/docs/discovery-data?topic=discovery-data-configuring-fields).
+    """
+    def __init__(self, *, enabled: bool = None, model: str = None) -> None:
+        """
+        Initialize a CollectionDetailsSmartDocumentUnderstanding object.
+
+        :param bool enabled: (optional) When `true`, smart document understanding
+               conversion is enabled for the collection.
+        :param str model: (optional) Specifies the type of Smart Document
+               Understanding (SDU) model that is enabled for the collection. The following
+               types of models are supported:
+                * `custom`: A user-trained model is applied.
+                * `pre_trained`: A pretrained model is applied. This type of model is
+               applied automatically to *Document Retrieval for Contracts* projects.
+                * `text_extraction`: An SDU model that extracts text and metadata from the
+               content. This model is enabled in collections by default regardless of the
+               types of documents in the collection (as long as the service plan supports
+               SDU models).
+               You can apply user-trained or pretrained models to collections from the
+               *Identify fields* page of the product user interface. For more information,
+               see [the product
+               documentation](/docs/discovery-data?topic=discovery-data-configuring-fields).
+        """
+        self.enabled = enabled
+        self.model = model
+
+    @classmethod
+    def from_dict(
+            cls, _dict: Dict) -> 'CollectionDetailsSmartDocumentUnderstanding':
+        """Initialize a CollectionDetailsSmartDocumentUnderstanding object from a json dictionary."""
+        args = {}
+        if 'enabled' in _dict:
+            args['enabled'] = _dict.get('enabled')
+        if 'model' in _dict:
+            args['model'] = _dict.get('model')
+        return cls(**args)
+
+    @classmethod
+    def _from_dict(cls, _dict):
+        """Initialize a CollectionDetailsSmartDocumentUnderstanding object from a json dictionary."""
+        return cls.from_dict(_dict)
+
+    def to_dict(self) -> Dict:
+        """Return a json dictionary representing this model."""
+        _dict = {}
+        if hasattr(self, 'enabled') and self.enabled is not None:
+            _dict['enabled'] = self.enabled
+        if hasattr(self, 'model') and self.model is not None:
+            _dict['model'] = self.model
+        return _dict
+
+    def _to_dict(self):
+        """Return a json dictionary representing this model."""
+        return self.to_dict()
+
+    def __str__(self) -> str:
+        """Return a `str` version of this CollectionDetailsSmartDocumentUnderstanding object."""
+        return json.dumps(self.to_dict(), indent=2)
+
+    def __eq__(self,
+               other: 'CollectionDetailsSmartDocumentUnderstanding') -> bool:
+        """Return `true` when self and other are equal, false otherwise."""
+        if not isinstance(other, self.__class__):
+            return False
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self,
+               other: 'CollectionDetailsSmartDocumentUnderstanding') -> bool:
+        """Return `true` when self and other are not equal, false otherwise."""
+        return not self == other
+
+    class ModelEnum(str, Enum):
+        """
+        Specifies the type of Smart Document Understanding (SDU) model that is enabled for
+        the collection. The following types of models are supported:
+         * `custom`: A user-trained model is applied.
+         * `pre_trained`: A pretrained model is applied. This type of model is applied
+        automatically to *Document Retrieval for Contracts* projects.
+         * `text_extraction`: An SDU model that extracts text and metadata from the
+        content. This model is enabled in collections by default regardless of the types
+        of documents in the collection (as long as the service plan supports SDU models).
+        You can apply user-trained or pretrained models to collections from the *Identify
+        fields* page of the product user interface. For more information, see [the product
+        documentation](/docs/discovery-data?topic=discovery-data-configuring-fields).
+        """
+        CUSTOM = 'custom'
+        PRE_TRAINED = 'pre_trained'
+        TEXT_EXTRACTION = 'text_extraction'
+
+
 class CollectionEnrichment():
     """
-    An object describing an Enrichment for a collection.
+    An object describing an enrichment for a collection.
 
     :attr str enrichment_id: (optional) The unique identifier of this enrichment.
+          For more information about how to determine the ID of an enrichment, see [the
+          product
+          documentation](/docs/discovery-data?topic=discovery-data-manage-enrichments#enrichments-ids).
     :attr List[str] fields: (optional) An array of field names that the enrichment
           is applied to.
           If you apply an enrichment to a field from a JSON file, the data is converted to
           an array automatically, even if the field contains a single value.
     """
-
     def __init__(self,
                  *,
                  enrichment_id: str = None,
@@ -2351,7 +3870,9 @@ class CollectionEnrichment():
         Initialize a CollectionEnrichment object.
 
         :param str enrichment_id: (optional) The unique identifier of this
-               enrichment.
+               enrichment. For more information about how to determine the ID of an
+               enrichment, see [the product
+               documentation](/docs/discovery-data?topic=discovery-data-manage-enrichments#enrichments-ids).
         :param List[str] fields: (optional) An array of field names that the
                enrichment is applied to.
                If you apply an enrichment to a field from a JSON file, the data is
@@ -2411,7 +3932,6 @@ class Completions():
     :attr List[str] completions: (optional) Array of autocomplete suggestion based
           on the provided prefix.
     """
-
     def __init__(self, *, completions: List[str] = None) -> None:
         """
         Initialize a Completions object.
@@ -2472,7 +3992,6 @@ class ComponentSettingsAggregation():
     :attr str visualization_type: (optional) Type of visualization to use when
           rendering the aggregation.
     """
-
     def __init__(self,
                  *,
                  name: str = None,
@@ -2523,7 +4042,7 @@ class ComponentSettingsAggregation():
         if hasattr(self, 'label') and self.label is not None:
             _dict['label'] = self.label
         if hasattr(self, 'multiple_selections_allowed'
-                  ) and self.multiple_selections_allowed is not None:
+                   ) and self.multiple_selections_allowed is not None:
             _dict[
                 'multiple_selections_allowed'] = self.multiple_selections_allowed
         if hasattr(
@@ -2567,7 +4086,6 @@ class ComponentSettingsFieldsShown():
     :attr ComponentSettingsFieldsShownBody body: (optional) Body label.
     :attr ComponentSettingsFieldsShownTitle title: (optional) Title label.
     """
-
     def __init__(self,
                  *,
                  body: 'ComponentSettingsFieldsShownBody' = None,
@@ -2633,7 +4151,6 @@ class ComponentSettingsFieldsShownBody():
     :attr bool use_passage: (optional) Use the whole passage as the body.
     :attr str field: (optional) Use a specific field as the title.
     """
-
     def __init__(self, *, use_passage: bool = None, field: str = None) -> None:
         """
         Initialize a ComponentSettingsFieldsShownBody object.
@@ -2693,7 +4210,6 @@ class ComponentSettingsFieldsShownTitle():
 
     :attr str field: (optional) Use a specific field as the title.
     """
-
     def __init__(self, *, field: str = None) -> None:
         """
         Initialize a ComponentSettingsFieldsShownTitle object.
@@ -2754,7 +4270,6 @@ class ComponentSettingsResponse():
     :attr List[ComponentSettingsAggregation] aggregations: (optional) a list of
           component setting aggregations.
     """
-
     def __init__(
             self,
             *,
@@ -2843,18 +4358,170 @@ class ComponentSettingsResponse():
         return not self == other
 
 
+class CreateDocumentClassifier():
+    """
+    An object that manages the settings and data that is required to train a document
+    classification model.
+
+    :attr str name: A human-readable name of the document classifier.
+    :attr str description: (optional) A description of the document classifier.
+    :attr str language: The language of the training data that is associated with
+          the document classifier. Language is specified by using the ISO 639-1 language
+          code, such as `en` for English or `ja` for Japanese.
+    :attr str answer_field: The name of the field from the training and test data
+          that contains the classification labels.
+    :attr List[DocumentClassifierEnrichment] enrichments: (optional) An array of
+          enrichments to apply to the data that is used to train and test the document
+          classifier. The output from the enrichments is used as features by the
+          classifier to classify the document content both during training and at run
+          time.
+    :attr ClassifierFederatedModel federated_classification: (optional) An object
+          with details for creating federated document classifier models.
+    """
+    def __init__(
+            self,
+            name: str,
+            language: str,
+            answer_field: str,
+            *,
+            description: str = None,
+            enrichments: List['DocumentClassifierEnrichment'] = None,
+            federated_classification: 'ClassifierFederatedModel' = None
+    ) -> None:
+        """
+        Initialize a CreateDocumentClassifier object.
+
+        :param str name: A human-readable name of the document classifier.
+        :param str language: The language of the training data that is associated
+               with the document classifier. Language is specified by using the ISO 639-1
+               language code, such as `en` for English or `ja` for Japanese.
+        :param str answer_field: The name of the field from the training and test
+               data that contains the classification labels.
+        :param str description: (optional) A description of the document
+               classifier.
+        :param List[DocumentClassifierEnrichment] enrichments: (optional) An array
+               of enrichments to apply to the data that is used to train and test the
+               document classifier. The output from the enrichments is used as features by
+               the classifier to classify the document content both during training and at
+               run time.
+        :param ClassifierFederatedModel federated_classification: (optional) An
+               object with details for creating federated document classifier models.
+        """
+        self.name = name
+        self.description = description
+        self.language = language
+        self.answer_field = answer_field
+        self.enrichments = enrichments
+        self.federated_classification = federated_classification
+
+    @classmethod
+    def from_dict(cls, _dict: Dict) -> 'CreateDocumentClassifier':
+        """Initialize a CreateDocumentClassifier object from a json dictionary."""
+        args = {}
+        if 'name' in _dict:
+            args['name'] = _dict.get('name')
+        else:
+            raise ValueError(
+                'Required property \'name\' not present in CreateDocumentClassifier JSON'
+            )
+        if 'description' in _dict:
+            args['description'] = _dict.get('description')
+        if 'language' in _dict:
+            args['language'] = _dict.get('language')
+        else:
+            raise ValueError(
+                'Required property \'language\' not present in CreateDocumentClassifier JSON'
+            )
+        if 'answer_field' in _dict:
+            args['answer_field'] = _dict.get('answer_field')
+        else:
+            raise ValueError(
+                'Required property \'answer_field\' not present in CreateDocumentClassifier JSON'
+            )
+        if 'enrichments' in _dict:
+            args['enrichments'] = [
+                DocumentClassifierEnrichment.from_dict(x)
+                for x in _dict.get('enrichments')
+            ]
+        if 'federated_classification' in _dict:
+            args[
+                'federated_classification'] = ClassifierFederatedModel.from_dict(
+                    _dict.get('federated_classification'))
+        return cls(**args)
+
+    @classmethod
+    def _from_dict(cls, _dict):
+        """Initialize a CreateDocumentClassifier object from a json dictionary."""
+        return cls.from_dict(_dict)
+
+    def to_dict(self) -> Dict:
+        """Return a json dictionary representing this model."""
+        _dict = {}
+        if hasattr(self, 'name') and self.name is not None:
+            _dict['name'] = self.name
+        if hasattr(self, 'description') and self.description is not None:
+            _dict['description'] = self.description
+        if hasattr(self, 'language') and self.language is not None:
+            _dict['language'] = self.language
+        if hasattr(self, 'answer_field') and self.answer_field is not None:
+            _dict['answer_field'] = self.answer_field
+        if hasattr(self, 'enrichments') and self.enrichments is not None:
+            _dict['enrichments'] = [x.to_dict() for x in self.enrichments]
+        if hasattr(self, 'federated_classification'
+                   ) and self.federated_classification is not None:
+            _dict[
+                'federated_classification'] = self.federated_classification.to_dict(
+                )
+        return _dict
+
+    def _to_dict(self):
+        """Return a json dictionary representing this model."""
+        return self.to_dict()
+
+    def __str__(self) -> str:
+        """Return a `str` version of this CreateDocumentClassifier object."""
+        return json.dumps(self.to_dict(), indent=2)
+
+    def __eq__(self, other: 'CreateDocumentClassifier') -> bool:
+        """Return `true` when self and other are equal, false otherwise."""
+        if not isinstance(other, self.__class__):
+            return False
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other: 'CreateDocumentClassifier') -> bool:
+        """Return `true` when self and other are not equal, false otherwise."""
+        return not self == other
+
+
 class CreateEnrichment():
     """
     Information about a specific enrichment.
 
     :attr str name: (optional) The human readable name for this enrichment.
     :attr str description: (optional) The description of this enrichment.
-    :attr str type: (optional) The type of this enrichment.
+    :attr str type: (optional) The type of this enrichment. The following types are
+          supported:
+          * `classifier`: Creates a document classifier enrichment from a document
+          classifier model that you create by using the [Document classifier
+          API](/apidocs/discovery-data#createdocumentclassifier). **Note**: A text
+          classifier enrichment can be created only from the product user interface.
+          * `dictionary`: Creates a custom dictionary enrichment that you define in a CSV
+          file.
+          * `regular_expression`: Creates a custom regular expression enrichment from
+          regex syntax that you specify in the request.
+          * `rule_based`: Creates an enrichment from an advanced rules model that is
+          created and exported as a ZIP file from Watson Knowledge Studio.
+          * `uima_annotator`: Creates an enrichment from a custom UIMA text analysis model
+          that is defined in a PEAR file created in one of the following ways:
+              * Watson Explorer Content Analytics Studio. **Note**: Supported in IBM Cloud
+          Pak for Data instances only.
+              * Rule-based model that is created in Watson Knowledge Studio.
+          * `watson_knowledge_studio_model`: Creates an enrichment from a Watson Knowledge
+          Studio machine learning model that is defined in a ZIP file.
     :attr EnrichmentOptions options: (optional) An object that contains options for
           the current enrichment. Starting with version `2020-08-30`, the enrichment
           options are not included in responses from the List Enrichments method.
     """
-
     def __init__(self,
                  *,
                  name: str = None,
@@ -2866,7 +4533,25 @@ class CreateEnrichment():
 
         :param str name: (optional) The human readable name for this enrichment.
         :param str description: (optional) The description of this enrichment.
-        :param str type: (optional) The type of this enrichment.
+        :param str type: (optional) The type of this enrichment. The following
+               types are supported:
+               * `classifier`: Creates a document classifier enrichment from a document
+               classifier model that you create by using the [Document classifier
+               API](/apidocs/discovery-data#createdocumentclassifier). **Note**: A text
+               classifier enrichment can be created only from the product user interface.
+               * `dictionary`: Creates a custom dictionary enrichment that you define in a
+               CSV file.
+               * `regular_expression`: Creates a custom regular expression enrichment from
+               regex syntax that you specify in the request.
+               * `rule_based`: Creates an enrichment from an advanced rules model that is
+               created and exported as a ZIP file from Watson Knowledge Studio.
+               * `uima_annotator`: Creates an enrichment from a custom UIMA text analysis
+               model that is defined in a PEAR file created in one of the following ways:
+                   * Watson Explorer Content Analytics Studio. **Note**: Supported in IBM
+               Cloud Pak for Data instances only.
+                   * Rule-based model that is created in Watson Knowledge Studio.
+               * `watson_knowledge_studio_model`: Creates an enrichment from a Watson
+               Knowledge Studio machine learning model that is defined in a ZIP file.
         :param EnrichmentOptions options: (optional) An object that contains
                options for the current enrichment. Starting with version `2020-08-30`, the
                enrichment options are not included in responses from the List Enrichments
@@ -2929,8 +4614,26 @@ class CreateEnrichment():
 
     class TypeEnum(str, Enum):
         """
-        The type of this enrichment.
+        The type of this enrichment. The following types are supported:
+        * `classifier`: Creates a document classifier enrichment from a document
+        classifier model that you create by using the [Document classifier
+        API](/apidocs/discovery-data#createdocumentclassifier). **Note**: A text
+        classifier enrichment can be created only from the product user interface.
+        * `dictionary`: Creates a custom dictionary enrichment that you define in a CSV
+        file.
+        * `regular_expression`: Creates a custom regular expression enrichment from regex
+        syntax that you specify in the request.
+        * `rule_based`: Creates an enrichment from an advanced rules model that is created
+        and exported as a ZIP file from Watson Knowledge Studio.
+        * `uima_annotator`: Creates an enrichment from a custom UIMA text analysis model
+        that is defined in a PEAR file created in one of the following ways:
+            * Watson Explorer Content Analytics Studio. **Note**: Supported in IBM Cloud
+        Pak for Data instances only.
+            * Rule-based model that is created in Watson Knowledge Studio.
+        * `watson_knowledge_studio_model`: Creates an enrichment from a Watson Knowledge
+        Studio machine learning model that is defined in a ZIP file.
         """
+        CLASSIFIER = 'classifier'
         DICTIONARY = 'dictionary'
         REGULAR_EXPRESSION = 'regular_expression'
         UIMA_ANNOTATOR = 'uima_annotator'
@@ -2951,11 +4654,12 @@ class DefaultQueryParams():
     :attr str aggregation: (optional) A string representing the default aggregation
           query for the project.
     :attr DefaultQueryParamsSuggestedRefinements suggested_refinements: (optional)
-          Object that contains suggested refinement settings. Available with Premium plans
-          only.
+          Object that contains suggested refinement settings.
+          **Note**: The `suggested_refinements` parameter that identified dynamic facets
+          from the data is deprecated.
     :attr bool spelling_suggestions: (optional) When `true`, a spelling suggestions
           for the query are returned by default.
-    :attr bool highlight: (optional) When `true`, a highlights for the query are
+    :attr bool highlight: (optional) When `true`, highlights for the query are
           returned by default.
     :attr int count: (optional) The number of document results returned by default.
     :attr str sort: (optional) A comma separated list of document fields to sort
@@ -2963,7 +4667,6 @@ class DefaultQueryParams():
     :attr List[str] return_: (optional) An array of field names to return in
           document results if present by default.
     """
-
     def __init__(self,
                  *,
                  collection_ids: List[str] = None,
@@ -2990,12 +4693,13 @@ class DefaultQueryParams():
         :param str aggregation: (optional) A string representing the default
                aggregation query for the project.
         :param DefaultQueryParamsSuggestedRefinements suggested_refinements:
-               (optional) Object that contains suggested refinement settings. Available
-               with Premium plans only.
+               (optional) Object that contains suggested refinement settings.
+               **Note**: The `suggested_refinements` parameter that identified dynamic
+               facets from the data is deprecated.
         :param bool spelling_suggestions: (optional) When `true`, a spelling
                suggestions for the query are returned by default.
-        :param bool highlight: (optional) When `true`, a highlights for the query
-               are returned by default.
+        :param bool highlight: (optional) When `true`, highlights for the query are
+               returned by default.
         :param int count: (optional) The number of document results returned by
                default.
         :param str sort: (optional) A comma separated list of document fields to
@@ -3061,11 +4765,12 @@ class DefaultQueryParams():
         if hasattr(self, 'aggregation') and self.aggregation is not None:
             _dict['aggregation'] = self.aggregation
         if hasattr(self, 'suggested_refinements'
-                  ) and self.suggested_refinements is not None:
-            _dict['suggested_refinements'] = self.suggested_refinements.to_dict(
-            )
+                   ) and self.suggested_refinements is not None:
+            _dict[
+                'suggested_refinements'] = self.suggested_refinements.to_dict(
+                )
         if hasattr(self, 'spelling_suggestions'
-                  ) and self.spelling_suggestions is not None:
+                   ) and self.spelling_suggestions is not None:
             _dict['spelling_suggestions'] = self.spelling_suggestions
         if hasattr(self, 'highlight') and self.highlight is not None:
             _dict['highlight'] = self.highlight
@@ -3113,7 +4818,6 @@ class DefaultQueryParamsPassages():
     :attr int max_per_document: (optional) The default maximum number of passages
           that can be taken from a single document as the result of a passage query.
     """
-
     def __init__(self,
                  *,
                  enabled: bool = None,
@@ -3208,14 +4912,15 @@ class DefaultQueryParamsPassages():
 
 class DefaultQueryParamsSuggestedRefinements():
     """
-    Object that contains suggested refinement settings. Available with Premium plans only.
+    Object that contains suggested refinement settings.
+    **Note**: The `suggested_refinements` parameter that identified dynamic facets from
+    the data is deprecated.
 
     :attr bool enabled: (optional) When `true`, suggested refinements for the query
           are returned by default.
     :attr int count: (optional) The number of suggested refinements to return by
           default.
     """
-
     def __init__(self, *, enabled: bool = None, count: int = None) -> None:
         """
         Initialize a DefaultQueryParamsSuggestedRefinements object.
@@ -3229,7 +4934,8 @@ class DefaultQueryParamsSuggestedRefinements():
         self.count = count
 
     @classmethod
-    def from_dict(cls, _dict: Dict) -> 'DefaultQueryParamsSuggestedRefinements':
+    def from_dict(cls,
+                  _dict: Dict) -> 'DefaultQueryParamsSuggestedRefinements':
         """Initialize a DefaultQueryParamsSuggestedRefinements object from a json dictionary."""
         args = {}
         if 'enabled' in _dict:
@@ -3281,7 +4987,6 @@ class DefaultQueryParamsTableResults():
     :attr int per_document: (optional) The number of table results to include in
           each result document.
     """
-
     def __init__(self,
                  *,
                  enabled: bool = None,
@@ -3356,7 +5061,6 @@ class DeleteDocumentResponse():
     :attr str status: (optional) Status of the document. A deleted document has the
           status deleted.
     """
-
     def __init__(self, *, document_id: str = None, status: str = None) -> None:
         """
         Initialize a DeleteDocumentResponse object.
@@ -3428,7 +5132,6 @@ class DocumentAccepted():
           *version* date before `2019-01-01`. The `pending` status is returned for all
           others.
     """
-
     def __init__(self, *, document_id: str = None, status: str = None) -> None:
         """
         Initialize a DocumentAccepted object.
@@ -3505,7 +5208,6 @@ class DocumentAttribute():
           identified element in the document, represented with two integers labeled
           `begin` and `end`.
     """
-
     def __init__(self,
                  *,
                  type: str = None,
@@ -3572,6 +5274,779 @@ class DocumentAttribute():
         return not self == other
 
 
+class DocumentClassifier():
+    """
+    Information about a document classifier.
+
+    :attr str classifier_id: (optional) A unique identifier of the document
+          classifier.
+    :attr str name: A human-readable name of the document classifier.
+    :attr str description: (optional) A description of the document classifier.
+    :attr datetime created: (optional) The date that the document classifier was
+          created.
+    :attr str language: (optional) The language of the training data that is
+          associated with the document classifier. Language is specified by using the ISO
+          639-1 language code, such as `en` for English or `ja` for Japanese.
+    :attr List[DocumentClassifierEnrichment] enrichments: (optional) An array of
+          enrichments to apply to the data that is used to train and test the document
+          classifier. The output from the enrichments is used as features by the
+          classifier to classify the document content both during training and at run
+          time.
+    :attr List[str] recognized_fields: (optional) An array of fields that are used
+          to train the document classifier. The same set of fields must exist in the
+          training data, the test data, and the documents where the resulting document
+          classifier enrichment is applied at run time.
+    :attr str answer_field: (optional) The name of the field from the training and
+          test data that contains the classification labels.
+    :attr str training_data_file: (optional) Name of the CSV file with training data
+          that is used to train the document classifier.
+    :attr str test_data_file: (optional) Name of the CSV file with data that is used
+          to test the document classifier. If no test data is provided, a subset of the
+          training data is used for testing purposes.
+    :attr ClassifierFederatedModel federated_classification: (optional) An object
+          with details for creating federated document classifier models.
+    """
+    def __init__(
+            self,
+            name: str,
+            *,
+            classifier_id: str = None,
+            description: str = None,
+            created: datetime = None,
+            language: str = None,
+            enrichments: List['DocumentClassifierEnrichment'] = None,
+            recognized_fields: List[str] = None,
+            answer_field: str = None,
+            training_data_file: str = None,
+            test_data_file: str = None,
+            federated_classification: 'ClassifierFederatedModel' = None
+    ) -> None:
+        """
+        Initialize a DocumentClassifier object.
+
+        :param str name: A human-readable name of the document classifier.
+        :param str description: (optional) A description of the document
+               classifier.
+        :param str language: (optional) The language of the training data that is
+               associated with the document classifier. Language is specified by using the
+               ISO 639-1 language code, such as `en` for English or `ja` for Japanese.
+        :param List[DocumentClassifierEnrichment] enrichments: (optional) An array
+               of enrichments to apply to the data that is used to train and test the
+               document classifier. The output from the enrichments is used as features by
+               the classifier to classify the document content both during training and at
+               run time.
+        :param List[str] recognized_fields: (optional) An array of fields that are
+               used to train the document classifier. The same set of fields must exist in
+               the training data, the test data, and the documents where the resulting
+               document classifier enrichment is applied at run time.
+        :param str answer_field: (optional) The name of the field from the training
+               and test data that contains the classification labels.
+        :param str training_data_file: (optional) Name of the CSV file with
+               training data that is used to train the document classifier.
+        :param str test_data_file: (optional) Name of the CSV file with data that
+               is used to test the document classifier. If no test data is provided, a
+               subset of the training data is used for testing purposes.
+        :param ClassifierFederatedModel federated_classification: (optional) An
+               object with details for creating federated document classifier models.
+        """
+        self.classifier_id = classifier_id
+        self.name = name
+        self.description = description
+        self.created = created
+        self.language = language
+        self.enrichments = enrichments
+        self.recognized_fields = recognized_fields
+        self.answer_field = answer_field
+        self.training_data_file = training_data_file
+        self.test_data_file = test_data_file
+        self.federated_classification = federated_classification
+
+    @classmethod
+    def from_dict(cls, _dict: Dict) -> 'DocumentClassifier':
+        """Initialize a DocumentClassifier object from a json dictionary."""
+        args = {}
+        if 'classifier_id' in _dict:
+            args['classifier_id'] = _dict.get('classifier_id')
+        if 'name' in _dict:
+            args['name'] = _dict.get('name')
+        else:
+            raise ValueError(
+                'Required property \'name\' not present in DocumentClassifier JSON'
+            )
+        if 'description' in _dict:
+            args['description'] = _dict.get('description')
+        if 'created' in _dict:
+            args['created'] = string_to_datetime(_dict.get('created'))
+        if 'language' in _dict:
+            args['language'] = _dict.get('language')
+        if 'enrichments' in _dict:
+            args['enrichments'] = [
+                DocumentClassifierEnrichment.from_dict(x)
+                for x in _dict.get('enrichments')
+            ]
+        if 'recognized_fields' in _dict:
+            args['recognized_fields'] = _dict.get('recognized_fields')
+        if 'answer_field' in _dict:
+            args['answer_field'] = _dict.get('answer_field')
+        if 'training_data_file' in _dict:
+            args['training_data_file'] = _dict.get('training_data_file')
+        if 'test_data_file' in _dict:
+            args['test_data_file'] = _dict.get('test_data_file')
+        if 'federated_classification' in _dict:
+            args[
+                'federated_classification'] = ClassifierFederatedModel.from_dict(
+                    _dict.get('federated_classification'))
+        return cls(**args)
+
+    @classmethod
+    def _from_dict(cls, _dict):
+        """Initialize a DocumentClassifier object from a json dictionary."""
+        return cls.from_dict(_dict)
+
+    def to_dict(self) -> Dict:
+        """Return a json dictionary representing this model."""
+        _dict = {}
+        if hasattr(self, 'classifier_id') and getattr(
+                self, 'classifier_id') is not None:
+            _dict['classifier_id'] = getattr(self, 'classifier_id')
+        if hasattr(self, 'name') and self.name is not None:
+            _dict['name'] = self.name
+        if hasattr(self, 'description') and self.description is not None:
+            _dict['description'] = self.description
+        if hasattr(self, 'created') and getattr(self, 'created') is not None:
+            _dict['created'] = datetime_to_string(getattr(self, 'created'))
+        if hasattr(self, 'language') and self.language is not None:
+            _dict['language'] = self.language
+        if hasattr(self, 'enrichments') and self.enrichments is not None:
+            _dict['enrichments'] = [x.to_dict() for x in self.enrichments]
+        if hasattr(self,
+                   'recognized_fields') and self.recognized_fields is not None:
+            _dict['recognized_fields'] = self.recognized_fields
+        if hasattr(self, 'answer_field') and self.answer_field is not None:
+            _dict['answer_field'] = self.answer_field
+        if hasattr(
+                self,
+                'training_data_file') and self.training_data_file is not None:
+            _dict['training_data_file'] = self.training_data_file
+        if hasattr(self, 'test_data_file') and self.test_data_file is not None:
+            _dict['test_data_file'] = self.test_data_file
+        if hasattr(self, 'federated_classification'
+                   ) and self.federated_classification is not None:
+            _dict[
+                'federated_classification'] = self.federated_classification.to_dict(
+                )
+        return _dict
+
+    def _to_dict(self):
+        """Return a json dictionary representing this model."""
+        return self.to_dict()
+
+    def __str__(self) -> str:
+        """Return a `str` version of this DocumentClassifier object."""
+        return json.dumps(self.to_dict(), indent=2)
+
+    def __eq__(self, other: 'DocumentClassifier') -> bool:
+        """Return `true` when self and other are equal, false otherwise."""
+        if not isinstance(other, self.__class__):
+            return False
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other: 'DocumentClassifier') -> bool:
+        """Return `true` when self and other are not equal, false otherwise."""
+        return not self == other
+
+
+class DocumentClassifierEnrichment():
+    """
+    An object that describes enrichments that are applied to the training and test data
+    that is used by the document classifier.
+
+    :attr str enrichment_id: (optional) A unique identifier of the enrichment.
+    :attr List[str] fields: An array of field names where the enrichment is applied.
+    """
+    def __init__(self,
+                 fields: List[str],
+                 *,
+                 enrichment_id: str = None) -> None:
+        """
+        Initialize a DocumentClassifierEnrichment object.
+
+        :param List[str] fields: An array of field names where the enrichment is
+               applied.
+        :param str enrichment_id: (optional) A unique identifier of the enrichment.
+        """
+        self.enrichment_id = enrichment_id
+        self.fields = fields
+
+    @classmethod
+    def from_dict(cls, _dict: Dict) -> 'DocumentClassifierEnrichment':
+        """Initialize a DocumentClassifierEnrichment object from a json dictionary."""
+        args = {}
+        if 'enrichment_id' in _dict:
+            args['enrichment_id'] = _dict.get('enrichment_id')
+        if 'fields' in _dict:
+            args['fields'] = _dict.get('fields')
+        else:
+            raise ValueError(
+                'Required property \'fields\' not present in DocumentClassifierEnrichment JSON'
+            )
+        return cls(**args)
+
+    @classmethod
+    def _from_dict(cls, _dict):
+        """Initialize a DocumentClassifierEnrichment object from a json dictionary."""
+        return cls.from_dict(_dict)
+
+    def to_dict(self) -> Dict:
+        """Return a json dictionary representing this model."""
+        _dict = {}
+        if hasattr(self, 'enrichment_id') and self.enrichment_id is not None:
+            _dict['enrichment_id'] = self.enrichment_id
+        if hasattr(self, 'fields') and self.fields is not None:
+            _dict['fields'] = self.fields
+        return _dict
+
+    def _to_dict(self):
+        """Return a json dictionary representing this model."""
+        return self.to_dict()
+
+    def __str__(self) -> str:
+        """Return a `str` version of this DocumentClassifierEnrichment object."""
+        return json.dumps(self.to_dict(), indent=2)
+
+    def __eq__(self, other: 'DocumentClassifierEnrichment') -> bool:
+        """Return `true` when self and other are equal, false otherwise."""
+        if not isinstance(other, self.__class__):
+            return False
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other: 'DocumentClassifierEnrichment') -> bool:
+        """Return `true` when self and other are not equal, false otherwise."""
+        return not self == other
+
+
+class DocumentClassifierModel():
+    """
+    Information about a document classifier model.
+
+    :attr str model_id: (optional) A unique identifier of the document classifier
+          model.
+    :attr str name: A human-readable name of the document classifier model.
+    :attr str description: (optional) A description of the document classifier
+          model.
+    :attr datetime created: (optional) The date that the document classifier model
+          was created.
+    :attr datetime updated: (optional) The date that the document classifier model
+          was last updated.
+    :attr str training_data_file: (optional) Name of the CSV file that contains the
+          training data that is used to train the document classifier model.
+    :attr str test_data_file: (optional) Name of the CSV file that contains data
+          that is used to test the document classifier model. If no test data is provided,
+          a subset of the training data is used for testing purposes.
+    :attr str status: (optional) The status of the training run.
+    :attr ClassifierModelEvaluation evaluation: (optional) An object that contains
+          information about a trained document classifier model.
+    :attr str enrichment_id: (optional) A unique identifier of the enrichment that
+          is generated by this document classifier model.
+    :attr datetime deployed_at: (optional) The date that the document classifier
+          model was deployed.
+    """
+    def __init__(self,
+                 name: str,
+                 *,
+                 model_id: str = None,
+                 description: str = None,
+                 created: datetime = None,
+                 updated: datetime = None,
+                 training_data_file: str = None,
+                 test_data_file: str = None,
+                 status: str = None,
+                 evaluation: 'ClassifierModelEvaluation' = None,
+                 enrichment_id: str = None,
+                 deployed_at: datetime = None) -> None:
+        """
+        Initialize a DocumentClassifierModel object.
+
+        :param str name: A human-readable name of the document classifier model.
+        :param str description: (optional) A description of the document classifier
+               model.
+        :param str training_data_file: (optional) Name of the CSV file that
+               contains the training data that is used to train the document classifier
+               model.
+        :param str test_data_file: (optional) Name of the CSV file that contains
+               data that is used to test the document classifier model. If no test data is
+               provided, a subset of the training data is used for testing purposes.
+        :param str status: (optional) The status of the training run.
+        :param ClassifierModelEvaluation evaluation: (optional) An object that
+               contains information about a trained document classifier model.
+        :param str enrichment_id: (optional) A unique identifier of the enrichment
+               that is generated by this document classifier model.
+        """
+        self.model_id = model_id
+        self.name = name
+        self.description = description
+        self.created = created
+        self.updated = updated
+        self.training_data_file = training_data_file
+        self.test_data_file = test_data_file
+        self.status = status
+        self.evaluation = evaluation
+        self.enrichment_id = enrichment_id
+        self.deployed_at = deployed_at
+
+    @classmethod
+    def from_dict(cls, _dict: Dict) -> 'DocumentClassifierModel':
+        """Initialize a DocumentClassifierModel object from a json dictionary."""
+        args = {}
+        if 'model_id' in _dict:
+            args['model_id'] = _dict.get('model_id')
+        if 'name' in _dict:
+            args['name'] = _dict.get('name')
+        else:
+            raise ValueError(
+                'Required property \'name\' not present in DocumentClassifierModel JSON'
+            )
+        if 'description' in _dict:
+            args['description'] = _dict.get('description')
+        if 'created' in _dict:
+            args['created'] = string_to_datetime(_dict.get('created'))
+        if 'updated' in _dict:
+            args['updated'] = string_to_datetime(_dict.get('updated'))
+        if 'training_data_file' in _dict:
+            args['training_data_file'] = _dict.get('training_data_file')
+        if 'test_data_file' in _dict:
+            args['test_data_file'] = _dict.get('test_data_file')
+        if 'status' in _dict:
+            args['status'] = _dict.get('status')
+        if 'evaluation' in _dict:
+            args['evaluation'] = ClassifierModelEvaluation.from_dict(
+                _dict.get('evaluation'))
+        if 'enrichment_id' in _dict:
+            args['enrichment_id'] = _dict.get('enrichment_id')
+        if 'deployed_at' in _dict:
+            args['deployed_at'] = string_to_datetime(_dict.get('deployed_at'))
+        return cls(**args)
+
+    @classmethod
+    def _from_dict(cls, _dict):
+        """Initialize a DocumentClassifierModel object from a json dictionary."""
+        return cls.from_dict(_dict)
+
+    def to_dict(self) -> Dict:
+        """Return a json dictionary representing this model."""
+        _dict = {}
+        if hasattr(self, 'model_id') and getattr(self, 'model_id') is not None:
+            _dict['model_id'] = getattr(self, 'model_id')
+        if hasattr(self, 'name') and self.name is not None:
+            _dict['name'] = self.name
+        if hasattr(self, 'description') and self.description is not None:
+            _dict['description'] = self.description
+        if hasattr(self, 'created') and getattr(self, 'created') is not None:
+            _dict['created'] = datetime_to_string(getattr(self, 'created'))
+        if hasattr(self, 'updated') and getattr(self, 'updated') is not None:
+            _dict['updated'] = datetime_to_string(getattr(self, 'updated'))
+        if hasattr(
+                self,
+                'training_data_file') and self.training_data_file is not None:
+            _dict['training_data_file'] = self.training_data_file
+        if hasattr(self, 'test_data_file') and self.test_data_file is not None:
+            _dict['test_data_file'] = self.test_data_file
+        if hasattr(self, 'status') and self.status is not None:
+            _dict['status'] = self.status
+        if hasattr(self, 'evaluation') and self.evaluation is not None:
+            _dict['evaluation'] = self.evaluation.to_dict()
+        if hasattr(self, 'enrichment_id') and self.enrichment_id is not None:
+            _dict['enrichment_id'] = self.enrichment_id
+        if hasattr(self, 'deployed_at') and getattr(self,
+                                                    'deployed_at') is not None:
+            _dict['deployed_at'] = datetime_to_string(
+                getattr(self, 'deployed_at'))
+        return _dict
+
+    def _to_dict(self):
+        """Return a json dictionary representing this model."""
+        return self.to_dict()
+
+    def __str__(self) -> str:
+        """Return a `str` version of this DocumentClassifierModel object."""
+        return json.dumps(self.to_dict(), indent=2)
+
+    def __eq__(self, other: 'DocumentClassifierModel') -> bool:
+        """Return `true` when self and other are equal, false otherwise."""
+        if not isinstance(other, self.__class__):
+            return False
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other: 'DocumentClassifierModel') -> bool:
+        """Return `true` when self and other are not equal, false otherwise."""
+        return not self == other
+
+    class StatusEnum(str, Enum):
+        """
+        The status of the training run.
+        """
+        TRAINING = 'training'
+        AVAILABLE = 'available'
+        FAILED = 'failed'
+
+
+class DocumentClassifierModels():
+    """
+    An object that contains a list of document classifier model definitions.
+
+    :attr List[DocumentClassifierModel] models: (optional) An array of document
+          classifier model definitions.
+    """
+    def __init__(self,
+                 *,
+                 models: List['DocumentClassifierModel'] = None) -> None:
+        """
+        Initialize a DocumentClassifierModels object.
+
+        :param List[DocumentClassifierModel] models: (optional) An array of
+               document classifier model definitions.
+        """
+        self.models = models
+
+    @classmethod
+    def from_dict(cls, _dict: Dict) -> 'DocumentClassifierModels':
+        """Initialize a DocumentClassifierModels object from a json dictionary."""
+        args = {}
+        if 'models' in _dict:
+            args['models'] = [
+                DocumentClassifierModel.from_dict(x)
+                for x in _dict.get('models')
+            ]
+        return cls(**args)
+
+    @classmethod
+    def _from_dict(cls, _dict):
+        """Initialize a DocumentClassifierModels object from a json dictionary."""
+        return cls.from_dict(_dict)
+
+    def to_dict(self) -> Dict:
+        """Return a json dictionary representing this model."""
+        _dict = {}
+        if hasattr(self, 'models') and self.models is not None:
+            _dict['models'] = [x.to_dict() for x in self.models]
+        return _dict
+
+    def _to_dict(self):
+        """Return a json dictionary representing this model."""
+        return self.to_dict()
+
+    def __str__(self) -> str:
+        """Return a `str` version of this DocumentClassifierModels object."""
+        return json.dumps(self.to_dict(), indent=2)
+
+    def __eq__(self, other: 'DocumentClassifierModels') -> bool:
+        """Return `true` when self and other are equal, false otherwise."""
+        if not isinstance(other, self.__class__):
+            return False
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other: 'DocumentClassifierModels') -> bool:
+        """Return `true` when self and other are not equal, false otherwise."""
+        return not self == other
+
+
+class DocumentClassifiers():
+    """
+    An object that contains a list of document classifier definitions.
+
+    :attr List[DocumentClassifier] classifiers: (optional) An array of document
+          classifier definitions.
+    """
+    def __init__(self,
+                 *,
+                 classifiers: List['DocumentClassifier'] = None) -> None:
+        """
+        Initialize a DocumentClassifiers object.
+
+        :param List[DocumentClassifier] classifiers: (optional) An array of
+               document classifier definitions.
+        """
+        self.classifiers = classifiers
+
+    @classmethod
+    def from_dict(cls, _dict: Dict) -> 'DocumentClassifiers':
+        """Initialize a DocumentClassifiers object from a json dictionary."""
+        args = {}
+        if 'classifiers' in _dict:
+            args['classifiers'] = [
+                DocumentClassifier.from_dict(x)
+                for x in _dict.get('classifiers')
+            ]
+        return cls(**args)
+
+    @classmethod
+    def _from_dict(cls, _dict):
+        """Initialize a DocumentClassifiers object from a json dictionary."""
+        return cls.from_dict(_dict)
+
+    def to_dict(self) -> Dict:
+        """Return a json dictionary representing this model."""
+        _dict = {}
+        if hasattr(self, 'classifiers') and self.classifiers is not None:
+            _dict['classifiers'] = [x.to_dict() for x in self.classifiers]
+        return _dict
+
+    def _to_dict(self):
+        """Return a json dictionary representing this model."""
+        return self.to_dict()
+
+    def __str__(self) -> str:
+        """Return a `str` version of this DocumentClassifiers object."""
+        return json.dumps(self.to_dict(), indent=2)
+
+    def __eq__(self, other: 'DocumentClassifiers') -> bool:
+        """Return `true` when self and other are equal, false otherwise."""
+        if not isinstance(other, self.__class__):
+            return False
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other: 'DocumentClassifiers') -> bool:
+        """Return `true` when self and other are not equal, false otherwise."""
+        return not self == other
+
+
+class DocumentDetails():
+    """
+    Information about a document.
+
+    :attr str document_id: (optional) The unique identifier of the document.
+    :attr datetime created: (optional) Date and time that the document is added to
+          the collection. For a child document, the date and time when the process that
+          generates the child document runs. The date-time format is
+          `yyyy-MM-dd'T'HH:mm:ss.SSS'Z'`.
+    :attr datetime updated: (optional) Date and time that the document is finished
+          being processed and is indexed. This date changes whenever the document is
+          reprocessed, including for enrichment changes. The date-time format is
+          `yyyy-MM-dd'T'HH:mm:ss.SSS'Z'`.
+    :attr str status: (optional) The status of the ingestion of the document. The
+          possible values are:
+          * `available`: Ingestion is finished and the document is indexed.
+          * `failed`: Ingestion is finished, but the document is not indexed because of an
+          error.
+          * `pending`: The document is uploaded, but the ingestion process is not started.
+          * `processing`: Ingestion is in progress.
+    :attr List[Notice] notices: (optional) Array of JSON objects for notices,
+          meaning warning or error messages, that are produced by the document ingestion
+          process. The array does not include notices that are produced for child
+          documents that are generated when a document is processed.
+    :attr DocumentDetailsChildren children: (optional) Information about the child
+          documents that are generated from a single document during ingestion or other
+          processing.
+    :attr str filename: (optional) Name of the original source file (if available).
+    :attr str file_type: (optional) The type of the original source file, such as
+          `csv`, `excel`, `html`, `json`, `pdf`, `text`, `word`, and so on.
+    :attr str sha256: (optional) The SHA-256 hash of the original source file. The
+          hash is formatted as a hexadecimal string.
+    """
+    def __init__(self,
+                 *,
+                 document_id: str = None,
+                 created: datetime = None,
+                 updated: datetime = None,
+                 status: str = None,
+                 notices: List['Notice'] = None,
+                 children: 'DocumentDetailsChildren' = None,
+                 filename: str = None,
+                 file_type: str = None,
+                 sha256: str = None) -> None:
+        """
+        Initialize a DocumentDetails object.
+
+        :param str status: (optional) The status of the ingestion of the document.
+               The possible values are:
+               * `available`: Ingestion is finished and the document is indexed.
+               * `failed`: Ingestion is finished, but the document is not indexed because
+               of an error.
+               * `pending`: The document is uploaded, but the ingestion process is not
+               started.
+               * `processing`: Ingestion is in progress.
+        :param List[Notice] notices: (optional) Array of JSON objects for notices,
+               meaning warning or error messages, that are produced by the document
+               ingestion process. The array does not include notices that are produced for
+               child documents that are generated when a document is processed.
+        :param DocumentDetailsChildren children: (optional) Information about the
+               child documents that are generated from a single document during ingestion
+               or other processing.
+        :param str filename: (optional) Name of the original source file (if
+               available).
+        :param str file_type: (optional) The type of the original source file, such
+               as `csv`, `excel`, `html`, `json`, `pdf`, `text`, `word`, and so on.
+        :param str sha256: (optional) The SHA-256 hash of the original source file.
+               The hash is formatted as a hexadecimal string.
+        """
+        self.document_id = document_id
+        self.created = created
+        self.updated = updated
+        self.status = status
+        self.notices = notices
+        self.children = children
+        self.filename = filename
+        self.file_type = file_type
+        self.sha256 = sha256
+
+    @classmethod
+    def from_dict(cls, _dict: Dict) -> 'DocumentDetails':
+        """Initialize a DocumentDetails object from a json dictionary."""
+        args = {}
+        if 'document_id' in _dict:
+            args['document_id'] = _dict.get('document_id')
+        if 'created' in _dict:
+            args['created'] = string_to_datetime(_dict.get('created'))
+        if 'updated' in _dict:
+            args['updated'] = string_to_datetime(_dict.get('updated'))
+        if 'status' in _dict:
+            args['status'] = _dict.get('status')
+        if 'notices' in _dict:
+            args['notices'] = [
+                Notice.from_dict(x) for x in _dict.get('notices')
+            ]
+        if 'children' in _dict:
+            args['children'] = DocumentDetailsChildren.from_dict(
+                _dict.get('children'))
+        if 'filename' in _dict:
+            args['filename'] = _dict.get('filename')
+        if 'file_type' in _dict:
+            args['file_type'] = _dict.get('file_type')
+        if 'sha256' in _dict:
+            args['sha256'] = _dict.get('sha256')
+        return cls(**args)
+
+    @classmethod
+    def _from_dict(cls, _dict):
+        """Initialize a DocumentDetails object from a json dictionary."""
+        return cls.from_dict(_dict)
+
+    def to_dict(self) -> Dict:
+        """Return a json dictionary representing this model."""
+        _dict = {}
+        if hasattr(self, 'document_id') and getattr(self,
+                                                    'document_id') is not None:
+            _dict['document_id'] = getattr(self, 'document_id')
+        if hasattr(self, 'created') and getattr(self, 'created') is not None:
+            _dict['created'] = datetime_to_string(getattr(self, 'created'))
+        if hasattr(self, 'updated') and getattr(self, 'updated') is not None:
+            _dict['updated'] = datetime_to_string(getattr(self, 'updated'))
+        if hasattr(self, 'status') and self.status is not None:
+            _dict['status'] = self.status
+        if hasattr(self, 'notices') and self.notices is not None:
+            _dict['notices'] = [x.to_dict() for x in self.notices]
+        if hasattr(self, 'children') and self.children is not None:
+            _dict['children'] = self.children.to_dict()
+        if hasattr(self, 'filename') and self.filename is not None:
+            _dict['filename'] = self.filename
+        if hasattr(self, 'file_type') and self.file_type is not None:
+            _dict['file_type'] = self.file_type
+        if hasattr(self, 'sha256') and self.sha256 is not None:
+            _dict['sha256'] = self.sha256
+        return _dict
+
+    def _to_dict(self):
+        """Return a json dictionary representing this model."""
+        return self.to_dict()
+
+    def __str__(self) -> str:
+        """Return a `str` version of this DocumentDetails object."""
+        return json.dumps(self.to_dict(), indent=2)
+
+    def __eq__(self, other: 'DocumentDetails') -> bool:
+        """Return `true` when self and other are equal, false otherwise."""
+        if not isinstance(other, self.__class__):
+            return False
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other: 'DocumentDetails') -> bool:
+        """Return `true` when self and other are not equal, false otherwise."""
+        return not self == other
+
+    class StatusEnum(str, Enum):
+        """
+        The status of the ingestion of the document. The possible values are:
+        * `available`: Ingestion is finished and the document is indexed.
+        * `failed`: Ingestion is finished, but the document is not indexed because of an
+        error.
+        * `pending`: The document is uploaded, but the ingestion process is not started.
+        * `processing`: Ingestion is in progress.
+        """
+        AVAILABLE = 'available'
+        FAILED = 'failed'
+        PENDING = 'pending'
+        PROCESSING = 'processing'
+
+
+class DocumentDetailsChildren():
+    """
+    Information about the child documents that are generated from a single document during
+    ingestion or other processing.
+
+    :attr bool have_notices: (optional) Indicates whether the child documents have
+          any notices. The value is `false` if the document does not have child documents.
+    :attr int count: (optional) Number of child documents. The value is `0` when
+          processing of the document doesn't generate any child documents.
+    """
+    def __init__(self,
+                 *,
+                 have_notices: bool = None,
+                 count: int = None) -> None:
+        """
+        Initialize a DocumentDetailsChildren object.
+
+        :param bool have_notices: (optional) Indicates whether the child documents
+               have any notices. The value is `false` if the document does not have child
+               documents.
+        :param int count: (optional) Number of child documents. The value is `0`
+               when processing of the document doesn't generate any child documents.
+        """
+        self.have_notices = have_notices
+        self.count = count
+
+    @classmethod
+    def from_dict(cls, _dict: Dict) -> 'DocumentDetailsChildren':
+        """Initialize a DocumentDetailsChildren object from a json dictionary."""
+        args = {}
+        if 'have_notices' in _dict:
+            args['have_notices'] = _dict.get('have_notices')
+        if 'count' in _dict:
+            args['count'] = _dict.get('count')
+        return cls(**args)
+
+    @classmethod
+    def _from_dict(cls, _dict):
+        """Initialize a DocumentDetailsChildren object from a json dictionary."""
+        return cls.from_dict(_dict)
+
+    def to_dict(self) -> Dict:
+        """Return a json dictionary representing this model."""
+        _dict = {}
+        if hasattr(self, 'have_notices') and self.have_notices is not None:
+            _dict['have_notices'] = self.have_notices
+        if hasattr(self, 'count') and self.count is not None:
+            _dict['count'] = self.count
+        return _dict
+
+    def _to_dict(self):
+        """Return a json dictionary representing this model."""
+        return self.to_dict()
+
+    def __str__(self) -> str:
+        """Return a `str` version of this DocumentDetailsChildren object."""
+        return json.dumps(self.to_dict(), indent=2)
+
+    def __eq__(self, other: 'DocumentDetailsChildren') -> bool:
+        """Return `true` when self and other are equal, false otherwise."""
+        if not isinstance(other, self.__class__):
+            return False
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other: 'DocumentDetailsChildren') -> bool:
+        """Return `true` when self and other are not equal, false otherwise."""
+        return not self == other
+
+
 class Enrichment():
     """
     Information about a specific enrichment.
@@ -3584,7 +6059,6 @@ class Enrichment():
           the current enrichment. Starting with version `2020-08-30`, the enrichment
           options are not included in responses from the List Enrichments method.
     """
-
     def __init__(self,
                  *,
                  enrichment_id: str = None,
@@ -3676,6 +6150,7 @@ class Enrichment():
         UIMA_ANNOTATOR = 'uima_annotator'
         RULE_BASED = 'rule_based'
         WATSON_KNOWLEDGE_STUDIO_MODEL = 'watson_knowledge_studio_model'
+        CLASSIFIER = 'classifier'
 
 
 class EnrichmentOptions():
@@ -3685,46 +6160,89 @@ class EnrichmentOptions():
     Enrichments method.
 
     :attr List[str] languages: (optional) An array of supported languages for this
-          enrichment. Required when `type` is `dictionary`. Optional when `type` is
-          `rule_based`. Not valid when creating any other type of enrichment.
+          enrichment. When creating an enrichment, only specify a language that is used by
+          the model or in the dictionary. Required when **type** is `dictionary`. Optional
+          when **type** is `rule_based`. Not valid when creating any other type of
+          enrichment.
     :attr str entity_type: (optional) The name of the entity type. This value is
-          used as the field name in the index. Required when `type` is `dictionary` or
+          used as the field name in the index. Required when **type** is `dictionary` or
           `regular_expression`. Not valid when creating any other type of enrichment.
     :attr str regular_expression: (optional) The regular expression to apply for
-          this enrichment. Required when `type` is `regular_expression`. Not valid when
+          this enrichment. Required when **type** is `regular_expression`. Not valid when
           creating any other type of enrichment.
     :attr str result_field: (optional) The name of the result document field that
-          this enrichment creates. Required when `type` is `rule_based`. Not valid when
-          creating any other type of enrichment.
+          this enrichment creates. Required when **type** is `rule_based` or `classifier`.
+          Not valid when creating any other type of enrichment.
+    :attr str classifier_id: (optional) A unique identifier of the document
+          classifier. Required when **type** is `classifier`. Not valid when creating any
+          other type of enrichment.
+    :attr str model_id: (optional) A unique identifier of the document classifier
+          model. Required when **type** is `classifier`. Not valid when creating any other
+          type of enrichment.
+    :attr float confidence_threshold: (optional) Specifies a threshold. Only classes
+          with evaluation confidence scores that are higher than the specified threshold
+          are included in the output. Optional when **type** is `classifier`. Not valid
+          when creating any other type of enrichment.
+    :attr int top_k: (optional) Evaluates only the classes that fall in the top set
+          of results when ranked by confidence. For example, if set to `5`, then the top
+          five classes for each document are evaluated. If set to 0, the
+          **confidence_threshold** is used to determine the predicted classes. Optional
+          when **type** is `classifier`. Not valid when creating any other type of
+          enrichment.
     """
-
     def __init__(self,
                  *,
                  languages: List[str] = None,
                  entity_type: str = None,
                  regular_expression: str = None,
-                 result_field: str = None) -> None:
+                 result_field: str = None,
+                 classifier_id: str = None,
+                 model_id: str = None,
+                 confidence_threshold: float = None,
+                 top_k: int = None) -> None:
         """
         Initialize a EnrichmentOptions object.
 
         :param List[str] languages: (optional) An array of supported languages for
-               this enrichment. Required when `type` is `dictionary`. Optional when `type`
-               is `rule_based`. Not valid when creating any other type of enrichment.
+               this enrichment. When creating an enrichment, only specify a language that
+               is used by the model or in the dictionary. Required when **type** is
+               `dictionary`. Optional when **type** is `rule_based`. Not valid when
+               creating any other type of enrichment.
         :param str entity_type: (optional) The name of the entity type. This value
-               is used as the field name in the index. Required when `type` is
+               is used as the field name in the index. Required when **type** is
                `dictionary` or `regular_expression`. Not valid when creating any other
                type of enrichment.
         :param str regular_expression: (optional) The regular expression to apply
-               for this enrichment. Required when `type` is `regular_expression`. Not
+               for this enrichment. Required when **type** is `regular_expression`. Not
                valid when creating any other type of enrichment.
         :param str result_field: (optional) The name of the result document field
-               that this enrichment creates. Required when `type` is `rule_based`. Not
-               valid when creating any other type of enrichment.
+               that this enrichment creates. Required when **type** is `rule_based` or
+               `classifier`. Not valid when creating any other type of enrichment.
+        :param str classifier_id: (optional) A unique identifier of the document
+               classifier. Required when **type** is `classifier`. Not valid when creating
+               any other type of enrichment.
+        :param str model_id: (optional) A unique identifier of the document
+               classifier model. Required when **type** is `classifier`. Not valid when
+               creating any other type of enrichment.
+        :param float confidence_threshold: (optional) Specifies a threshold. Only
+               classes with evaluation confidence scores that are higher than the
+               specified threshold are included in the output. Optional when **type** is
+               `classifier`. Not valid when creating any other type of enrichment.
+        :param int top_k: (optional) Evaluates only the classes that fall in the
+               top set of results when ranked by confidence. For example, if set to `5`,
+               then the top five classes for each document are evaluated. If set to 0, the
+               **confidence_threshold** is used to determine the predicted classes.
+               Optional when **type** is `classifier`. Not valid when creating any other
+               type of enrichment.
         """
         self.languages = languages
         self.entity_type = entity_type
         self.regular_expression = regular_expression
         self.result_field = result_field
+        self.classifier_id = classifier_id
+        self.model_id = model_id
+        self.confidence_threshold = confidence_threshold
+        self.top_k = top_k
 
     @classmethod
     def from_dict(cls, _dict: Dict) -> 'EnrichmentOptions':
@@ -3738,6 +6256,14 @@ class EnrichmentOptions():
             args['regular_expression'] = _dict.get('regular_expression')
         if 'result_field' in _dict:
             args['result_field'] = _dict.get('result_field')
+        if 'classifier_id' in _dict:
+            args['classifier_id'] = _dict.get('classifier_id')
+        if 'model_id' in _dict:
+            args['model_id'] = _dict.get('model_id')
+        if 'confidence_threshold' in _dict:
+            args['confidence_threshold'] = _dict.get('confidence_threshold')
+        if 'top_k' in _dict:
+            args['top_k'] = _dict.get('top_k')
         return cls(**args)
 
     @classmethod
@@ -3758,6 +6284,15 @@ class EnrichmentOptions():
             _dict['regular_expression'] = self.regular_expression
         if hasattr(self, 'result_field') and self.result_field is not None:
             _dict['result_field'] = self.result_field
+        if hasattr(self, 'classifier_id') and self.classifier_id is not None:
+            _dict['classifier_id'] = self.classifier_id
+        if hasattr(self, 'model_id') and self.model_id is not None:
+            _dict['model_id'] = self.model_id
+        if hasattr(self, 'confidence_threshold'
+                   ) and self.confidence_threshold is not None:
+            _dict['confidence_threshold'] = self.confidence_threshold
+        if hasattr(self, 'top_k') and self.top_k is not None:
+            _dict['top_k'] = self.top_k
         return _dict
 
     def _to_dict(self):
@@ -3786,7 +6321,6 @@ class Enrichments():
     :attr List[Enrichment] enrichments: (optional) An array of enrichment
           definitions.
     """
-
     def __init__(self, *, enrichments: List['Enrichment'] = None) -> None:
         """
         Initialize a Enrichments object.
@@ -3837,6 +6371,167 @@ class Enrichments():
         return not self == other
 
 
+class Expansion():
+    """
+    An expansion definition. Each object respresents one set of expandable strings. For
+    example, you could have expansions for the word `hot` in one object, and expansions
+    for the word `cold` in another. Follow these guidelines when you add terms:
+    * Specify the terms in lowercase. Lowercase terms expand to uppercase.
+    * Multiword terms are supported only in bidirectional expansions.
+    * Do not specify a term that is specified in the stop words list for the collection.
+
+    :attr List[str] input_terms: (optional) A list of terms that will be expanded
+          for this expansion. If specified, only the items in this list are expanded.
+    :attr List[str] expanded_terms: A list of terms that this expansion will be
+          expanded to. If specified without **input_terms**, the list also functions as
+          the input term list.
+    """
+    def __init__(self,
+                 expanded_terms: List[str],
+                 *,
+                 input_terms: List[str] = None) -> None:
+        """
+        Initialize a Expansion object.
+
+        :param List[str] expanded_terms: A list of terms that this expansion will
+               be expanded to. If specified without **input_terms**, the list also
+               functions as the input term list.
+        :param List[str] input_terms: (optional) A list of terms that will be
+               expanded for this expansion. If specified, only the items in this list are
+               expanded.
+        """
+        self.input_terms = input_terms
+        self.expanded_terms = expanded_terms
+
+    @classmethod
+    def from_dict(cls, _dict: Dict) -> 'Expansion':
+        """Initialize a Expansion object from a json dictionary."""
+        args = {}
+        if 'input_terms' in _dict:
+            args['input_terms'] = _dict.get('input_terms')
+        if 'expanded_terms' in _dict:
+            args['expanded_terms'] = _dict.get('expanded_terms')
+        else:
+            raise ValueError(
+                'Required property \'expanded_terms\' not present in Expansion JSON'
+            )
+        return cls(**args)
+
+    @classmethod
+    def _from_dict(cls, _dict):
+        """Initialize a Expansion object from a json dictionary."""
+        return cls.from_dict(_dict)
+
+    def to_dict(self) -> Dict:
+        """Return a json dictionary representing this model."""
+        _dict = {}
+        if hasattr(self, 'input_terms') and self.input_terms is not None:
+            _dict['input_terms'] = self.input_terms
+        if hasattr(self, 'expanded_terms') and self.expanded_terms is not None:
+            _dict['expanded_terms'] = self.expanded_terms
+        return _dict
+
+    def _to_dict(self):
+        """Return a json dictionary representing this model."""
+        return self.to_dict()
+
+    def __str__(self) -> str:
+        """Return a `str` version of this Expansion object."""
+        return json.dumps(self.to_dict(), indent=2)
+
+    def __eq__(self, other: 'Expansion') -> bool:
+        """Return `true` when self and other are equal, false otherwise."""
+        if not isinstance(other, self.__class__):
+            return False
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other: 'Expansion') -> bool:
+        """Return `true` when self and other are not equal, false otherwise."""
+        return not self == other
+
+
+class Expansions():
+    """
+    The query expansion definitions for the specified collection.
+
+    :attr List[Expansion] expansions: An array of query expansion definitions.
+           Each object in the **expansions** array represents a term or set of terms that
+          will be expanded into other terms. Each expansion object can be configured as
+          `bidirectional` or `unidirectional`.
+          * **Bidirectional**: Each entry in the `expanded_terms` list expands to include
+          all expanded terms. For example, a query for `ibm` expands to `ibm OR
+          international business machines OR big blue`.
+          * **Unidirectional**: The terms in `input_terms` in the query are replaced by
+          the terms in `expanded_terms`. For example, a query for the often misused term
+          `on premise` is converted to `on premises OR on-premises` and does not contain
+          the original term. If you want an input term to be included in the query, then
+          repeat the input term in the expanded terms list.
+    """
+    def __init__(self, expansions: List['Expansion']) -> None:
+        """
+        Initialize a Expansions object.
+
+        :param List[Expansion] expansions: An array of query expansion definitions.
+                Each object in the **expansions** array represents a term or set of terms
+               that will be expanded into other terms. Each expansion object can be
+               configured as `bidirectional` or `unidirectional`.
+               * **Bidirectional**: Each entry in the `expanded_terms` list expands to
+               include all expanded terms. For example, a query for `ibm` expands to `ibm
+               OR international business machines OR big blue`.
+               * **Unidirectional**: The terms in `input_terms` in the query are replaced
+               by the terms in `expanded_terms`. For example, a query for the often
+               misused term `on premise` is converted to `on premises OR on-premises` and
+               does not contain the original term. If you want an input term to be
+               included in the query, then repeat the input term in the expanded terms
+               list.
+        """
+        self.expansions = expansions
+
+    @classmethod
+    def from_dict(cls, _dict: Dict) -> 'Expansions':
+        """Initialize a Expansions object from a json dictionary."""
+        args = {}
+        if 'expansions' in _dict:
+            args['expansions'] = [
+                Expansion.from_dict(x) for x in _dict.get('expansions')
+            ]
+        else:
+            raise ValueError(
+                'Required property \'expansions\' not present in Expansions JSON'
+            )
+        return cls(**args)
+
+    @classmethod
+    def _from_dict(cls, _dict):
+        """Initialize a Expansions object from a json dictionary."""
+        return cls.from_dict(_dict)
+
+    def to_dict(self) -> Dict:
+        """Return a json dictionary representing this model."""
+        _dict = {}
+        if hasattr(self, 'expansions') and self.expansions is not None:
+            _dict['expansions'] = [x.to_dict() for x in self.expansions]
+        return _dict
+
+    def _to_dict(self):
+        """Return a json dictionary representing this model."""
+        return self.to_dict()
+
+    def __str__(self) -> str:
+        """Return a `str` version of this Expansions object."""
+        return json.dumps(self.to_dict(), indent=2)
+
+    def __eq__(self, other: 'Expansions') -> bool:
+        """Return `true` when self and other are equal, false otherwise."""
+        if not isinstance(other, self.__class__):
+            return False
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other: 'Expansions') -> bool:
+        """Return `true` when self and other are not equal, false otherwise."""
+        return not self == other
+
+
 class Field():
     """
     Object that contains field details.
@@ -3846,7 +6541,6 @@ class Field():
     :attr str collection_id: (optional) The collection Id of the collection where
           the field was found.
     """
-
     def __init__(self,
                  *,
                  field: str = None,
@@ -3931,7 +6625,6 @@ class ListCollectionsResponse():
     :attr List[Collection] collections: (optional) An array that contains
           information about each collection in the project.
     """
-
     def __init__(self, *, collections: List['Collection'] = None) -> None:
         """
         Initialize a ListCollectionsResponse object.
@@ -3982,6 +6675,80 @@ class ListCollectionsResponse():
         return not self == other
 
 
+class ListDocumentsResponse():
+    """
+    Response object that contains an array of documents.
+
+    :attr int matching_results: (optional) The number of matching results for the
+          document query.
+    :attr List[DocumentDetails] documents: (optional) An array that lists the
+          documents in a collection. Only the document ID of each document is returned in
+          the list. You can use the [Get document](#getdocument) method to get more
+          information about an individual document.
+    """
+    def __init__(self,
+                 *,
+                 matching_results: int = None,
+                 documents: List['DocumentDetails'] = None) -> None:
+        """
+        Initialize a ListDocumentsResponse object.
+
+        :param int matching_results: (optional) The number of matching results for
+               the document query.
+        :param List[DocumentDetails] documents: (optional) An array that lists the
+               documents in a collection. Only the document ID of each document is
+               returned in the list. You can use the [Get document](#getdocument) method
+               to get more information about an individual document.
+        """
+        self.matching_results = matching_results
+        self.documents = documents
+
+    @classmethod
+    def from_dict(cls, _dict: Dict) -> 'ListDocumentsResponse':
+        """Initialize a ListDocumentsResponse object from a json dictionary."""
+        args = {}
+        if 'matching_results' in _dict:
+            args['matching_results'] = _dict.get('matching_results')
+        if 'documents' in _dict:
+            args['documents'] = [
+                DocumentDetails.from_dict(x) for x in _dict.get('documents')
+            ]
+        return cls(**args)
+
+    @classmethod
+    def _from_dict(cls, _dict):
+        """Initialize a ListDocumentsResponse object from a json dictionary."""
+        return cls.from_dict(_dict)
+
+    def to_dict(self) -> Dict:
+        """Return a json dictionary representing this model."""
+        _dict = {}
+        if hasattr(self,
+                   'matching_results') and self.matching_results is not None:
+            _dict['matching_results'] = self.matching_results
+        if hasattr(self, 'documents') and self.documents is not None:
+            _dict['documents'] = [x.to_dict() for x in self.documents]
+        return _dict
+
+    def _to_dict(self):
+        """Return a json dictionary representing this model."""
+        return self.to_dict()
+
+    def __str__(self) -> str:
+        """Return a `str` version of this ListDocumentsResponse object."""
+        return json.dumps(self.to_dict(), indent=2)
+
+    def __eq__(self, other: 'ListDocumentsResponse') -> bool:
+        """Return `true` when self and other are equal, false otherwise."""
+        if not isinstance(other, self.__class__):
+            return False
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other: 'ListDocumentsResponse') -> bool:
+        """Return `true` when self and other are not equal, false otherwise."""
+        return not self == other
+
+
 class ListFieldsResponse():
     """
     The list of fetched fields.
@@ -3995,7 +6762,6 @@ class ListFieldsResponse():
     :attr List[Field] fields: (optional) An array that contains information about
           each field in the collections.
     """
-
     def __init__(self, *, fields: List['Field'] = None) -> None:
         """
         Initialize a ListFieldsResponse object.
@@ -4050,7 +6816,6 @@ class ListProjectsResponse():
 
     :attr List[ProjectListDetails] projects: (optional) An array of project details.
     """
-
     def __init__(self, *, projects: List['ProjectListDetails'] = None) -> None:
         """
         Initialize a ListProjectsResponse object.
@@ -4101,6 +6866,188 @@ class ListProjectsResponse():
         return not self == other
 
 
+class ModelEvaluationMacroAverage():
+    """
+    A macro-average computes metric independently for each class and then takes the
+    average. Class refers to the classification label that is specified in the
+    **answer_field**.
+
+    :attr float precision: A metric that measures how many of the overall documents
+          are classified correctly.
+    :attr float recall: A metric that measures how often documents that should be
+          classified into certain classes are classified into those classes.
+    :attr float f1: A metric that measures whether the optimal balance between
+          precision and recall is reached. The F1 score can be interpreted as a weighted
+          average of the precision and recall values. An F1 score reaches its best value
+          at 1 and worst value at 0.
+    """
+    def __init__(self, precision: float, recall: float, f1: float) -> None:
+        """
+        Initialize a ModelEvaluationMacroAverage object.
+
+        :param float precision: A metric that measures how many of the overall
+               documents are classified correctly.
+        :param float recall: A metric that measures how often documents that should
+               be classified into certain classes are classified into those classes.
+        :param float f1: A metric that measures whether the optimal balance between
+               precision and recall is reached. The F1 score can be interpreted as a
+               weighted average of the precision and recall values. An F1 score reaches
+               its best value at 1 and worst value at 0.
+        """
+        self.precision = precision
+        self.recall = recall
+        self.f1 = f1
+
+    @classmethod
+    def from_dict(cls, _dict: Dict) -> 'ModelEvaluationMacroAverage':
+        """Initialize a ModelEvaluationMacroAverage object from a json dictionary."""
+        args = {}
+        if 'precision' in _dict:
+            args['precision'] = _dict.get('precision')
+        else:
+            raise ValueError(
+                'Required property \'precision\' not present in ModelEvaluationMacroAverage JSON'
+            )
+        if 'recall' in _dict:
+            args['recall'] = _dict.get('recall')
+        else:
+            raise ValueError(
+                'Required property \'recall\' not present in ModelEvaluationMacroAverage JSON'
+            )
+        if 'f1' in _dict:
+            args['f1'] = _dict.get('f1')
+        else:
+            raise ValueError(
+                'Required property \'f1\' not present in ModelEvaluationMacroAverage JSON'
+            )
+        return cls(**args)
+
+    @classmethod
+    def _from_dict(cls, _dict):
+        """Initialize a ModelEvaluationMacroAverage object from a json dictionary."""
+        return cls.from_dict(_dict)
+
+    def to_dict(self) -> Dict:
+        """Return a json dictionary representing this model."""
+        _dict = {}
+        if hasattr(self, 'precision') and self.precision is not None:
+            _dict['precision'] = self.precision
+        if hasattr(self, 'recall') and self.recall is not None:
+            _dict['recall'] = self.recall
+        if hasattr(self, 'f1') and self.f1 is not None:
+            _dict['f1'] = self.f1
+        return _dict
+
+    def _to_dict(self):
+        """Return a json dictionary representing this model."""
+        return self.to_dict()
+
+    def __str__(self) -> str:
+        """Return a `str` version of this ModelEvaluationMacroAverage object."""
+        return json.dumps(self.to_dict(), indent=2)
+
+    def __eq__(self, other: 'ModelEvaluationMacroAverage') -> bool:
+        """Return `true` when self and other are equal, false otherwise."""
+        if not isinstance(other, self.__class__):
+            return False
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other: 'ModelEvaluationMacroAverage') -> bool:
+        """Return `true` when self and other are not equal, false otherwise."""
+        return not self == other
+
+
+class ModelEvaluationMicroAverage():
+    """
+    A micro-average aggregates the contributions of all classes to compute the average
+    metric. Classes refers to the classification labels that are specified in the
+    **answer_field**.
+
+    :attr float precision: A metric that measures how many of the overall documents
+          are classified correctly.
+    :attr float recall: A metric that measures how often documents that should be
+          classified into certain classes are classified into those classes.
+    :attr float f1: A metric that measures whether the optimal balance between
+          precision and recall is reached. The F1 score can be interpreted as a weighted
+          average of the precision and recall values. An F1 score reaches its best value
+          at 1 and worst value at 0.
+    """
+    def __init__(self, precision: float, recall: float, f1: float) -> None:
+        """
+        Initialize a ModelEvaluationMicroAverage object.
+
+        :param float precision: A metric that measures how many of the overall
+               documents are classified correctly.
+        :param float recall: A metric that measures how often documents that should
+               be classified into certain classes are classified into those classes.
+        :param float f1: A metric that measures whether the optimal balance between
+               precision and recall is reached. The F1 score can be interpreted as a
+               weighted average of the precision and recall values. An F1 score reaches
+               its best value at 1 and worst value at 0.
+        """
+        self.precision = precision
+        self.recall = recall
+        self.f1 = f1
+
+    @classmethod
+    def from_dict(cls, _dict: Dict) -> 'ModelEvaluationMicroAverage':
+        """Initialize a ModelEvaluationMicroAverage object from a json dictionary."""
+        args = {}
+        if 'precision' in _dict:
+            args['precision'] = _dict.get('precision')
+        else:
+            raise ValueError(
+                'Required property \'precision\' not present in ModelEvaluationMicroAverage JSON'
+            )
+        if 'recall' in _dict:
+            args['recall'] = _dict.get('recall')
+        else:
+            raise ValueError(
+                'Required property \'recall\' not present in ModelEvaluationMicroAverage JSON'
+            )
+        if 'f1' in _dict:
+            args['f1'] = _dict.get('f1')
+        else:
+            raise ValueError(
+                'Required property \'f1\' not present in ModelEvaluationMicroAverage JSON'
+            )
+        return cls(**args)
+
+    @classmethod
+    def _from_dict(cls, _dict):
+        """Initialize a ModelEvaluationMicroAverage object from a json dictionary."""
+        return cls.from_dict(_dict)
+
+    def to_dict(self) -> Dict:
+        """Return a json dictionary representing this model."""
+        _dict = {}
+        if hasattr(self, 'precision') and self.precision is not None:
+            _dict['precision'] = self.precision
+        if hasattr(self, 'recall') and self.recall is not None:
+            _dict['recall'] = self.recall
+        if hasattr(self, 'f1') and self.f1 is not None:
+            _dict['f1'] = self.f1
+        return _dict
+
+    def _to_dict(self):
+        """Return a json dictionary representing this model."""
+        return self.to_dict()
+
+    def __str__(self) -> str:
+        """Return a `str` version of this ModelEvaluationMicroAverage object."""
+        return json.dumps(self.to_dict(), indent=2)
+
+    def __eq__(self, other: 'ModelEvaluationMicroAverage') -> bool:
+        """Return `true` when self and other are equal, false otherwise."""
+        if not isinstance(other, self.__class__):
+            return False
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other: 'ModelEvaluationMicroAverage') -> bool:
+        """Return `true` when self and other are not equal, false otherwise."""
+        return not self == other
+
+
 class Notice():
     """
     A notice produced for the collection.
@@ -4108,7 +7055,8 @@ class Notice():
     :attr str notice_id: (optional) Identifies the notice. Many notices might have
           the same ID. This field exists so that user applications can programmatically
           identify a notice and take automatic corrective action. Typical notice IDs
-          include: `index_failed`, `index_failed_too_many_requests`,
+          include:
+          `index_failed`, `index_failed_too_many_requests`,
           `index_failed_incompatible_field`, `index_failed_cluster_unavailable`,
           `ingestion_timeout`, `ingestion_error`, `bad_request`, `internal_error`,
           `missing_model`, `unsupported_model`,
@@ -4118,7 +7066,7 @@ class Notice():
           `smart_document_understanding_failed_warning`,
           `smart_document_understanding_page_error`,
           `smart_document_understanding_page_warning`. **Note:** This is not a complete
-          list, other values might be returned.
+          list. Other values might be returned.
     :attr datetime created: (optional) The creation date of the collection in the
           format yyyy-MM-dd'T'HH:mm:ss.SSS'Z'.
     :attr str document_id: (optional) Unique identifier of the document.
@@ -4130,7 +7078,6 @@ class Notice():
           occurred.
     :attr str description: (optional) The description of the notice.
     """
-
     def __init__(self,
                  *,
                  notice_id: str = None,
@@ -4232,6 +7179,110 @@ class Notice():
         ERROR = 'error'
 
 
+class PerClassModelEvaluation():
+    """
+    An object that measures the metrics from a training run for each classification label
+    separately.
+
+    :attr str name: Class name. Each class name is derived from a value in the
+          **answer_field**.
+    :attr float precision: A metric that measures how many of the overall documents
+          are classified correctly.
+    :attr float recall: A metric that measures how often documents that should be
+          classified into certain classes are classified into those classes.
+    :attr float f1: A metric that measures whether the optimal balance between
+          precision and recall is reached. The F1 score can be interpreted as a weighted
+          average of the precision and recall values. An F1 score reaches its best value
+          at 1 and worst value at 0.
+    """
+    def __init__(self, name: str, precision: float, recall: float,
+                 f1: float) -> None:
+        """
+        Initialize a PerClassModelEvaluation object.
+
+        :param str name: Class name. Each class name is derived from a value in the
+               **answer_field**.
+        :param float precision: A metric that measures how many of the overall
+               documents are classified correctly.
+        :param float recall: A metric that measures how often documents that should
+               be classified into certain classes are classified into those classes.
+        :param float f1: A metric that measures whether the optimal balance between
+               precision and recall is reached. The F1 score can be interpreted as a
+               weighted average of the precision and recall values. An F1 score reaches
+               its best value at 1 and worst value at 0.
+        """
+        self.name = name
+        self.precision = precision
+        self.recall = recall
+        self.f1 = f1
+
+    @classmethod
+    def from_dict(cls, _dict: Dict) -> 'PerClassModelEvaluation':
+        """Initialize a PerClassModelEvaluation object from a json dictionary."""
+        args = {}
+        if 'name' in _dict:
+            args['name'] = _dict.get('name')
+        else:
+            raise ValueError(
+                'Required property \'name\' not present in PerClassModelEvaluation JSON'
+            )
+        if 'precision' in _dict:
+            args['precision'] = _dict.get('precision')
+        else:
+            raise ValueError(
+                'Required property \'precision\' not present in PerClassModelEvaluation JSON'
+            )
+        if 'recall' in _dict:
+            args['recall'] = _dict.get('recall')
+        else:
+            raise ValueError(
+                'Required property \'recall\' not present in PerClassModelEvaluation JSON'
+            )
+        if 'f1' in _dict:
+            args['f1'] = _dict.get('f1')
+        else:
+            raise ValueError(
+                'Required property \'f1\' not present in PerClassModelEvaluation JSON'
+            )
+        return cls(**args)
+
+    @classmethod
+    def _from_dict(cls, _dict):
+        """Initialize a PerClassModelEvaluation object from a json dictionary."""
+        return cls.from_dict(_dict)
+
+    def to_dict(self) -> Dict:
+        """Return a json dictionary representing this model."""
+        _dict = {}
+        if hasattr(self, 'name') and self.name is not None:
+            _dict['name'] = self.name
+        if hasattr(self, 'precision') and self.precision is not None:
+            _dict['precision'] = self.precision
+        if hasattr(self, 'recall') and self.recall is not None:
+            _dict['recall'] = self.recall
+        if hasattr(self, 'f1') and self.f1 is not None:
+            _dict['f1'] = self.f1
+        return _dict
+
+    def _to_dict(self):
+        """Return a json dictionary representing this model."""
+        return self.to_dict()
+
+    def __str__(self) -> str:
+        """Return a `str` version of this PerClassModelEvaluation object."""
+        return json.dumps(self.to_dict(), indent=2)
+
+    def __eq__(self, other: 'PerClassModelEvaluation') -> bool:
+        """Return `true` when self and other are equal, false otherwise."""
+        if not isinstance(other, self.__class__):
+            return False
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other: 'PerClassModelEvaluation') -> bool:
+        """Return `true` when self and other are not equal, false otherwise."""
+        return not self == other
+
+
 class ProjectDetails():
     """
     Detailed information about the specified project.
@@ -4250,16 +7301,16 @@ class ProjectDetails():
     :attr DefaultQueryParams default_query_parameters: (optional) Default query
           parameters for this project.
     """
-
-    def __init__(self,
-                 *,
-                 project_id: str = None,
-                 name: str = None,
-                 type: str = None,
-                 relevancy_training_status:
-                 'ProjectListDetailsRelevancyTrainingStatus' = None,
-                 collection_count: int = None,
-                 default_query_parameters: 'DefaultQueryParams' = None) -> None:
+    def __init__(
+            self,
+            *,
+            project_id: str = None,
+            name: str = None,
+            type: str = None,
+            relevancy_training_status:
+        'ProjectListDetailsRelevancyTrainingStatus' = None,
+            collection_count: int = None,
+            default_query_parameters: 'DefaultQueryParams' = None) -> None:
         """
         Initialize a ProjectDetails object.
 
@@ -4318,7 +7369,7 @@ class ProjectDetails():
         if hasattr(self, 'type') and self.type is not None:
             _dict['type'] = self.type
         if hasattr(self, 'relevancy_training_status'
-                  ) and self.relevancy_training_status is not None:
+                   ) and self.relevancy_training_status is not None:
             _dict[
                 'relevancy_training_status'] = self.relevancy_training_status.to_dict(
                 )
@@ -4326,7 +7377,7 @@ class ProjectDetails():
                 self, 'collection_count') is not None:
             _dict['collection_count'] = getattr(self, 'collection_count')
         if hasattr(self, 'default_query_parameters'
-                  ) and self.default_query_parameters is not None:
+                   ) and self.default_query_parameters is not None:
             _dict[
                 'default_query_parameters'] = self.default_query_parameters.to_dict(
                 )
@@ -4381,7 +7432,6 @@ class ProjectListDetails():
     :attr int collection_count: (optional) The number of collections configured in
           this project.
     """
-
     def __init__(self,
                  *,
                  project_id: str = None,
@@ -4442,7 +7492,7 @@ class ProjectListDetails():
         if hasattr(self, 'type') and self.type is not None:
             _dict['type'] = self.type
         if hasattr(self, 'relevancy_training_status'
-                  ) and self.relevancy_training_status is not None:
+                   ) and self.relevancy_training_status is not None:
             _dict[
                 'relevancy_training_status'] = self.relevancy_training_status.to_dict(
                 )
@@ -4505,7 +7555,6 @@ class ProjectListDetailsRelevancyTrainingStatus():
     :attr bool minimum_queries_added: (optional) When `true`, the minimum number of
           queries required to train has been met.
     """
-
     def __init__(self,
                  *,
                  data_updated: str = None,
@@ -4562,7 +7611,8 @@ class ProjectListDetailsRelevancyTrainingStatus():
         if 'processing' in _dict:
             args['processing'] = _dict.get('processing')
         if 'minimum_examples_added' in _dict:
-            args['minimum_examples_added'] = _dict.get('minimum_examples_added')
+            args['minimum_examples_added'] = _dict.get(
+                'minimum_examples_added')
         if 'successfully_trained' in _dict:
             args['successfully_trained'] = _dict.get('successfully_trained')
         if 'available' in _dict:
@@ -4586,23 +7636,23 @@ class ProjectListDetailsRelevancyTrainingStatus():
         if hasattr(self, 'total_examples') and self.total_examples is not None:
             _dict['total_examples'] = self.total_examples
         if hasattr(self, 'sufficient_label_diversity'
-                  ) and self.sufficient_label_diversity is not None:
+                   ) and self.sufficient_label_diversity is not None:
             _dict[
                 'sufficient_label_diversity'] = self.sufficient_label_diversity
         if hasattr(self, 'processing') and self.processing is not None:
             _dict['processing'] = self.processing
         if hasattr(self, 'minimum_examples_added'
-                  ) and self.minimum_examples_added is not None:
+                   ) and self.minimum_examples_added is not None:
             _dict['minimum_examples_added'] = self.minimum_examples_added
         if hasattr(self, 'successfully_trained'
-                  ) and self.successfully_trained is not None:
+                   ) and self.successfully_trained is not None:
             _dict['successfully_trained'] = self.successfully_trained
         if hasattr(self, 'available') and self.available is not None:
             _dict['available'] = self.available
         if hasattr(self, 'notices') and self.notices is not None:
             _dict['notices'] = self.notices
         if hasattr(self, 'minimum_queries_added'
-                  ) and self.minimum_queries_added is not None:
+                   ) and self.minimum_queries_added is not None:
             _dict['minimum_queries_added'] = self.minimum_queries_added
         return _dict
 
@@ -4635,7 +7685,6 @@ class QueryAggregation():
           histogram, timeslice, nested, filter, min, max, sum, average, unique_count, and
           top_hits.
     """
-
     def __init__(self, type: str) -> None:
         """
         Initialize a QueryAggregation object.
@@ -4737,7 +7786,6 @@ class QueryGroupByAggregationResult():
     :attr List[QueryAggregation] aggregations: (optional) An array of
           sub-aggregations.
     """
-
     def __init__(self,
                  key: str,
                  matching_results: int,
@@ -4796,7 +7844,8 @@ class QueryGroupByAggregationResult():
                 'estimated_matching_documents')
         if 'aggregations' in _dict:
             args['aggregations'] = [
-                QueryAggregation.from_dict(x) for x in _dict.get('aggregations')
+                QueryAggregation.from_dict(x)
+                for x in _dict.get('aggregations')
             ]
         return cls(**args)
 
@@ -4816,10 +7865,10 @@ class QueryGroupByAggregationResult():
         if hasattr(self, 'relevancy') and self.relevancy is not None:
             _dict['relevancy'] = self.relevancy
         if hasattr(self, 'total_matching_documents'
-                  ) and self.total_matching_documents is not None:
+                   ) and self.total_matching_documents is not None:
             _dict['total_matching_documents'] = self.total_matching_documents
         if hasattr(self, 'estimated_matching_documents'
-                  ) and self.estimated_matching_documents is not None:
+                   ) and self.estimated_matching_documents is not None:
             _dict[
                 'estimated_matching_documents'] = self.estimated_matching_documents
         if hasattr(self, 'aggregations') and self.aggregations is not None:
@@ -4855,7 +7904,6 @@ class QueryHistogramAggregationResult():
     :attr List[QueryAggregation] aggregations: (optional) An array of
           sub-aggregations.
     """
-
     def __init__(self,
                  key: int,
                  matching_results: int,
@@ -4892,7 +7940,8 @@ class QueryHistogramAggregationResult():
             )
         if 'aggregations' in _dict:
             args['aggregations'] = [
-                QueryAggregation.from_dict(x) for x in _dict.get('aggregations')
+                QueryAggregation.from_dict(x)
+                for x in _dict.get('aggregations')
             ]
         return cls(**args)
 
@@ -4946,11 +7995,11 @@ class QueryLargePassages():
           regardless of the document quality and returns them in a separate `passages`
           field in the response.
     :attr int max_per_document: (optional) Maximum number of passages to return per
-          document in the result. Ignored if `passages.per_document` is `false`.
+          document in the result. Ignored if **passages.per_document** is `false`.
     :attr List[str] fields: (optional) A list of fields to extract passages from. If
           this parameter is an empty list, then all root-level fields are included.
     :attr int count: (optional) The maximum number of passages to return. Ignored if
-          `passages.per_document` is `true`.
+          **passages.per_document** is `true`.
     :attr int characters: (optional) The approximate number of characters that any
           one passage will have.
     :attr bool find_answers: (optional) When true, `answer` objects are returned as
@@ -4973,7 +8022,6 @@ class QueryLargePassages():
     :attr int max_answers_per_passage: (optional) The number of `answer` objects to
           return per passage if the **find_answers** parmeter is specified as `true`.
     """
-
     def __init__(self,
                  *,
                  enabled: bool = None,
@@ -4997,13 +8045,13 @@ class QueryLargePassages():
                regardless of the document quality and returns them in a separate
                `passages` field in the response.
         :param int max_per_document: (optional) Maximum number of passages to
-               return per document in the result. Ignored if `passages.per_document` is
+               return per document in the result. Ignored if **passages.per_document** is
                `false`.
         :param List[str] fields: (optional) A list of fields to extract passages
                from. If this parameter is an empty list, then all root-level fields are
                included.
         :param int count: (optional) The maximum number of passages to return.
-               Ignored if `passages.per_document` is `true`.
+               Ignored if **passages.per_document** is `true`.
         :param int characters: (optional) The approximate number of characters that
                any one passage will have.
         :param bool find_answers: (optional) When true, `answer` objects are
@@ -5085,7 +8133,7 @@ class QueryLargePassages():
         if hasattr(self, 'find_answers') and self.find_answers is not None:
             _dict['find_answers'] = self.find_answers
         if hasattr(self, 'max_answers_per_passage'
-                  ) and self.max_answers_per_passage is not None:
+                   ) and self.max_answers_per_passage is not None:
             _dict['max_answers_per_passage'] = self.max_answers_per_passage
         return _dict
 
@@ -5108,15 +8156,98 @@ class QueryLargePassages():
         return not self == other
 
 
+class QueryLargeSimilar():
+    """
+    Finds results from documents that are similar to documents of interest. Use this
+    parameter to add a *More like these* function to your search. You can include this
+    parameter with or without a **query**, **filter** or **natural_language_query**
+    parameter.
+
+    :attr bool enabled: (optional) When `true`, includes documents in the query
+          results that are similar to documents you specify.
+    :attr List[str] document_ids: (optional) The list of documents of interest.
+          Required if `enabled` is `true`.
+    :attr List[str] fields: (optional) Looks for similarities in the specified
+          subset of fields in the documents. If not specified, all of the document fields
+          are used.
+    """
+    def __init__(self,
+                 *,
+                 enabled: bool = None,
+                 document_ids: List[str] = None,
+                 fields: List[str] = None) -> None:
+        """
+        Initialize a QueryLargeSimilar object.
+
+        :param bool enabled: (optional) When `true`, includes documents in the
+               query results that are similar to documents you specify.
+        :param List[str] document_ids: (optional) The list of documents of
+               interest. Required if `enabled` is `true`.
+        :param List[str] fields: (optional) Looks for similarities in the specified
+               subset of fields in the documents. If not specified, all of the document
+               fields are used.
+        """
+        self.enabled = enabled
+        self.document_ids = document_ids
+        self.fields = fields
+
+    @classmethod
+    def from_dict(cls, _dict: Dict) -> 'QueryLargeSimilar':
+        """Initialize a QueryLargeSimilar object from a json dictionary."""
+        args = {}
+        if 'enabled' in _dict:
+            args['enabled'] = _dict.get('enabled')
+        if 'document_ids' in _dict:
+            args['document_ids'] = _dict.get('document_ids')
+        if 'fields' in _dict:
+            args['fields'] = _dict.get('fields')
+        return cls(**args)
+
+    @classmethod
+    def _from_dict(cls, _dict):
+        """Initialize a QueryLargeSimilar object from a json dictionary."""
+        return cls.from_dict(_dict)
+
+    def to_dict(self) -> Dict:
+        """Return a json dictionary representing this model."""
+        _dict = {}
+        if hasattr(self, 'enabled') and self.enabled is not None:
+            _dict['enabled'] = self.enabled
+        if hasattr(self, 'document_ids') and self.document_ids is not None:
+            _dict['document_ids'] = self.document_ids
+        if hasattr(self, 'fields') and self.fields is not None:
+            _dict['fields'] = self.fields
+        return _dict
+
+    def _to_dict(self):
+        """Return a json dictionary representing this model."""
+        return self.to_dict()
+
+    def __str__(self) -> str:
+        """Return a `str` version of this QueryLargeSimilar object."""
+        return json.dumps(self.to_dict(), indent=2)
+
+    def __eq__(self, other: 'QueryLargeSimilar') -> bool:
+        """Return `true` when self and other are equal, false otherwise."""
+        if not isinstance(other, self.__class__):
+            return False
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other: 'QueryLargeSimilar') -> bool:
+        """Return `true` when self and other are not equal, false otherwise."""
+        return not self == other
+
+
 class QueryLargeSuggestedRefinements():
     """
-    Configuration for suggested refinements. Available with Premium plans only.
+    Configuration for suggested refinements.
+    **Note**: The **suggested_refinements** parameter that identified dynamic facets from
+    the data is deprecated.
 
     :attr bool enabled: (optional) Whether to perform suggested refinements.
     :attr int count: (optional) Maximum number of suggested refinements texts to be
           returned. The maximum is `100`.
     """
-
     def __init__(self, *, enabled: bool = None, count: int = None) -> None:
         """
         Initialize a QueryLargeSuggestedRefinements object.
@@ -5178,7 +8309,6 @@ class QueryLargeTableResults():
     :attr bool enabled: (optional) Whether to enable table retrieval.
     :attr int count: (optional) Maximum number of tables to return.
     """
-
     def __init__(self, *, enabled: bool = None, count: int = None) -> None:
         """
         Initialize a QueryLargeTableResults object.
@@ -5240,7 +8370,6 @@ class QueryNoticesResponse():
     :attr List[Notice] notices: (optional) Array of document results that match the
           query.
     """
-
     def __init__(self,
                  *,
                  matching_results: int = None,
@@ -5316,22 +8445,23 @@ class QueryResponse():
     :attr str suggested_query: (optional) Suggested correction to the submitted
           **natural_language_query** value.
     :attr List[QuerySuggestedRefinement] suggested_refinements: (optional) Array of
-          suggested refinements.
+          suggested refinements. **Note**: The `suggested_refinements` parameter that
+          identified dynamic facets from the data is deprecated.
     :attr List[QueryTableResult] table_results: (optional) Array of table results.
     :attr List[QueryResponsePassage] passages: (optional) Passages that best match
           the query from across all of the collections in the project.
     """
-
-    def __init__(self,
-                 *,
-                 matching_results: int = None,
-                 results: List['QueryResult'] = None,
-                 aggregations: List['QueryAggregation'] = None,
-                 retrieval_details: 'RetrievalDetails' = None,
-                 suggested_query: str = None,
-                 suggested_refinements: List['QuerySuggestedRefinement'] = None,
-                 table_results: List['QueryTableResult'] = None,
-                 passages: List['QueryResponsePassage'] = None) -> None:
+    def __init__(
+            self,
+            *,
+            matching_results: int = None,
+            results: List['QueryResult'] = None,
+            aggregations: List['QueryAggregation'] = None,
+            retrieval_details: 'RetrievalDetails' = None,
+            suggested_query: str = None,
+            suggested_refinements: List['QuerySuggestedRefinement'] = None,
+            table_results: List['QueryTableResult'] = None,
+            passages: List['QueryResponsePassage'] = None) -> None:
         """
         Initialize a QueryResponse object.
 
@@ -5347,7 +8477,8 @@ class QueryResponse():
         :param str suggested_query: (optional) Suggested correction to the
                submitted **natural_language_query** value.
         :param List[QuerySuggestedRefinement] suggested_refinements: (optional)
-               Array of suggested refinements.
+               Array of suggested refinements. **Note**: The `suggested_refinements`
+               parameter that identified dynamic facets from the data is deprecated.
         :param List[QueryTableResult] table_results: (optional) Array of table
                results.
         :param List[QueryResponsePassage] passages: (optional) Passages that best
@@ -5374,7 +8505,8 @@ class QueryResponse():
             ]
         if 'aggregations' in _dict:
             args['aggregations'] = [
-                QueryAggregation.from_dict(x) for x in _dict.get('aggregations')
+                QueryAggregation.from_dict(x)
+                for x in _dict.get('aggregations')
             ]
         if 'retrieval_details' in _dict:
             args['retrieval_details'] = RetrievalDetails.from_dict(
@@ -5393,7 +8525,8 @@ class QueryResponse():
             ]
         if 'passages' in _dict:
             args['passages'] = [
-                QueryResponsePassage.from_dict(x) for x in _dict.get('passages')
+                QueryResponsePassage.from_dict(x)
+                for x in _dict.get('passages')
             ]
         return cls(**args)
 
@@ -5419,7 +8552,7 @@ class QueryResponse():
                    'suggested_query') and self.suggested_query is not None:
             _dict['suggested_query'] = self.suggested_query
         if hasattr(self, 'suggested_refinements'
-                  ) and self.suggested_refinements is not None:
+                   ) and self.suggested_refinements is not None:
             _dict['suggested_refinements'] = [
                 x.to_dict() for x in self.suggested_refinements
             ]
@@ -5454,7 +8587,9 @@ class QueryResponsePassage():
 
     :attr str passage_text: (optional) The content of the extracted passage.
     :attr float passage_score: (optional) The confidence score of the passage's
-          analysis. A higher score indicates greater confidence.
+          analysis. A higher score indicates greater confidence. The score is used to rank
+          the passages from all documents and is returned only if
+          **passages.per_document** is `false`.
     :attr str document_id: (optional) The unique identifier of the ingested
           document.
     :attr str collection_id: (optional) The unique identifier of the collection.
@@ -5469,7 +8604,6 @@ class QueryResponsePassage():
     :attr List[ResultPassageAnswer] answers: (optional) An array of extracted
           answers to the specified query.
     """
-
     def __init__(self,
                  *,
                  passage_text: str = None,
@@ -5486,7 +8620,9 @@ class QueryResponsePassage():
 
         :param str passage_text: (optional) The content of the extracted passage.
         :param float passage_score: (optional) The confidence score of the
-               passage's analysis. A higher score indicates greater confidence.
+               passage's analysis. A higher score indicates greater confidence. The score
+               is used to rank the passages from all documents and is returned only if
+               **passages.per_document** is `false`.
         :param str document_id: (optional) The unique identifier of the ingested
                document.
         :param str collection_id: (optional) The unique identifier of the
@@ -5649,7 +8785,8 @@ class QueryResult():
                 for x in _dict.get('document_passages')
             ]
         args.update(
-            {k: v for (k, v) in _dict.items() if k not in cls._properties})
+            {k: v
+             for (k, v) in _dict.items() if k not in cls._properties})
         return cls(**args)
 
     @classmethod
@@ -5673,7 +8810,8 @@ class QueryResult():
                 x.to_dict() for x in self.document_passages
             ]
         for _key in [
-                k for k in vars(self).keys() if k not in QueryResult._properties
+                k for k in vars(self).keys()
+                if k not in QueryResult._properties
         ]:
             if getattr(self, _key, None) is not None:
                 _dict[_key] = getattr(self, _key)
@@ -5688,7 +8826,8 @@ class QueryResult():
         _dict = {}
 
         for _key in [
-                k for k in vars(self).keys() if k not in QueryResult._properties
+                k for k in vars(self).keys()
+                if k not in QueryResult._properties
         ]:
             _dict[_key] = getattr(self, _key)
         return _dict
@@ -5696,7 +8835,8 @@ class QueryResult():
     def set_properties(self, _dict: dict):
         """Set a dictionary of arbitrary properties to this instance of QueryResult"""
         for _key in [
-                k for k in vars(self).keys() if k not in QueryResult._properties
+                k for k in vars(self).keys()
+                if k not in QueryResult._properties
         ]:
             delattr(self, _key)
 
@@ -5735,7 +8875,6 @@ class QueryResultMetadata():
           field is only returned if the **natural_language_query** parameter is specified
           in the query.
     """
-
     def __init__(self,
                  collection_id: str,
                  *,
@@ -5786,7 +8925,7 @@ class QueryResultMetadata():
         """Return a json dictionary representing this model."""
         _dict = {}
         if hasattr(self, 'document_retrieval_source'
-                  ) and self.document_retrieval_source is not None:
+                   ) and self.document_retrieval_source is not None:
             _dict['document_retrieval_source'] = self.document_retrieval_source
         if hasattr(self, 'collection_id') and self.collection_id is not None:
             _dict['collection_id'] = self.collection_id
@@ -5836,7 +8975,6 @@ class QueryResultPassage():
     :attr List[ResultPassageAnswer] answers: (optional) An arry of extracted answers
           to the specified query.
     """
-
     def __init__(self,
                  *,
                  passage_text: str = None,
@@ -5930,11 +9068,11 @@ class QueryResultPassage():
 
 class QuerySuggestedRefinement():
     """
-    A suggested additional query term or terms user to filter results.
+    A suggested additional query term or terms user to filter results. **Note**: The
+    `suggested_refinements` parameter is deprecated.
 
     :attr str text: (optional) The text used to filter.
     """
-
     def __init__(self, *, text: str = None) -> None:
         """
         Initialize a QuerySuggestedRefinement object.
@@ -5997,7 +9135,6 @@ class QueryTableResult():
     :attr TableResultTable table: (optional) Full table object retrieved from Table
           Understanding Enrichment.
     """
-
     def __init__(self,
                  *,
                  table_id: str = None,
@@ -6105,7 +9242,6 @@ class QueryTermAggregationResult():
     :attr List[QueryAggregation] aggregations: (optional) An array of
           sub-aggregations.
     """
-
     def __init__(self,
                  key: str,
                  matching_results: int,
@@ -6164,7 +9300,8 @@ class QueryTermAggregationResult():
                 'estimated_matching_documents')
         if 'aggregations' in _dict:
             args['aggregations'] = [
-                QueryAggregation.from_dict(x) for x in _dict.get('aggregations')
+                QueryAggregation.from_dict(x)
+                for x in _dict.get('aggregations')
             ]
         return cls(**args)
 
@@ -6184,10 +9321,10 @@ class QueryTermAggregationResult():
         if hasattr(self, 'relevancy') and self.relevancy is not None:
             _dict['relevancy'] = self.relevancy
         if hasattr(self, 'total_matching_documents'
-                  ) and self.total_matching_documents is not None:
+                   ) and self.total_matching_documents is not None:
             _dict['total_matching_documents'] = self.total_matching_documents
         if hasattr(self, 'estimated_matching_documents'
-                  ) and self.estimated_matching_documents is not None:
+                   ) and self.estimated_matching_documents is not None:
             _dict[
                 'estimated_matching_documents'] = self.estimated_matching_documents
         if hasattr(self, 'aggregations') and self.aggregations is not None:
@@ -6226,7 +9363,6 @@ class QueryTimesliceAggregationResult():
     :attr List[QueryAggregation] aggregations: (optional) An array of
           sub-aggregations.
     """
-
     def __init__(self,
                  key_as_string: str,
                  key: int,
@@ -6274,7 +9410,8 @@ class QueryTimesliceAggregationResult():
             )
         if 'aggregations' in _dict:
             args['aggregations'] = [
-                QueryAggregation.from_dict(x) for x in _dict.get('aggregations')
+                QueryAggregation.from_dict(x)
+                for x in _dict.get('aggregations')
             ]
         return cls(**args)
 
@@ -6323,7 +9460,6 @@ class QueryTopHitsAggregationResult():
     :attr int matching_results: Number of matching results.
     :attr List[dict] hits: (optional) An array of the document results.
     """
-
     def __init__(self,
                  matching_results: int,
                  *,
@@ -6398,7 +9534,6 @@ class ResultPassageAnswer():
     :attr float confidence: (optional) An estimate of the probability that the
           answer is relevant.
     """
-
     def __init__(self,
                  *,
                  answer_text: str = None,
@@ -6484,7 +9619,6 @@ class RetrievalDetails():
           model is not used to return results, the **document_retrieval_strategy** is
           listed as `untrained`.
     """
-
     def __init__(self, *, document_retrieval_strategy: str = None) -> None:
         """
         Initialize a RetrievalDetails object.
@@ -6516,7 +9650,7 @@ class RetrievalDetails():
         """Return a json dictionary representing this model."""
         _dict = {}
         if hasattr(self, 'document_retrieval_strategy'
-                  ) and self.document_retrieval_strategy is not None:
+                   ) and self.document_retrieval_strategy is not None:
             _dict[
                 'document_retrieval_strategy'] = self.document_retrieval_strategy
         return _dict
@@ -6552,6 +9686,63 @@ class RetrievalDetails():
         RELEVANCY_TRAINING = 'relevancy_training'
 
 
+class StopWordList():
+    """
+    List of words to filter out of text that is submitted in queries.
+
+    :attr List[str] stopwords: List of stop words.
+    """
+    def __init__(self, stopwords: List[str]) -> None:
+        """
+        Initialize a StopWordList object.
+
+        :param List[str] stopwords: List of stop words.
+        """
+        self.stopwords = stopwords
+
+    @classmethod
+    def from_dict(cls, _dict: Dict) -> 'StopWordList':
+        """Initialize a StopWordList object from a json dictionary."""
+        args = {}
+        if 'stopwords' in _dict:
+            args['stopwords'] = _dict.get('stopwords')
+        else:
+            raise ValueError(
+                'Required property \'stopwords\' not present in StopWordList JSON'
+            )
+        return cls(**args)
+
+    @classmethod
+    def _from_dict(cls, _dict):
+        """Initialize a StopWordList object from a json dictionary."""
+        return cls.from_dict(_dict)
+
+    def to_dict(self) -> Dict:
+        """Return a json dictionary representing this model."""
+        _dict = {}
+        if hasattr(self, 'stopwords') and self.stopwords is not None:
+            _dict['stopwords'] = self.stopwords
+        return _dict
+
+    def _to_dict(self):
+        """Return a json dictionary representing this model."""
+        return self.to_dict()
+
+    def __str__(self) -> str:
+        """Return a `str` version of this StopWordList object."""
+        return json.dumps(self.to_dict(), indent=2)
+
+    def __eq__(self, other: 'StopWordList') -> bool:
+        """Return `true` when self and other are equal, false otherwise."""
+        if not isinstance(other, self.__class__):
+            return False
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other: 'StopWordList') -> bool:
+        """Return `true` when self and other are not equal, false otherwise."""
+        return not self == other
+
+
 class TableBodyCells():
     """
     Cells that are not table header, column header, or row header cells.
@@ -6585,7 +9776,6 @@ class TableBodyCells():
     :attr List[DocumentAttribute] attributes: (optional) A list of document
           attributes.
     """
-
     def __init__(self,
                  *,
                  cell_id: str = None,
@@ -6735,14 +9925,16 @@ class TableBodyCells():
                    'column_index_end') and self.column_index_end is not None:
             _dict['column_index_end'] = self.column_index_end
         if hasattr(self, 'row_header_ids') and self.row_header_ids is not None:
-            _dict['row_header_ids'] = [x.to_dict() for x in self.row_header_ids]
+            _dict['row_header_ids'] = [
+                x.to_dict() for x in self.row_header_ids
+            ]
         if hasattr(self,
                    'row_header_texts') and self.row_header_texts is not None:
             _dict['row_header_texts'] = [
                 x.to_dict() for x in self.row_header_texts
             ]
         if hasattr(self, 'row_header_texts_normalized'
-                  ) and self.row_header_texts_normalized is not None:
+                   ) and self.row_header_texts_normalized is not None:
             _dict['row_header_texts_normalized'] = [
                 x.to_dict() for x in self.row_header_texts_normalized
             ]
@@ -6751,14 +9943,13 @@ class TableBodyCells():
             _dict['column_header_ids'] = [
                 x.to_dict() for x in self.column_header_ids
             ]
-        if hasattr(
-                self,
-                'column_header_texts') and self.column_header_texts is not None:
+        if hasattr(self, 'column_header_texts'
+                   ) and self.column_header_texts is not None:
             _dict['column_header_texts'] = [
                 x.to_dict() for x in self.column_header_texts
             ]
         if hasattr(self, 'column_header_texts_normalized'
-                  ) and self.column_header_texts_normalized is not None:
+                   ) and self.column_header_texts_normalized is not None:
             _dict['column_header_texts_normalized'] = [
                 x.to_dict() for x in self.column_header_texts_normalized
             ]
@@ -6796,7 +9987,6 @@ class TableCellKey():
     :attr str text: (optional) The text content of the table cell without HTML
           markup.
     """
-
     def __init__(self,
                  *,
                  cell_id: str = None,
@@ -6875,7 +10065,6 @@ class TableCellValues():
     :attr str text: (optional) The text content of the table cell without HTML
           markup.
     """
-
     def __init__(self,
                  *,
                  cell_id: str = None,
@@ -6950,7 +10139,6 @@ class TableColumnHeaderIds():
 
     :attr str id: (optional) The `id` value of a column header.
     """
-
     def __init__(self, *, id: str = None) -> None:
         """
         Initialize a TableColumnHeaderIds object.
@@ -7005,7 +10193,6 @@ class TableColumnHeaderTexts():
 
     :attr str text: (optional) The `text` value of a column header.
     """
-
     def __init__(self, *, text: str = None) -> None:
         """
         Initialize a TableColumnHeaderTexts object.
@@ -7061,7 +10248,6 @@ class TableColumnHeaderTextsNormalized():
     :attr str text_normalized: (optional) The normalized version of a column header
           text.
     """
-
     def __init__(self, *, text_normalized: str = None) -> None:
         """
         Initialize a TableColumnHeaderTextsNormalized object.
@@ -7134,7 +10320,6 @@ class TableColumnHeaders():
     :attr int column_index_end: (optional) The `end` index of this cell's `column`
           location in the current table.
     """
-
     def __init__(self,
                  *,
                  cell_id: str = None,
@@ -7256,7 +10441,6 @@ class TableElementLocation():
     :attr int begin: The element's `begin` index.
     :attr int end: The element's `end` index.
     """
-
     def __init__(self, begin: int, end: int) -> None:
         """
         Initialize a TableElementLocation object.
@@ -7337,7 +10521,6 @@ class TableHeaders():
     :attr int column_index_end: (optional) The `end` index of this cell's `column`
           location in the current table.
     """
-
     def __init__(self,
                  *,
                  cell_id: str = None,
@@ -7449,7 +10632,6 @@ class TableKeyValuePairs():
     :attr List[TableCellValues] value: (optional) A list of values in a key-value
           pair.
     """
-
     def __init__(self,
                  *,
                  key: 'TableCellKey' = None,
@@ -7538,7 +10720,6 @@ class TableResultTable():
     :attr List[TableTextLocation] contexts: (optional) An array of lists of textual
           entries across the document related to the current table being parsed.
     """
-
     def __init__(self,
                  *,
                  location: 'TableElementLocation' = None,
@@ -7654,7 +10835,9 @@ class TableResultTable():
         if hasattr(self, 'row_headers') and self.row_headers is not None:
             _dict['row_headers'] = [x.to_dict() for x in self.row_headers]
         if hasattr(self, 'column_headers') and self.column_headers is not None:
-            _dict['column_headers'] = [x.to_dict() for x in self.column_headers]
+            _dict['column_headers'] = [
+                x.to_dict() for x in self.column_headers
+            ]
         if hasattr(self,
                    'key_value_pairs') and self.key_value_pairs is not None:
             _dict['key_value_pairs'] = [
@@ -7692,7 +10875,6 @@ class TableRowHeaderIds():
 
     :attr str id: (optional) The `id` values of a row header.
     """
-
     def __init__(self, *, id: str = None) -> None:
         """
         Initialize a TableRowHeaderIds object.
@@ -7747,7 +10929,6 @@ class TableRowHeaderTexts():
 
     :attr str text: (optional) The `text` value of a row header.
     """
-
     def __init__(self, *, text: str = None) -> None:
         """
         Initialize a TableRowHeaderTexts object.
@@ -7803,7 +10984,6 @@ class TableRowHeaderTextsNormalized():
     :attr str text_normalized: (optional) The normalized version of a row header
           text.
     """
-
     def __init__(self, *, text_normalized: str = None) -> None:
         """
         Initialize a TableRowHeaderTextsNormalized object.
@@ -7876,7 +11056,6 @@ class TableRowHeaders():
     :attr int column_index_end: (optional) The `end` index of this cell's `column`
           location in the current table.
     """
-
     def __init__(self,
                  *,
                  cell_id: str = None,
@@ -8000,7 +11179,6 @@ class TableTextLocation():
           identified element in the document, represented with two integers labeled
           `begin` and `end`.
     """
-
     def __init__(self,
                  *,
                  text: str = None,
@@ -8071,7 +11249,6 @@ class TrainingExample():
     :attr datetime created: (optional) The date and time the example was created.
     :attr datetime updated: (optional) The date and time the example was updated.
     """
-
     def __init__(self,
                  document_id: str,
                  collection_id: str,
@@ -8173,7 +11350,6 @@ class TrainingQuery():
     :attr datetime updated: (optional) The date and time the query was updated.
     :attr List[TrainingExample] examples: Array of training examples.
     """
-
     def __init__(self,
                  natural_language_query: str,
                  examples: List['TrainingExample'],
@@ -8205,7 +11381,8 @@ class TrainingQuery():
         if 'query_id' in _dict:
             args['query_id'] = _dict.get('query_id')
         if 'natural_language_query' in _dict:
-            args['natural_language_query'] = _dict.get('natural_language_query')
+            args['natural_language_query'] = _dict.get(
+                'natural_language_query')
         else:
             raise ValueError(
                 'Required property \'natural_language_query\' not present in TrainingQuery JSON'
@@ -8237,7 +11414,7 @@ class TrainingQuery():
         if hasattr(self, 'query_id') and getattr(self, 'query_id') is not None:
             _dict['query_id'] = getattr(self, 'query_id')
         if hasattr(self, 'natural_language_query'
-                  ) and self.natural_language_query is not None:
+                   ) and self.natural_language_query is not None:
             _dict['natural_language_query'] = self.natural_language_query
         if hasattr(self, 'filter') and self.filter is not None:
             _dict['filter'] = self.filter
@@ -8272,14 +11449,17 @@ class TrainingQuerySet():
     """
     Object specifying the training queries contained in the identified training set.
 
-    :attr List[TrainingQuery] queries: (optional) Array of training queries.
+    :attr List[TrainingQuery] queries: (optional) Array of training queries. At
+          least 50 queries are required for training to begin. A maximum of 10,000 queries
+          are returned.
     """
-
     def __init__(self, *, queries: List['TrainingQuery'] = None) -> None:
         """
         Initialize a TrainingQuerySet object.
 
         :param List[TrainingQuery] queries: (optional) Array of training queries.
+               At least 50 queries are required for training to begin. A maximum of 10,000
+               queries are returned.
         """
         self.queries = queries
 
@@ -8324,6 +11504,67 @@ class TrainingQuerySet():
         return not self == other
 
 
+class UpdateDocumentClassifier():
+    """
+    An object that contains a new name or description for a document classifier, updated
+    training data, or new or updated test data.
+
+    :attr str name: (optional) A new name for the classifier.
+    :attr str description: (optional) A new description for the classifier.
+    """
+    def __init__(self, *, name: str = None, description: str = None) -> None:
+        """
+        Initialize a UpdateDocumentClassifier object.
+
+        :param str name: (optional) A new name for the classifier.
+        :param str description: (optional) A new description for the classifier.
+        """
+        self.name = name
+        self.description = description
+
+    @classmethod
+    def from_dict(cls, _dict: Dict) -> 'UpdateDocumentClassifier':
+        """Initialize a UpdateDocumentClassifier object from a json dictionary."""
+        args = {}
+        if 'name' in _dict:
+            args['name'] = _dict.get('name')
+        if 'description' in _dict:
+            args['description'] = _dict.get('description')
+        return cls(**args)
+
+    @classmethod
+    def _from_dict(cls, _dict):
+        """Initialize a UpdateDocumentClassifier object from a json dictionary."""
+        return cls.from_dict(_dict)
+
+    def to_dict(self) -> Dict:
+        """Return a json dictionary representing this model."""
+        _dict = {}
+        if hasattr(self, 'name') and self.name is not None:
+            _dict['name'] = self.name
+        if hasattr(self, 'description') and self.description is not None:
+            _dict['description'] = self.description
+        return _dict
+
+    def _to_dict(self):
+        """Return a json dictionary representing this model."""
+        return self.to_dict()
+
+    def __str__(self) -> str:
+        """Return a `str` version of this UpdateDocumentClassifier object."""
+        return json.dumps(self.to_dict(), indent=2)
+
+    def __eq__(self, other: 'UpdateDocumentClassifier') -> bool:
+        """Return `true` when self and other are equal, false otherwise."""
+        if not isinstance(other, self.__class__):
+            return False
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other: 'UpdateDocumentClassifier') -> bool:
+        """Return `true` when self and other are not equal, false otherwise."""
+        return not self == other
+
+
 class QueryCalculationAggregation(QueryAggregation):
     """
     Returns a scalar calculation across all documents for the field specified. Possible
@@ -8332,7 +11573,6 @@ class QueryCalculationAggregation(QueryAggregation):
     :attr str field: The field to perform the calculation on.
     :attr float value: (optional) The value of the calculation.
     """
-
     def __init__(self, type: str, field: str, *, value: float = None) -> None:
         """
         Initialize a QueryCalculationAggregation object.
@@ -8412,7 +11652,6 @@ class QueryFilterAggregation(QueryAggregation):
     :attr List[QueryAggregation] aggregations: (optional) An array of
           sub-aggregations.
     """
-
     def __init__(self,
                  type: str,
                  match: str,
@@ -8460,7 +11699,8 @@ class QueryFilterAggregation(QueryAggregation):
             )
         if 'aggregations' in _dict:
             args['aggregations'] = [
-                QueryAggregation.from_dict(x) for x in _dict.get('aggregations')
+                QueryAggregation.from_dict(x)
+                for x in _dict.get('aggregations')
             ]
         return cls(**args)
 
@@ -8509,11 +11749,11 @@ class QueryGroupByAggregation(QueryAggregation):
     :attr List[QueryGroupByAggregationResult] results: (optional) Array of top
           values for the field.
     """
-
-    def __init__(self,
-                 type: str,
-                 *,
-                 results: List['QueryGroupByAggregationResult'] = None) -> None:
+    def __init__(
+            self,
+            type: str,
+            *,
+            results: List['QueryGroupByAggregationResult'] = None) -> None:
         """
         Initialize a QueryGroupByAggregation object.
 
@@ -8588,7 +11828,6 @@ class QueryHistogramAggregation(QueryAggregation):
     :attr List[QueryHistogramAggregationResult] results: (optional) Array of numeric
           intervals.
     """
-
     def __init__(
             self,
             type: str,
@@ -8698,7 +11937,6 @@ class QueryNestedAggregation(QueryAggregation):
     :attr List[QueryAggregation] aggregations: (optional) An array of
           sub-aggregations.
     """
-
     def __init__(self,
                  type: str,
                  path: str,
@@ -8747,7 +11985,8 @@ class QueryNestedAggregation(QueryAggregation):
             )
         if 'aggregations' in _dict:
             args['aggregations'] = [
-                QueryAggregation.from_dict(x) for x in _dict.get('aggregations')
+                QueryAggregation.from_dict(x)
+                for x in _dict.get('aggregations')
             ]
         return cls(**args)
 
@@ -8800,7 +12039,6 @@ class QueryTermAggregation(QueryAggregation):
     :attr List[QueryTermAggregationResult] results: (optional) Array of top values
           for the field.
     """
-
     def __init__(self,
                  type: str,
                  field: str,
@@ -8906,7 +12144,6 @@ class QueryTimesliceAggregation(QueryAggregation):
     :attr List[QueryTimesliceAggregationResult] results: (optional) Array of
           aggregation results.
     """
-
     def __init__(
             self,
             type: str,
@@ -9014,7 +12251,6 @@ class QueryTopHitsAggregation(QueryAggregation):
           aggregation.
     :attr QueryTopHitsAggregationResult hits: (optional)
     """
-
     def __init__(self,
                  type: str,
                  size: int,

--- a/ibm_watson/discovery_v2.py
+++ b/ibm_watson/discovery_v2.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 
-# (C) Copyright IBM Corp. 2022.
+# (C) Copyright IBM Corp. 2019-2022.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/unit/test_discovery_v2.py
+++ b/test/unit/test_discovery_v2.py
@@ -12,7 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """
 Unit Tests for DiscoveryV2
 """
@@ -33,10 +32,7 @@ from ibm_watson.discovery_v2 import *
 
 version = 'testString'
 
-_service = DiscoveryV2(
-    authenticator=NoAuthAuthenticator(),
-    version=version
-)
+_service = DiscoveryV2(authenticator=NoAuthAuthenticator(), version=version)
 
 _base_url = 'https://api.us-south.discovery.watson.cloud.ibm.com'
 _service.set_service_url(_base_url)
@@ -73,11 +69,11 @@ def preprocess_url(operation_path: str):
 ##############################################################################
 # region
 
+
 class TestListProjects():
     """
     Test Class for list_projects
     """
-
     @responses.activate
     def test_list_projects_all_params(self):
         """
@@ -94,7 +90,6 @@ class TestListProjects():
 
         # Invoke method
         response = _service.list_projects()
-
 
         # Check for correct operation
         assert len(responses.calls) == 1
@@ -124,10 +119,12 @@ class TestListProjects():
                       status=200)
 
         # Pass in all but one required param and check for a ValueError
-        req_param_dict = {
-        }
+        req_param_dict = {}
         for param in req_param_dict.keys():
-            req_copy = {key:val if key is not param else None for (key,val) in req_param_dict.items()}
+            req_copy = {
+                key: val if key is not param else None
+                for (key, val) in req_param_dict.items()
+            }
             with pytest.raises(ValueError):
                 _service.list_projects(**req_copy)
 
@@ -140,11 +137,11 @@ class TestListProjects():
         _service.disable_retries()
         self.test_list_projects_value_error()
 
+
 class TestCreateProject():
     """
     Test Class for create_project
     """
-
     @responses.activate
     def test_create_project_all_params(self):
         """
@@ -182,10 +179,13 @@ class TestCreateProject():
         # Construct a dict representation of a DefaultQueryParams model
         default_query_params_model = {}
         default_query_params_model['collection_ids'] = ['testString']
-        default_query_params_model['passages'] = default_query_params_passages_model
-        default_query_params_model['table_results'] = default_query_params_table_results_model
+        default_query_params_model[
+            'passages'] = default_query_params_passages_model
+        default_query_params_model[
+            'table_results'] = default_query_params_table_results_model
         default_query_params_model['aggregation'] = 'testString'
-        default_query_params_model['suggested_refinements'] = default_query_params_suggested_refinements_model
+        default_query_params_model[
+            'suggested_refinements'] = default_query_params_suggested_refinements_model
         default_query_params_model['spelling_suggestions'] = True
         default_query_params_model['highlight'] = True
         default_query_params_model['count'] = 38
@@ -202,8 +202,7 @@ class TestCreateProject():
             name,
             type,
             default_query_parameters=default_query_parameters,
-            headers={}
-        )
+            headers={})
 
         # Check for correct operation
         assert len(responses.calls) == 1
@@ -212,7 +211,8 @@ class TestCreateProject():
         req_body = json.loads(str(responses.calls[0].request.body, 'utf-8'))
         assert req_body['name'] == 'testString'
         assert req_body['type'] == 'document_retrieval'
-        assert req_body['default_query_parameters'] == default_query_params_model
+        assert req_body[
+            'default_query_parameters'] == default_query_params_model
 
     def test_create_project_all_params_with_retries(self):
         # Enable retries and run test_create_project_all_params.
@@ -260,10 +260,13 @@ class TestCreateProject():
         # Construct a dict representation of a DefaultQueryParams model
         default_query_params_model = {}
         default_query_params_model['collection_ids'] = ['testString']
-        default_query_params_model['passages'] = default_query_params_passages_model
-        default_query_params_model['table_results'] = default_query_params_table_results_model
+        default_query_params_model[
+            'passages'] = default_query_params_passages_model
+        default_query_params_model[
+            'table_results'] = default_query_params_table_results_model
         default_query_params_model['aggregation'] = 'testString'
-        default_query_params_model['suggested_refinements'] = default_query_params_suggested_refinements_model
+        default_query_params_model[
+            'suggested_refinements'] = default_query_params_suggested_refinements_model
         default_query_params_model['spelling_suggestions'] = True
         default_query_params_model['highlight'] = True
         default_query_params_model['count'] = 38
@@ -281,7 +284,10 @@ class TestCreateProject():
             "type": type,
         }
         for param in req_param_dict.keys():
-            req_copy = {key:val if key is not param else None for (key,val) in req_param_dict.items()}
+            req_copy = {
+                key: val if key is not param else None
+                for (key, val) in req_param_dict.items()
+            }
             with pytest.raises(ValueError):
                 _service.create_project(**req_copy)
 
@@ -294,11 +300,11 @@ class TestCreateProject():
         _service.disable_retries()
         self.test_create_project_value_error()
 
+
 class TestGetProject():
     """
     Test Class for get_project
     """
-
     @responses.activate
     def test_get_project_all_params(self):
         """
@@ -317,10 +323,7 @@ class TestGetProject():
         project_id = 'testString'
 
         # Invoke method
-        response = _service.get_project(
-            project_id,
-            headers={}
-        )
+        response = _service.get_project(project_id, headers={})
 
         # Check for correct operation
         assert len(responses.calls) == 1
@@ -357,7 +360,10 @@ class TestGetProject():
             "project_id": project_id,
         }
         for param in req_param_dict.keys():
-            req_copy = {key:val if key is not param else None for (key,val) in req_param_dict.items()}
+            req_copy = {
+                key: val if key is not param else None
+                for (key, val) in req_param_dict.items()
+            }
             with pytest.raises(ValueError):
                 _service.get_project(**req_copy)
 
@@ -370,11 +376,11 @@ class TestGetProject():
         _service.disable_retries()
         self.test_get_project_value_error()
 
+
 class TestUpdateProject():
     """
     Test Class for update_project
     """
-
     @responses.activate
     def test_update_project_all_params(self):
         """
@@ -394,11 +400,7 @@ class TestUpdateProject():
         name = 'testString'
 
         # Invoke method
-        response = _service.update_project(
-            project_id,
-            name=name,
-            headers={}
-        )
+        response = _service.update_project(project_id, name=name, headers={})
 
         # Check for correct operation
         assert len(responses.calls) == 1
@@ -434,10 +436,7 @@ class TestUpdateProject():
         project_id = 'testString'
 
         # Invoke method
-        response = _service.update_project(
-            project_id,
-            headers={}
-        )
+        response = _service.update_project(project_id, headers={})
 
         # Check for correct operation
         assert len(responses.calls) == 1
@@ -474,7 +473,10 @@ class TestUpdateProject():
             "project_id": project_id,
         }
         for param in req_param_dict.keys():
-            req_copy = {key:val if key is not param else None for (key,val) in req_param_dict.items()}
+            req_copy = {
+                key: val if key is not param else None
+                for (key, val) in req_param_dict.items()
+            }
             with pytest.raises(ValueError):
                 _service.update_project(**req_copy)
 
@@ -487,11 +489,11 @@ class TestUpdateProject():
         _service.disable_retries()
         self.test_update_project_value_error()
 
+
 class TestDeleteProject():
     """
     Test Class for delete_project
     """
-
     @responses.activate
     def test_delete_project_all_params(self):
         """
@@ -499,18 +501,13 @@ class TestDeleteProject():
         """
         # Set up mock
         url = preprocess_url('/v2/projects/testString')
-        responses.add(responses.DELETE,
-                      url,
-                      status=204)
+        responses.add(responses.DELETE, url, status=204)
 
         # Set up parameter values
         project_id = 'testString'
 
         # Invoke method
-        response = _service.delete_project(
-            project_id,
-            headers={}
-        )
+        response = _service.delete_project(project_id, headers={})
 
         # Check for correct operation
         assert len(responses.calls) == 1
@@ -532,9 +529,7 @@ class TestDeleteProject():
         """
         # Set up mock
         url = preprocess_url('/v2/projects/testString')
-        responses.add(responses.DELETE,
-                      url,
-                      status=204)
+        responses.add(responses.DELETE, url, status=204)
 
         # Set up parameter values
         project_id = 'testString'
@@ -544,7 +539,10 @@ class TestDeleteProject():
             "project_id": project_id,
         }
         for param in req_param_dict.keys():
-            req_copy = {key:val if key is not param else None for (key,val) in req_param_dict.items()}
+            req_copy = {
+                key: val if key is not param else None
+                for (key, val) in req_param_dict.items()
+            }
             with pytest.raises(ValueError):
                 _service.delete_project(**req_copy)
 
@@ -557,11 +555,11 @@ class TestDeleteProject():
         _service.disable_retries()
         self.test_delete_project_value_error()
 
+
 class TestListFields():
     """
     Test Class for list_fields
     """
-
     @responses.activate
     def test_list_fields_all_params(self):
         """
@@ -581,19 +579,18 @@ class TestListFields():
         collection_ids = ['testString']
 
         # Invoke method
-        response = _service.list_fields(
-            project_id,
-            collection_ids=collection_ids,
-            headers={}
-        )
+        response = _service.list_fields(project_id,
+                                        collection_ids=collection_ids,
+                                        headers={})
 
         # Check for correct operation
         assert len(responses.calls) == 1
         assert response.status_code == 200
         # Validate query params
-        query_string = responses.calls[0].request.url.split('?',1)[1]
+        query_string = responses.calls[0].request.url.split('?', 1)[1]
         query_string = urllib.parse.unquote_plus(query_string)
-        assert 'collection_ids={}'.format(','.join(collection_ids)) in query_string
+        assert 'collection_ids={}'.format(
+            ','.join(collection_ids)) in query_string
 
     def test_list_fields_all_params_with_retries(self):
         # Enable retries and run test_list_fields_all_params.
@@ -622,10 +619,7 @@ class TestListFields():
         project_id = 'testString'
 
         # Invoke method
-        response = _service.list_fields(
-            project_id,
-            headers={}
-        )
+        response = _service.list_fields(project_id, headers={})
 
         # Check for correct operation
         assert len(responses.calls) == 1
@@ -662,7 +656,10 @@ class TestListFields():
             "project_id": project_id,
         }
         for param in req_param_dict.keys():
-            req_copy = {key:val if key is not param else None for (key,val) in req_param_dict.items()}
+            req_copy = {
+                key: val if key is not param else None
+                for (key, val) in req_param_dict.items()
+            }
             with pytest.raises(ValueError):
                 _service.list_fields(**req_copy)
 
@@ -675,6 +672,7 @@ class TestListFields():
         _service.disable_retries()
         self.test_list_fields_value_error()
 
+
 # endregion
 ##############################################################################
 # End of Service: Projects
@@ -685,11 +683,11 @@ class TestListFields():
 ##############################################################################
 # region
 
+
 class TestListCollections():
     """
     Test Class for list_collections
     """
-
     @responses.activate
     def test_list_collections_all_params(self):
         """
@@ -708,10 +706,7 @@ class TestListCollections():
         project_id = 'testString'
 
         # Invoke method
-        response = _service.list_collections(
-            project_id,
-            headers={}
-        )
+        response = _service.list_collections(project_id, headers={})
 
         # Check for correct operation
         assert len(responses.calls) == 1
@@ -748,7 +743,10 @@ class TestListCollections():
             "project_id": project_id,
         }
         for param in req_param_dict.keys():
-            req_copy = {key:val if key is not param else None for (key,val) in req_param_dict.items()}
+            req_copy = {
+                key: val if key is not param else None
+                for (key, val) in req_param_dict.items()
+            }
             with pytest.raises(ValueError):
                 _service.list_collections(**req_copy)
 
@@ -761,11 +759,11 @@ class TestListCollections():
         _service.disable_retries()
         self.test_list_collections_value_error()
 
+
 class TestCreateCollection():
     """
     Test Class for create_collection
     """
-
     @responses.activate
     def test_create_collection_all_params(self):
         """
@@ -788,7 +786,8 @@ class TestCreateCollection():
         # Construct a dict representation of a CollectionDetailsSmartDocumentUnderstanding model
         collection_details_smart_document_understanding_model = {}
         collection_details_smart_document_understanding_model['enabled'] = True
-        collection_details_smart_document_understanding_model['model'] = 'custom'
+        collection_details_smart_document_understanding_model[
+            'model'] = 'custom'
 
         # Set up parameter values
         project_id = 'testString'
@@ -806,8 +805,7 @@ class TestCreateCollection():
             language=language,
             enrichments=enrichments,
             smart_document_understanding=smart_document_understanding,
-            headers={}
-        )
+            headers={})
 
         # Check for correct operation
         assert len(responses.calls) == 1
@@ -818,7 +816,8 @@ class TestCreateCollection():
         assert req_body['description'] == 'testString'
         assert req_body['language'] == 'en'
         assert req_body['enrichments'] == [collection_enrichment_model]
-        assert req_body['smart_document_understanding'] == collection_details_smart_document_understanding_model
+        assert req_body[
+            'smart_document_understanding'] == collection_details_smart_document_understanding_model
 
     def test_create_collection_all_params_with_retries(self):
         # Enable retries and run test_create_collection_all_params.
@@ -851,7 +850,8 @@ class TestCreateCollection():
         # Construct a dict representation of a CollectionDetailsSmartDocumentUnderstanding model
         collection_details_smart_document_understanding_model = {}
         collection_details_smart_document_understanding_model['enabled'] = True
-        collection_details_smart_document_understanding_model['model'] = 'custom'
+        collection_details_smart_document_understanding_model[
+            'model'] = 'custom'
 
         # Set up parameter values
         project_id = 'testString'
@@ -867,7 +867,10 @@ class TestCreateCollection():
             "name": name,
         }
         for param in req_param_dict.keys():
-            req_copy = {key:val if key is not param else None for (key,val) in req_param_dict.items()}
+            req_copy = {
+                key: val if key is not param else None
+                for (key, val) in req_param_dict.items()
+            }
             with pytest.raises(ValueError):
                 _service.create_collection(**req_copy)
 
@@ -880,11 +883,11 @@ class TestCreateCollection():
         _service.disable_retries()
         self.test_create_collection_value_error()
 
+
 class TestGetCollection():
     """
     Test Class for get_collection
     """
-
     @responses.activate
     def test_get_collection_all_params(self):
         """
@@ -904,11 +907,9 @@ class TestGetCollection():
         collection_id = 'testString'
 
         # Invoke method
-        response = _service.get_collection(
-            project_id,
-            collection_id,
-            headers={}
-        )
+        response = _service.get_collection(project_id,
+                                           collection_id,
+                                           headers={})
 
         # Check for correct operation
         assert len(responses.calls) == 1
@@ -947,7 +948,10 @@ class TestGetCollection():
             "collection_id": collection_id,
         }
         for param in req_param_dict.keys():
-            req_copy = {key:val if key is not param else None for (key,val) in req_param_dict.items()}
+            req_copy = {
+                key: val if key is not param else None
+                for (key, val) in req_param_dict.items()
+            }
             with pytest.raises(ValueError):
                 _service.get_collection(**req_copy)
 
@@ -960,11 +964,11 @@ class TestGetCollection():
         _service.disable_retries()
         self.test_get_collection_value_error()
 
+
 class TestUpdateCollection():
     """
     Test Class for update_collection
     """
-
     @responses.activate
     def test_update_collection_all_params(self):
         """
@@ -992,14 +996,12 @@ class TestUpdateCollection():
         enrichments = [collection_enrichment_model]
 
         # Invoke method
-        response = _service.update_collection(
-            project_id,
-            collection_id,
-            name=name,
-            description=description,
-            enrichments=enrichments,
-            headers={}
-        )
+        response = _service.update_collection(project_id,
+                                              collection_id,
+                                              name=name,
+                                              description=description,
+                                              enrichments=enrichments,
+                                              headers={})
 
         # Check for correct operation
         assert len(responses.calls) == 1
@@ -1051,7 +1053,10 @@ class TestUpdateCollection():
             "collection_id": collection_id,
         }
         for param in req_param_dict.keys():
-            req_copy = {key:val if key is not param else None for (key,val) in req_param_dict.items()}
+            req_copy = {
+                key: val if key is not param else None
+                for (key, val) in req_param_dict.items()
+            }
             with pytest.raises(ValueError):
                 _service.update_collection(**req_copy)
 
@@ -1064,11 +1069,11 @@ class TestUpdateCollection():
         _service.disable_retries()
         self.test_update_collection_value_error()
 
+
 class TestDeleteCollection():
     """
     Test Class for delete_collection
     """
-
     @responses.activate
     def test_delete_collection_all_params(self):
         """
@@ -1076,20 +1081,16 @@ class TestDeleteCollection():
         """
         # Set up mock
         url = preprocess_url('/v2/projects/testString/collections/testString')
-        responses.add(responses.DELETE,
-                      url,
-                      status=204)
+        responses.add(responses.DELETE, url, status=204)
 
         # Set up parameter values
         project_id = 'testString'
         collection_id = 'testString'
 
         # Invoke method
-        response = _service.delete_collection(
-            project_id,
-            collection_id,
-            headers={}
-        )
+        response = _service.delete_collection(project_id,
+                                              collection_id,
+                                              headers={})
 
         # Check for correct operation
         assert len(responses.calls) == 1
@@ -1111,9 +1112,7 @@ class TestDeleteCollection():
         """
         # Set up mock
         url = preprocess_url('/v2/projects/testString/collections/testString')
-        responses.add(responses.DELETE,
-                      url,
-                      status=204)
+        responses.add(responses.DELETE, url, status=204)
 
         # Set up parameter values
         project_id = 'testString'
@@ -1125,7 +1124,10 @@ class TestDeleteCollection():
             "collection_id": collection_id,
         }
         for param in req_param_dict.keys():
-            req_copy = {key:val if key is not param else None for (key,val) in req_param_dict.items()}
+            req_copy = {
+                key: val if key is not param else None
+                for (key, val) in req_param_dict.items()
+            }
             with pytest.raises(ValueError):
                 _service.delete_collection(**req_copy)
 
@@ -1138,6 +1140,7 @@ class TestDeleteCollection():
         _service.disable_retries()
         self.test_delete_collection_value_error()
 
+
 # endregion
 ##############################################################################
 # End of Service: Collections
@@ -1148,18 +1151,19 @@ class TestDeleteCollection():
 ##############################################################################
 # region
 
+
 class TestListDocuments():
     """
     Test Class for list_documents
     """
-
     @responses.activate
     def test_list_documents_all_params(self):
         """
         list_documents()
         """
         # Set up mock
-        url = preprocess_url('/v2/projects/testString/collections/testString/documents')
+        url = preprocess_url(
+            '/v2/projects/testString/collections/testString/documents')
         mock_response = '{"matching_results": 16, "documents": [{"document_id": "document_id", "created": "2019-01-01T12:00:00.000Z", "updated": "2019-01-01T12:00:00.000Z", "status": "available", "notices": [{"notice_id": "notice_id", "created": "2019-01-01T12:00:00.000Z", "document_id": "document_id", "collection_id": "collection_id", "query_id": "query_id", "severity": "warning", "step": "step", "description": "description"}], "children": {"have_notices": true, "count": 5}, "filename": "filename", "file_type": "file_type", "sha256": "sha256"}]}'
         responses.add(responses.GET,
                       url,
@@ -1187,20 +1191,22 @@ class TestListDocuments():
             is_parent=is_parent,
             parent_document_id=parent_document_id,
             sha256=sha256,
-            headers={}
-        )
+            headers={})
 
         # Check for correct operation
         assert len(responses.calls) == 1
         assert response.status_code == 200
         # Validate query params
-        query_string = responses.calls[0].request.url.split('?',1)[1]
+        query_string = responses.calls[0].request.url.split('?', 1)[1]
         query_string = urllib.parse.unquote_plus(query_string)
         assert 'count={}'.format(count) in query_string
         assert 'status={}'.format(status) in query_string
-        assert 'has_notices={}'.format('true' if has_notices else 'false') in query_string
-        assert 'is_parent={}'.format('true' if is_parent else 'false') in query_string
-        assert 'parent_document_id={}'.format(parent_document_id) in query_string
+        assert 'has_notices={}'.format(
+            'true' if has_notices else 'false') in query_string
+        assert 'is_parent={}'.format(
+            'true' if is_parent else 'false') in query_string
+        assert 'parent_document_id={}'.format(
+            parent_document_id) in query_string
         assert 'sha256={}'.format(sha256) in query_string
 
     def test_list_documents_all_params_with_retries(self):
@@ -1218,7 +1224,8 @@ class TestListDocuments():
         test_list_documents_required_params()
         """
         # Set up mock
-        url = preprocess_url('/v2/projects/testString/collections/testString/documents')
+        url = preprocess_url(
+            '/v2/projects/testString/collections/testString/documents')
         mock_response = '{"matching_results": 16, "documents": [{"document_id": "document_id", "created": "2019-01-01T12:00:00.000Z", "updated": "2019-01-01T12:00:00.000Z", "status": "available", "notices": [{"notice_id": "notice_id", "created": "2019-01-01T12:00:00.000Z", "document_id": "document_id", "collection_id": "collection_id", "query_id": "query_id", "severity": "warning", "step": "step", "description": "description"}], "children": {"have_notices": true, "count": 5}, "filename": "filename", "file_type": "file_type", "sha256": "sha256"}]}'
         responses.add(responses.GET,
                       url,
@@ -1231,11 +1238,9 @@ class TestListDocuments():
         collection_id = 'testString'
 
         # Invoke method
-        response = _service.list_documents(
-            project_id,
-            collection_id,
-            headers={}
-        )
+        response = _service.list_documents(project_id,
+                                           collection_id,
+                                           headers={})
 
         # Check for correct operation
         assert len(responses.calls) == 1
@@ -1256,7 +1261,8 @@ class TestListDocuments():
         test_list_documents_value_error()
         """
         # Set up mock
-        url = preprocess_url('/v2/projects/testString/collections/testString/documents')
+        url = preprocess_url(
+            '/v2/projects/testString/collections/testString/documents')
         mock_response = '{"matching_results": 16, "documents": [{"document_id": "document_id", "created": "2019-01-01T12:00:00.000Z", "updated": "2019-01-01T12:00:00.000Z", "status": "available", "notices": [{"notice_id": "notice_id", "created": "2019-01-01T12:00:00.000Z", "document_id": "document_id", "collection_id": "collection_id", "query_id": "query_id", "severity": "warning", "step": "step", "description": "description"}], "children": {"have_notices": true, "count": 5}, "filename": "filename", "file_type": "file_type", "sha256": "sha256"}]}'
         responses.add(responses.GET,
                       url,
@@ -1274,7 +1280,10 @@ class TestListDocuments():
             "collection_id": collection_id,
         }
         for param in req_param_dict.keys():
-            req_copy = {key:val if key is not param else None for (key,val) in req_param_dict.items()}
+            req_copy = {
+                key: val if key is not param else None
+                for (key, val) in req_param_dict.items()
+            }
             with pytest.raises(ValueError):
                 _service.list_documents(**req_copy)
 
@@ -1287,18 +1296,19 @@ class TestListDocuments():
         _service.disable_retries()
         self.test_list_documents_value_error()
 
+
 class TestAddDocument():
     """
     Test Class for add_document
     """
-
     @responses.activate
     def test_add_document_all_params(self):
         """
         add_document()
         """
         # Set up mock
-        url = preprocess_url('/v2/projects/testString/collections/testString/documents')
+        url = preprocess_url(
+            '/v2/projects/testString/collections/testString/documents')
         mock_response = '{"document_id": "document_id", "status": "processing"}'
         responses.add(responses.POST,
                       url,
@@ -1324,8 +1334,7 @@ class TestAddDocument():
             file_content_type=file_content_type,
             metadata=metadata,
             x_watson_discovery_force=x_watson_discovery_force,
-            headers={}
-        )
+            headers={})
 
         # Check for correct operation
         assert len(responses.calls) == 1
@@ -1346,7 +1355,8 @@ class TestAddDocument():
         test_add_document_required_params()
         """
         # Set up mock
-        url = preprocess_url('/v2/projects/testString/collections/testString/documents')
+        url = preprocess_url(
+            '/v2/projects/testString/collections/testString/documents')
         mock_response = '{"document_id": "document_id", "status": "processing"}'
         responses.add(responses.POST,
                       url,
@@ -1359,11 +1369,7 @@ class TestAddDocument():
         collection_id = 'testString'
 
         # Invoke method
-        response = _service.add_document(
-            project_id,
-            collection_id,
-            headers={}
-        )
+        response = _service.add_document(project_id, collection_id, headers={})
 
         # Check for correct operation
         assert len(responses.calls) == 1
@@ -1384,7 +1390,8 @@ class TestAddDocument():
         test_add_document_value_error()
         """
         # Set up mock
-        url = preprocess_url('/v2/projects/testString/collections/testString/documents')
+        url = preprocess_url(
+            '/v2/projects/testString/collections/testString/documents')
         mock_response = '{"document_id": "document_id", "status": "processing"}'
         responses.add(responses.POST,
                       url,
@@ -1402,7 +1409,10 @@ class TestAddDocument():
             "collection_id": collection_id,
         }
         for param in req_param_dict.keys():
-            req_copy = {key:val if key is not param else None for (key,val) in req_param_dict.items()}
+            req_copy = {
+                key: val if key is not param else None
+                for (key, val) in req_param_dict.items()
+            }
             with pytest.raises(ValueError):
                 _service.add_document(**req_copy)
 
@@ -1415,18 +1425,20 @@ class TestAddDocument():
         _service.disable_retries()
         self.test_add_document_value_error()
 
+
 class TestGetDocument():
     """
     Test Class for get_document
     """
-
     @responses.activate
     def test_get_document_all_params(self):
         """
         get_document()
         """
         # Set up mock
-        url = preprocess_url('/v2/projects/testString/collections/testString/documents/testString')
+        url = preprocess_url(
+            '/v2/projects/testString/collections/testString/documents/testString'
+        )
         mock_response = '{"document_id": "document_id", "created": "2019-01-01T12:00:00.000Z", "updated": "2019-01-01T12:00:00.000Z", "status": "available", "notices": [{"notice_id": "notice_id", "created": "2019-01-01T12:00:00.000Z", "document_id": "document_id", "collection_id": "collection_id", "query_id": "query_id", "severity": "warning", "step": "step", "description": "description"}], "children": {"have_notices": true, "count": 5}, "filename": "filename", "file_type": "file_type", "sha256": "sha256"}'
         responses.add(responses.GET,
                       url,
@@ -1440,12 +1452,10 @@ class TestGetDocument():
         document_id = 'testString'
 
         # Invoke method
-        response = _service.get_document(
-            project_id,
-            collection_id,
-            document_id,
-            headers={}
-        )
+        response = _service.get_document(project_id,
+                                         collection_id,
+                                         document_id,
+                                         headers={})
 
         # Check for correct operation
         assert len(responses.calls) == 1
@@ -1466,7 +1476,9 @@ class TestGetDocument():
         test_get_document_value_error()
         """
         # Set up mock
-        url = preprocess_url('/v2/projects/testString/collections/testString/documents/testString')
+        url = preprocess_url(
+            '/v2/projects/testString/collections/testString/documents/testString'
+        )
         mock_response = '{"document_id": "document_id", "created": "2019-01-01T12:00:00.000Z", "updated": "2019-01-01T12:00:00.000Z", "status": "available", "notices": [{"notice_id": "notice_id", "created": "2019-01-01T12:00:00.000Z", "document_id": "document_id", "collection_id": "collection_id", "query_id": "query_id", "severity": "warning", "step": "step", "description": "description"}], "children": {"have_notices": true, "count": 5}, "filename": "filename", "file_type": "file_type", "sha256": "sha256"}'
         responses.add(responses.GET,
                       url,
@@ -1486,7 +1498,10 @@ class TestGetDocument():
             "document_id": document_id,
         }
         for param in req_param_dict.keys():
-            req_copy = {key:val if key is not param else None for (key,val) in req_param_dict.items()}
+            req_copy = {
+                key: val if key is not param else None
+                for (key, val) in req_param_dict.items()
+            }
             with pytest.raises(ValueError):
                 _service.get_document(**req_copy)
 
@@ -1499,18 +1514,20 @@ class TestGetDocument():
         _service.disable_retries()
         self.test_get_document_value_error()
 
+
 class TestUpdateDocument():
     """
     Test Class for update_document
     """
-
     @responses.activate
     def test_update_document_all_params(self):
         """
         update_document()
         """
         # Set up mock
-        url = preprocess_url('/v2/projects/testString/collections/testString/documents/testString')
+        url = preprocess_url(
+            '/v2/projects/testString/collections/testString/documents/testString'
+        )
         mock_response = '{"document_id": "document_id", "status": "processing"}'
         responses.add(responses.POST,
                       url,
@@ -1538,8 +1555,7 @@ class TestUpdateDocument():
             file_content_type=file_content_type,
             metadata=metadata,
             x_watson_discovery_force=x_watson_discovery_force,
-            headers={}
-        )
+            headers={})
 
         # Check for correct operation
         assert len(responses.calls) == 1
@@ -1560,7 +1576,9 @@ class TestUpdateDocument():
         test_update_document_required_params()
         """
         # Set up mock
-        url = preprocess_url('/v2/projects/testString/collections/testString/documents/testString')
+        url = preprocess_url(
+            '/v2/projects/testString/collections/testString/documents/testString'
+        )
         mock_response = '{"document_id": "document_id", "status": "processing"}'
         responses.add(responses.POST,
                       url,
@@ -1574,12 +1592,10 @@ class TestUpdateDocument():
         document_id = 'testString'
 
         # Invoke method
-        response = _service.update_document(
-            project_id,
-            collection_id,
-            document_id,
-            headers={}
-        )
+        response = _service.update_document(project_id,
+                                            collection_id,
+                                            document_id,
+                                            headers={})
 
         # Check for correct operation
         assert len(responses.calls) == 1
@@ -1600,7 +1616,9 @@ class TestUpdateDocument():
         test_update_document_value_error()
         """
         # Set up mock
-        url = preprocess_url('/v2/projects/testString/collections/testString/documents/testString')
+        url = preprocess_url(
+            '/v2/projects/testString/collections/testString/documents/testString'
+        )
         mock_response = '{"document_id": "document_id", "status": "processing"}'
         responses.add(responses.POST,
                       url,
@@ -1620,7 +1638,10 @@ class TestUpdateDocument():
             "document_id": document_id,
         }
         for param in req_param_dict.keys():
-            req_copy = {key:val if key is not param else None for (key,val) in req_param_dict.items()}
+            req_copy = {
+                key: val if key is not param else None
+                for (key, val) in req_param_dict.items()
+            }
             with pytest.raises(ValueError):
                 _service.update_document(**req_copy)
 
@@ -1633,18 +1654,20 @@ class TestUpdateDocument():
         _service.disable_retries()
         self.test_update_document_value_error()
 
+
 class TestDeleteDocument():
     """
     Test Class for delete_document
     """
-
     @responses.activate
     def test_delete_document_all_params(self):
         """
         delete_document()
         """
         # Set up mock
-        url = preprocess_url('/v2/projects/testString/collections/testString/documents/testString')
+        url = preprocess_url(
+            '/v2/projects/testString/collections/testString/documents/testString'
+        )
         mock_response = '{"document_id": "document_id", "status": "deleted"}'
         responses.add(responses.DELETE,
                       url,
@@ -1664,8 +1687,7 @@ class TestDeleteDocument():
             collection_id,
             document_id,
             x_watson_discovery_force=x_watson_discovery_force,
-            headers={}
-        )
+            headers={})
 
         # Check for correct operation
         assert len(responses.calls) == 1
@@ -1686,7 +1708,9 @@ class TestDeleteDocument():
         test_delete_document_required_params()
         """
         # Set up mock
-        url = preprocess_url('/v2/projects/testString/collections/testString/documents/testString')
+        url = preprocess_url(
+            '/v2/projects/testString/collections/testString/documents/testString'
+        )
         mock_response = '{"document_id": "document_id", "status": "deleted"}'
         responses.add(responses.DELETE,
                       url,
@@ -1700,12 +1724,10 @@ class TestDeleteDocument():
         document_id = 'testString'
 
         # Invoke method
-        response = _service.delete_document(
-            project_id,
-            collection_id,
-            document_id,
-            headers={}
-        )
+        response = _service.delete_document(project_id,
+                                            collection_id,
+                                            document_id,
+                                            headers={})
 
         # Check for correct operation
         assert len(responses.calls) == 1
@@ -1726,7 +1748,9 @@ class TestDeleteDocument():
         test_delete_document_value_error()
         """
         # Set up mock
-        url = preprocess_url('/v2/projects/testString/collections/testString/documents/testString')
+        url = preprocess_url(
+            '/v2/projects/testString/collections/testString/documents/testString'
+        )
         mock_response = '{"document_id": "document_id", "status": "deleted"}'
         responses.add(responses.DELETE,
                       url,
@@ -1746,7 +1770,10 @@ class TestDeleteDocument():
             "document_id": document_id,
         }
         for param in req_param_dict.keys():
-            req_copy = {key:val if key is not param else None for (key,val) in req_param_dict.items()}
+            req_copy = {
+                key: val if key is not param else None
+                for (key, val) in req_param_dict.items()
+            }
             with pytest.raises(ValueError):
                 _service.delete_document(**req_copy)
 
@@ -1759,6 +1786,7 @@ class TestDeleteDocument():
         _service.disable_retries()
         self.test_delete_document_value_error()
 
+
 # endregion
 ##############################################################################
 # End of Service: Documents
@@ -1769,11 +1797,11 @@ class TestDeleteDocument():
 ##############################################################################
 # region
 
+
 class TestQuery():
     """
     Test Class for query
     """
-
     @responses.activate
     def test_query_all_params(self):
         """
@@ -1851,8 +1879,7 @@ class TestQuery():
             suggested_refinements=suggested_refinements,
             passages=passages,
             similar=similar,
-            headers={}
-        )
+            headers={})
 
         # Check for correct operation
         assert len(responses.calls) == 1
@@ -1871,7 +1898,8 @@ class TestQuery():
         assert req_body['highlight'] == True
         assert req_body['spelling_suggestions'] == True
         assert req_body['table_results'] == query_large_table_results_model
-        assert req_body['suggested_refinements'] == query_large_suggested_refinements_model
+        assert req_body[
+            'suggested_refinements'] == query_large_suggested_refinements_model
         assert req_body['passages'] == query_large_passages_model
         assert req_body['similar'] == query_large_similar_model
 
@@ -1902,10 +1930,7 @@ class TestQuery():
         project_id = 'testString'
 
         # Invoke method
-        response = _service.query(
-            project_id,
-            headers={}
-        )
+        response = _service.query(project_id, headers={})
 
         # Check for correct operation
         assert len(responses.calls) == 1
@@ -1942,7 +1967,10 @@ class TestQuery():
             "project_id": project_id,
         }
         for param in req_param_dict.keys():
-            req_copy = {key:val if key is not param else None for (key,val) in req_param_dict.items()}
+            req_copy = {
+                key: val if key is not param else None
+                for (key, val) in req_param_dict.items()
+            }
             with pytest.raises(ValueError):
                 _service.query(**req_copy)
 
@@ -1955,11 +1983,11 @@ class TestQuery():
         _service.disable_retries()
         self.test_query_value_error()
 
+
 class TestGetAutocompletion():
     """
     Test Class for get_autocompletion
     """
-
     @responses.activate
     def test_get_autocompletion_all_params(self):
         """
@@ -1982,23 +2010,22 @@ class TestGetAutocompletion():
         count = 38
 
         # Invoke method
-        response = _service.get_autocompletion(
-            project_id,
-            prefix,
-            collection_ids=collection_ids,
-            field=field,
-            count=count,
-            headers={}
-        )
+        response = _service.get_autocompletion(project_id,
+                                               prefix,
+                                               collection_ids=collection_ids,
+                                               field=field,
+                                               count=count,
+                                               headers={})
 
         # Check for correct operation
         assert len(responses.calls) == 1
         assert response.status_code == 200
         # Validate query params
-        query_string = responses.calls[0].request.url.split('?',1)[1]
+        query_string = responses.calls[0].request.url.split('?', 1)[1]
         query_string = urllib.parse.unquote_plus(query_string)
         assert 'prefix={}'.format(prefix) in query_string
-        assert 'collection_ids={}'.format(','.join(collection_ids)) in query_string
+        assert 'collection_ids={}'.format(
+            ','.join(collection_ids)) in query_string
         assert 'field={}'.format(field) in query_string
         assert 'count={}'.format(count) in query_string
 
@@ -2030,17 +2057,13 @@ class TestGetAutocompletion():
         prefix = 'testString'
 
         # Invoke method
-        response = _service.get_autocompletion(
-            project_id,
-            prefix,
-            headers={}
-        )
+        response = _service.get_autocompletion(project_id, prefix, headers={})
 
         # Check for correct operation
         assert len(responses.calls) == 1
         assert response.status_code == 200
         # Validate query params
-        query_string = responses.calls[0].request.url.split('?',1)[1]
+        query_string = responses.calls[0].request.url.split('?', 1)[1]
         query_string = urllib.parse.unquote_plus(query_string)
         assert 'prefix={}'.format(prefix) in query_string
 
@@ -2077,7 +2100,10 @@ class TestGetAutocompletion():
             "prefix": prefix,
         }
         for param in req_param_dict.keys():
-            req_copy = {key:val if key is not param else None for (key,val) in req_param_dict.items()}
+            req_copy = {
+                key: val if key is not param else None
+                for (key, val) in req_param_dict.items()
+            }
             with pytest.raises(ValueError):
                 _service.get_autocompletion(**req_copy)
 
@@ -2090,18 +2116,19 @@ class TestGetAutocompletion():
         _service.disable_retries()
         self.test_get_autocompletion_value_error()
 
+
 class TestQueryCollectionNotices():
     """
     Test Class for query_collection_notices
     """
-
     @responses.activate
     def test_query_collection_notices_all_params(self):
         """
         query_collection_notices()
         """
         # Set up mock
-        url = preprocess_url('/v2/projects/testString/collections/testString/notices')
+        url = preprocess_url(
+            '/v2/projects/testString/collections/testString/notices')
         mock_response = '{"matching_results": 16, "notices": [{"notice_id": "notice_id", "created": "2019-01-01T12:00:00.000Z", "document_id": "document_id", "collection_id": "collection_id", "query_id": "query_id", "severity": "warning", "step": "step", "description": "description"}]}'
         responses.add(responses.GET,
                       url,
@@ -2127,18 +2154,18 @@ class TestQueryCollectionNotices():
             natural_language_query=natural_language_query,
             count=count,
             offset=offset,
-            headers={}
-        )
+            headers={})
 
         # Check for correct operation
         assert len(responses.calls) == 1
         assert response.status_code == 200
         # Validate query params
-        query_string = responses.calls[0].request.url.split('?',1)[1]
+        query_string = responses.calls[0].request.url.split('?', 1)[1]
         query_string = urllib.parse.unquote_plus(query_string)
         assert 'filter={}'.format(filter) in query_string
         assert 'query={}'.format(query) in query_string
-        assert 'natural_language_query={}'.format(natural_language_query) in query_string
+        assert 'natural_language_query={}'.format(
+            natural_language_query) in query_string
         assert 'count={}'.format(count) in query_string
         assert 'offset={}'.format(offset) in query_string
 
@@ -2157,7 +2184,8 @@ class TestQueryCollectionNotices():
         test_query_collection_notices_required_params()
         """
         # Set up mock
-        url = preprocess_url('/v2/projects/testString/collections/testString/notices')
+        url = preprocess_url(
+            '/v2/projects/testString/collections/testString/notices')
         mock_response = '{"matching_results": 16, "notices": [{"notice_id": "notice_id", "created": "2019-01-01T12:00:00.000Z", "document_id": "document_id", "collection_id": "collection_id", "query_id": "query_id", "severity": "warning", "step": "step", "description": "description"}]}'
         responses.add(responses.GET,
                       url,
@@ -2170,11 +2198,9 @@ class TestQueryCollectionNotices():
         collection_id = 'testString'
 
         # Invoke method
-        response = _service.query_collection_notices(
-            project_id,
-            collection_id,
-            headers={}
-        )
+        response = _service.query_collection_notices(project_id,
+                                                     collection_id,
+                                                     headers={})
 
         # Check for correct operation
         assert len(responses.calls) == 1
@@ -2195,7 +2221,8 @@ class TestQueryCollectionNotices():
         test_query_collection_notices_value_error()
         """
         # Set up mock
-        url = preprocess_url('/v2/projects/testString/collections/testString/notices')
+        url = preprocess_url(
+            '/v2/projects/testString/collections/testString/notices')
         mock_response = '{"matching_results": 16, "notices": [{"notice_id": "notice_id", "created": "2019-01-01T12:00:00.000Z", "document_id": "document_id", "collection_id": "collection_id", "query_id": "query_id", "severity": "warning", "step": "step", "description": "description"}]}'
         responses.add(responses.GET,
                       url,
@@ -2213,7 +2240,10 @@ class TestQueryCollectionNotices():
             "collection_id": collection_id,
         }
         for param in req_param_dict.keys():
-            req_copy = {key:val if key is not param else None for (key,val) in req_param_dict.items()}
+            req_copy = {
+                key: val if key is not param else None
+                for (key, val) in req_param_dict.items()
+            }
             with pytest.raises(ValueError):
                 _service.query_collection_notices(**req_copy)
 
@@ -2226,11 +2256,11 @@ class TestQueryCollectionNotices():
         _service.disable_retries()
         self.test_query_collection_notices_value_error()
 
+
 class TestQueryNotices():
     """
     Test Class for query_notices
     """
-
     @responses.activate
     def test_query_notices_all_params(self):
         """
@@ -2261,18 +2291,18 @@ class TestQueryNotices():
             natural_language_query=natural_language_query,
             count=count,
             offset=offset,
-            headers={}
-        )
+            headers={})
 
         # Check for correct operation
         assert len(responses.calls) == 1
         assert response.status_code == 200
         # Validate query params
-        query_string = responses.calls[0].request.url.split('?',1)[1]
+        query_string = responses.calls[0].request.url.split('?', 1)[1]
         query_string = urllib.parse.unquote_plus(query_string)
         assert 'filter={}'.format(filter) in query_string
         assert 'query={}'.format(query) in query_string
-        assert 'natural_language_query={}'.format(natural_language_query) in query_string
+        assert 'natural_language_query={}'.format(
+            natural_language_query) in query_string
         assert 'count={}'.format(count) in query_string
         assert 'offset={}'.format(offset) in query_string
 
@@ -2303,10 +2333,7 @@ class TestQueryNotices():
         project_id = 'testString'
 
         # Invoke method
-        response = _service.query_notices(
-            project_id,
-            headers={}
-        )
+        response = _service.query_notices(project_id, headers={})
 
         # Check for correct operation
         assert len(responses.calls) == 1
@@ -2343,7 +2370,10 @@ class TestQueryNotices():
             "project_id": project_id,
         }
         for param in req_param_dict.keys():
-            req_copy = {key:val if key is not param else None for (key,val) in req_param_dict.items()}
+            req_copy = {
+                key: val if key is not param else None
+                for (key, val) in req_param_dict.items()
+            }
             with pytest.raises(ValueError):
                 _service.query_notices(**req_copy)
 
@@ -2356,6 +2386,7 @@ class TestQueryNotices():
         _service.disable_retries()
         self.test_query_notices_value_error()
 
+
 # endregion
 ##############################################################################
 # End of Service: Queries
@@ -2366,18 +2397,19 @@ class TestQueryNotices():
 ##############################################################################
 # region
 
+
 class TestGetStopwordList():
     """
     Test Class for get_stopword_list
     """
-
     @responses.activate
     def test_get_stopword_list_all_params(self):
         """
         get_stopword_list()
         """
         # Set up mock
-        url = preprocess_url('/v2/projects/testString/collections/testString/stopwords')
+        url = preprocess_url(
+            '/v2/projects/testString/collections/testString/stopwords')
         mock_response = '{"stopwords": ["stopwords"]}'
         responses.add(responses.GET,
                       url,
@@ -2390,11 +2422,9 @@ class TestGetStopwordList():
         collection_id = 'testString'
 
         # Invoke method
-        response = _service.get_stopword_list(
-            project_id,
-            collection_id,
-            headers={}
-        )
+        response = _service.get_stopword_list(project_id,
+                                              collection_id,
+                                              headers={})
 
         # Check for correct operation
         assert len(responses.calls) == 1
@@ -2415,7 +2445,8 @@ class TestGetStopwordList():
         test_get_stopword_list_value_error()
         """
         # Set up mock
-        url = preprocess_url('/v2/projects/testString/collections/testString/stopwords')
+        url = preprocess_url(
+            '/v2/projects/testString/collections/testString/stopwords')
         mock_response = '{"stopwords": ["stopwords"]}'
         responses.add(responses.GET,
                       url,
@@ -2433,7 +2464,10 @@ class TestGetStopwordList():
             "collection_id": collection_id,
         }
         for param in req_param_dict.keys():
-            req_copy = {key:val if key is not param else None for (key,val) in req_param_dict.items()}
+            req_copy = {
+                key: val if key is not param else None
+                for (key, val) in req_param_dict.items()
+            }
             with pytest.raises(ValueError):
                 _service.get_stopword_list(**req_copy)
 
@@ -2446,18 +2480,19 @@ class TestGetStopwordList():
         _service.disable_retries()
         self.test_get_stopword_list_value_error()
 
+
 class TestCreateStopwordList():
     """
     Test Class for create_stopword_list
     """
-
     @responses.activate
     def test_create_stopword_list_all_params(self):
         """
         create_stopword_list()
         """
         # Set up mock
-        url = preprocess_url('/v2/projects/testString/collections/testString/stopwords')
+        url = preprocess_url(
+            '/v2/projects/testString/collections/testString/stopwords')
         mock_response = '{"stopwords": ["stopwords"]}'
         responses.add(responses.POST,
                       url,
@@ -2471,12 +2506,10 @@ class TestCreateStopwordList():
         stopwords = ['testString']
 
         # Invoke method
-        response = _service.create_stopword_list(
-            project_id,
-            collection_id,
-            stopwords=stopwords,
-            headers={}
-        )
+        response = _service.create_stopword_list(project_id,
+                                                 collection_id,
+                                                 stopwords=stopwords,
+                                                 headers={})
 
         # Check for correct operation
         assert len(responses.calls) == 1
@@ -2500,7 +2533,8 @@ class TestCreateStopwordList():
         test_create_stopword_list_required_params()
         """
         # Set up mock
-        url = preprocess_url('/v2/projects/testString/collections/testString/stopwords')
+        url = preprocess_url(
+            '/v2/projects/testString/collections/testString/stopwords')
         mock_response = '{"stopwords": ["stopwords"]}'
         responses.add(responses.POST,
                       url,
@@ -2513,11 +2547,9 @@ class TestCreateStopwordList():
         collection_id = 'testString'
 
         # Invoke method
-        response = _service.create_stopword_list(
-            project_id,
-            collection_id,
-            headers={}
-        )
+        response = _service.create_stopword_list(project_id,
+                                                 collection_id,
+                                                 headers={})
 
         # Check for correct operation
         assert len(responses.calls) == 1
@@ -2538,7 +2570,8 @@ class TestCreateStopwordList():
         test_create_stopword_list_value_error()
         """
         # Set up mock
-        url = preprocess_url('/v2/projects/testString/collections/testString/stopwords')
+        url = preprocess_url(
+            '/v2/projects/testString/collections/testString/stopwords')
         mock_response = '{"stopwords": ["stopwords"]}'
         responses.add(responses.POST,
                       url,
@@ -2556,7 +2589,10 @@ class TestCreateStopwordList():
             "collection_id": collection_id,
         }
         for param in req_param_dict.keys():
-            req_copy = {key:val if key is not param else None for (key,val) in req_param_dict.items()}
+            req_copy = {
+                key: val if key is not param else None
+                for (key, val) in req_param_dict.items()
+            }
             with pytest.raises(ValueError):
                 _service.create_stopword_list(**req_copy)
 
@@ -2569,32 +2605,29 @@ class TestCreateStopwordList():
         _service.disable_retries()
         self.test_create_stopword_list_value_error()
 
+
 class TestDeleteStopwordList():
     """
     Test Class for delete_stopword_list
     """
-
     @responses.activate
     def test_delete_stopword_list_all_params(self):
         """
         delete_stopword_list()
         """
         # Set up mock
-        url = preprocess_url('/v2/projects/testString/collections/testString/stopwords')
-        responses.add(responses.DELETE,
-                      url,
-                      status=204)
+        url = preprocess_url(
+            '/v2/projects/testString/collections/testString/stopwords')
+        responses.add(responses.DELETE, url, status=204)
 
         # Set up parameter values
         project_id = 'testString'
         collection_id = 'testString'
 
         # Invoke method
-        response = _service.delete_stopword_list(
-            project_id,
-            collection_id,
-            headers={}
-        )
+        response = _service.delete_stopword_list(project_id,
+                                                 collection_id,
+                                                 headers={})
 
         # Check for correct operation
         assert len(responses.calls) == 1
@@ -2615,10 +2648,9 @@ class TestDeleteStopwordList():
         test_delete_stopword_list_value_error()
         """
         # Set up mock
-        url = preprocess_url('/v2/projects/testString/collections/testString/stopwords')
-        responses.add(responses.DELETE,
-                      url,
-                      status=204)
+        url = preprocess_url(
+            '/v2/projects/testString/collections/testString/stopwords')
+        responses.add(responses.DELETE, url, status=204)
 
         # Set up parameter values
         project_id = 'testString'
@@ -2630,7 +2662,10 @@ class TestDeleteStopwordList():
             "collection_id": collection_id,
         }
         for param in req_param_dict.keys():
-            req_copy = {key:val if key is not param else None for (key,val) in req_param_dict.items()}
+            req_copy = {
+                key: val if key is not param else None
+                for (key, val) in req_param_dict.items()
+            }
             with pytest.raises(ValueError):
                 _service.delete_stopword_list(**req_copy)
 
@@ -2643,18 +2678,19 @@ class TestDeleteStopwordList():
         _service.disable_retries()
         self.test_delete_stopword_list_value_error()
 
+
 class TestListExpansions():
     """
     Test Class for list_expansions
     """
-
     @responses.activate
     def test_list_expansions_all_params(self):
         """
         list_expansions()
         """
         # Set up mock
-        url = preprocess_url('/v2/projects/testString/collections/testString/expansions')
+        url = preprocess_url(
+            '/v2/projects/testString/collections/testString/expansions')
         mock_response = '{"expansions": [{"input_terms": ["input_terms"], "expanded_terms": ["expanded_terms"]}]}'
         responses.add(responses.GET,
                       url,
@@ -2667,11 +2703,9 @@ class TestListExpansions():
         collection_id = 'testString'
 
         # Invoke method
-        response = _service.list_expansions(
-            project_id,
-            collection_id,
-            headers={}
-        )
+        response = _service.list_expansions(project_id,
+                                            collection_id,
+                                            headers={})
 
         # Check for correct operation
         assert len(responses.calls) == 1
@@ -2692,7 +2726,8 @@ class TestListExpansions():
         test_list_expansions_value_error()
         """
         # Set up mock
-        url = preprocess_url('/v2/projects/testString/collections/testString/expansions')
+        url = preprocess_url(
+            '/v2/projects/testString/collections/testString/expansions')
         mock_response = '{"expansions": [{"input_terms": ["input_terms"], "expanded_terms": ["expanded_terms"]}]}'
         responses.add(responses.GET,
                       url,
@@ -2710,7 +2745,10 @@ class TestListExpansions():
             "collection_id": collection_id,
         }
         for param in req_param_dict.keys():
-            req_copy = {key:val if key is not param else None for (key,val) in req_param_dict.items()}
+            req_copy = {
+                key: val if key is not param else None
+                for (key, val) in req_param_dict.items()
+            }
             with pytest.raises(ValueError):
                 _service.list_expansions(**req_copy)
 
@@ -2723,18 +2761,19 @@ class TestListExpansions():
         _service.disable_retries()
         self.test_list_expansions_value_error()
 
+
 class TestCreateExpansions():
     """
     Test Class for create_expansions
     """
-
     @responses.activate
     def test_create_expansions_all_params(self):
         """
         create_expansions()
         """
         # Set up mock
-        url = preprocess_url('/v2/projects/testString/collections/testString/expansions')
+        url = preprocess_url(
+            '/v2/projects/testString/collections/testString/expansions')
         mock_response = '{"expansions": [{"input_terms": ["input_terms"], "expanded_terms": ["expanded_terms"]}]}'
         responses.add(responses.POST,
                       url,
@@ -2753,12 +2792,10 @@ class TestCreateExpansions():
         expansions = [expansion_model]
 
         # Invoke method
-        response = _service.create_expansions(
-            project_id,
-            collection_id,
-            expansions,
-            headers={}
-        )
+        response = _service.create_expansions(project_id,
+                                              collection_id,
+                                              expansions,
+                                              headers={})
 
         # Check for correct operation
         assert len(responses.calls) == 1
@@ -2782,7 +2819,8 @@ class TestCreateExpansions():
         test_create_expansions_value_error()
         """
         # Set up mock
-        url = preprocess_url('/v2/projects/testString/collections/testString/expansions')
+        url = preprocess_url(
+            '/v2/projects/testString/collections/testString/expansions')
         mock_response = '{"expansions": [{"input_terms": ["input_terms"], "expanded_terms": ["expanded_terms"]}]}'
         responses.add(responses.POST,
                       url,
@@ -2807,7 +2845,10 @@ class TestCreateExpansions():
             "expansions": expansions,
         }
         for param in req_param_dict.keys():
-            req_copy = {key:val if key is not param else None for (key,val) in req_param_dict.items()}
+            req_copy = {
+                key: val if key is not param else None
+                for (key, val) in req_param_dict.items()
+            }
             with pytest.raises(ValueError):
                 _service.create_expansions(**req_copy)
 
@@ -2820,32 +2861,29 @@ class TestCreateExpansions():
         _service.disable_retries()
         self.test_create_expansions_value_error()
 
+
 class TestDeleteExpansions():
     """
     Test Class for delete_expansions
     """
-
     @responses.activate
     def test_delete_expansions_all_params(self):
         """
         delete_expansions()
         """
         # Set up mock
-        url = preprocess_url('/v2/projects/testString/collections/testString/expansions')
-        responses.add(responses.DELETE,
-                      url,
-                      status=204)
+        url = preprocess_url(
+            '/v2/projects/testString/collections/testString/expansions')
+        responses.add(responses.DELETE, url, status=204)
 
         # Set up parameter values
         project_id = 'testString'
         collection_id = 'testString'
 
         # Invoke method
-        response = _service.delete_expansions(
-            project_id,
-            collection_id,
-            headers={}
-        )
+        response = _service.delete_expansions(project_id,
+                                              collection_id,
+                                              headers={})
 
         # Check for correct operation
         assert len(responses.calls) == 1
@@ -2866,10 +2904,9 @@ class TestDeleteExpansions():
         test_delete_expansions_value_error()
         """
         # Set up mock
-        url = preprocess_url('/v2/projects/testString/collections/testString/expansions')
-        responses.add(responses.DELETE,
-                      url,
-                      status=204)
+        url = preprocess_url(
+            '/v2/projects/testString/collections/testString/expansions')
+        responses.add(responses.DELETE, url, status=204)
 
         # Set up parameter values
         project_id = 'testString'
@@ -2881,7 +2918,10 @@ class TestDeleteExpansions():
             "collection_id": collection_id,
         }
         for param in req_param_dict.keys():
-            req_copy = {key:val if key is not param else None for (key,val) in req_param_dict.items()}
+            req_copy = {
+                key: val if key is not param else None
+                for (key, val) in req_param_dict.items()
+            }
             with pytest.raises(ValueError):
                 _service.delete_expansions(**req_copy)
 
@@ -2894,6 +2934,7 @@ class TestDeleteExpansions():
         _service.disable_retries()
         self.test_delete_expansions_value_error()
 
+
 # endregion
 ##############################################################################
 # End of Service: QueryModifications
@@ -2904,11 +2945,11 @@ class TestDeleteExpansions():
 ##############################################################################
 # region
 
+
 class TestGetComponentSettings():
     """
     Test Class for get_component_settings
     """
-
     @responses.activate
     def test_get_component_settings_all_params(self):
         """
@@ -2927,10 +2968,7 @@ class TestGetComponentSettings():
         project_id = 'testString'
 
         # Invoke method
-        response = _service.get_component_settings(
-            project_id,
-            headers={}
-        )
+        response = _service.get_component_settings(project_id, headers={})
 
         # Check for correct operation
         assert len(responses.calls) == 1
@@ -2967,7 +3005,10 @@ class TestGetComponentSettings():
             "project_id": project_id,
         }
         for param in req_param_dict.keys():
-            req_copy = {key:val if key is not param else None for (key,val) in req_param_dict.items()}
+            req_copy = {
+                key: val if key is not param else None
+                for (key, val) in req_param_dict.items()
+            }
             with pytest.raises(ValueError):
                 _service.get_component_settings(**req_copy)
 
@@ -2980,6 +3021,7 @@ class TestGetComponentSettings():
         _service.disable_retries()
         self.test_get_component_settings_value_error()
 
+
 # endregion
 ##############################################################################
 # End of Service: ComponentSettings
@@ -2990,11 +3032,11 @@ class TestGetComponentSettings():
 ##############################################################################
 # region
 
+
 class TestListTrainingQueries():
     """
     Test Class for list_training_queries
     """
-
     @responses.activate
     def test_list_training_queries_all_params(self):
         """
@@ -3013,10 +3055,7 @@ class TestListTrainingQueries():
         project_id = 'testString'
 
         # Invoke method
-        response = _service.list_training_queries(
-            project_id,
-            headers={}
-        )
+        response = _service.list_training_queries(project_id, headers={})
 
         # Check for correct operation
         assert len(responses.calls) == 1
@@ -3053,7 +3092,10 @@ class TestListTrainingQueries():
             "project_id": project_id,
         }
         for param in req_param_dict.keys():
-            req_copy = {key:val if key is not param else None for (key,val) in req_param_dict.items()}
+            req_copy = {
+                key: val if key is not param else None
+                for (key, val) in req_param_dict.items()
+            }
             with pytest.raises(ValueError):
                 _service.list_training_queries(**req_copy)
 
@@ -3066,11 +3108,11 @@ class TestListTrainingQueries():
         _service.disable_retries()
         self.test_list_training_queries_value_error()
 
+
 class TestDeleteTrainingQueries():
     """
     Test Class for delete_training_queries
     """
-
     @responses.activate
     def test_delete_training_queries_all_params(self):
         """
@@ -3078,18 +3120,13 @@ class TestDeleteTrainingQueries():
         """
         # Set up mock
         url = preprocess_url('/v2/projects/testString/training_data/queries')
-        responses.add(responses.DELETE,
-                      url,
-                      status=204)
+        responses.add(responses.DELETE, url, status=204)
 
         # Set up parameter values
         project_id = 'testString'
 
         # Invoke method
-        response = _service.delete_training_queries(
-            project_id,
-            headers={}
-        )
+        response = _service.delete_training_queries(project_id, headers={})
 
         # Check for correct operation
         assert len(responses.calls) == 1
@@ -3111,9 +3148,7 @@ class TestDeleteTrainingQueries():
         """
         # Set up mock
         url = preprocess_url('/v2/projects/testString/training_data/queries')
-        responses.add(responses.DELETE,
-                      url,
-                      status=204)
+        responses.add(responses.DELETE, url, status=204)
 
         # Set up parameter values
         project_id = 'testString'
@@ -3123,7 +3158,10 @@ class TestDeleteTrainingQueries():
             "project_id": project_id,
         }
         for param in req_param_dict.keys():
-            req_copy = {key:val if key is not param else None for (key,val) in req_param_dict.items()}
+            req_copy = {
+                key: val if key is not param else None
+                for (key, val) in req_param_dict.items()
+            }
             with pytest.raises(ValueError):
                 _service.delete_training_queries(**req_copy)
 
@@ -3136,11 +3174,11 @@ class TestDeleteTrainingQueries():
         _service.disable_retries()
         self.test_delete_training_queries_value_error()
 
+
 class TestCreateTrainingQuery():
     """
     Test Class for create_training_query
     """
-
     @responses.activate
     def test_create_training_query_all_params(self):
         """
@@ -3168,13 +3206,11 @@ class TestCreateTrainingQuery():
         filter = 'testString'
 
         # Invoke method
-        response = _service.create_training_query(
-            project_id,
-            natural_language_query,
-            examples,
-            filter=filter,
-            headers={}
-        )
+        response = _service.create_training_query(project_id,
+                                                  natural_language_query,
+                                                  examples,
+                                                  filter=filter,
+                                                  headers={})
 
         # Check for correct operation
         assert len(responses.calls) == 1
@@ -3227,7 +3263,10 @@ class TestCreateTrainingQuery():
             "examples": examples,
         }
         for param in req_param_dict.keys():
-            req_copy = {key:val if key is not param else None for (key,val) in req_param_dict.items()}
+            req_copy = {
+                key: val if key is not param else None
+                for (key, val) in req_param_dict.items()
+            }
             with pytest.raises(ValueError):
                 _service.create_training_query(**req_copy)
 
@@ -3240,18 +3279,19 @@ class TestCreateTrainingQuery():
         _service.disable_retries()
         self.test_create_training_query_value_error()
 
+
 class TestGetTrainingQuery():
     """
     Test Class for get_training_query
     """
-
     @responses.activate
     def test_get_training_query_all_params(self):
         """
         get_training_query()
         """
         # Set up mock
-        url = preprocess_url('/v2/projects/testString/training_data/queries/testString')
+        url = preprocess_url(
+            '/v2/projects/testString/training_data/queries/testString')
         mock_response = '{"query_id": "query_id", "natural_language_query": "natural_language_query", "filter": "filter", "created": "2019-01-01T12:00:00.000Z", "updated": "2019-01-01T12:00:00.000Z", "examples": [{"document_id": "document_id", "collection_id": "collection_id", "relevance": 9, "created": "2019-01-01T12:00:00.000Z", "updated": "2019-01-01T12:00:00.000Z"}]}'
         responses.add(responses.GET,
                       url,
@@ -3264,11 +3304,9 @@ class TestGetTrainingQuery():
         query_id = 'testString'
 
         # Invoke method
-        response = _service.get_training_query(
-            project_id,
-            query_id,
-            headers={}
-        )
+        response = _service.get_training_query(project_id,
+                                               query_id,
+                                               headers={})
 
         # Check for correct operation
         assert len(responses.calls) == 1
@@ -3289,7 +3327,8 @@ class TestGetTrainingQuery():
         test_get_training_query_value_error()
         """
         # Set up mock
-        url = preprocess_url('/v2/projects/testString/training_data/queries/testString')
+        url = preprocess_url(
+            '/v2/projects/testString/training_data/queries/testString')
         mock_response = '{"query_id": "query_id", "natural_language_query": "natural_language_query", "filter": "filter", "created": "2019-01-01T12:00:00.000Z", "updated": "2019-01-01T12:00:00.000Z", "examples": [{"document_id": "document_id", "collection_id": "collection_id", "relevance": 9, "created": "2019-01-01T12:00:00.000Z", "updated": "2019-01-01T12:00:00.000Z"}]}'
         responses.add(responses.GET,
                       url,
@@ -3307,7 +3346,10 @@ class TestGetTrainingQuery():
             "query_id": query_id,
         }
         for param in req_param_dict.keys():
-            req_copy = {key:val if key is not param else None for (key,val) in req_param_dict.items()}
+            req_copy = {
+                key: val if key is not param else None
+                for (key, val) in req_param_dict.items()
+            }
             with pytest.raises(ValueError):
                 _service.get_training_query(**req_copy)
 
@@ -3320,18 +3362,19 @@ class TestGetTrainingQuery():
         _service.disable_retries()
         self.test_get_training_query_value_error()
 
+
 class TestUpdateTrainingQuery():
     """
     Test Class for update_training_query
     """
-
     @responses.activate
     def test_update_training_query_all_params(self):
         """
         update_training_query()
         """
         # Set up mock
-        url = preprocess_url('/v2/projects/testString/training_data/queries/testString')
+        url = preprocess_url(
+            '/v2/projects/testString/training_data/queries/testString')
         mock_response = '{"query_id": "query_id", "natural_language_query": "natural_language_query", "filter": "filter", "created": "2019-01-01T12:00:00.000Z", "updated": "2019-01-01T12:00:00.000Z", "examples": [{"document_id": "document_id", "collection_id": "collection_id", "relevance": 9, "created": "2019-01-01T12:00:00.000Z", "updated": "2019-01-01T12:00:00.000Z"}]}'
         responses.add(responses.POST,
                       url,
@@ -3353,14 +3396,12 @@ class TestUpdateTrainingQuery():
         filter = 'testString'
 
         # Invoke method
-        response = _service.update_training_query(
-            project_id,
-            query_id,
-            natural_language_query,
-            examples,
-            filter=filter,
-            headers={}
-        )
+        response = _service.update_training_query(project_id,
+                                                  query_id,
+                                                  natural_language_query,
+                                                  examples,
+                                                  filter=filter,
+                                                  headers={})
 
         # Check for correct operation
         assert len(responses.calls) == 1
@@ -3386,7 +3427,8 @@ class TestUpdateTrainingQuery():
         test_update_training_query_value_error()
         """
         # Set up mock
-        url = preprocess_url('/v2/projects/testString/training_data/queries/testString')
+        url = preprocess_url(
+            '/v2/projects/testString/training_data/queries/testString')
         mock_response = '{"query_id": "query_id", "natural_language_query": "natural_language_query", "filter": "filter", "created": "2019-01-01T12:00:00.000Z", "updated": "2019-01-01T12:00:00.000Z", "examples": [{"document_id": "document_id", "collection_id": "collection_id", "relevance": 9, "created": "2019-01-01T12:00:00.000Z", "updated": "2019-01-01T12:00:00.000Z"}]}'
         responses.add(responses.POST,
                       url,
@@ -3415,7 +3457,10 @@ class TestUpdateTrainingQuery():
             "examples": examples,
         }
         for param in req_param_dict.keys():
-            req_copy = {key:val if key is not param else None for (key,val) in req_param_dict.items()}
+            req_copy = {
+                key: val if key is not param else None
+                for (key, val) in req_param_dict.items()
+            }
             with pytest.raises(ValueError):
                 _service.update_training_query(**req_copy)
 
@@ -3428,32 +3473,29 @@ class TestUpdateTrainingQuery():
         _service.disable_retries()
         self.test_update_training_query_value_error()
 
+
 class TestDeleteTrainingQuery():
     """
     Test Class for delete_training_query
     """
-
     @responses.activate
     def test_delete_training_query_all_params(self):
         """
         delete_training_query()
         """
         # Set up mock
-        url = preprocess_url('/v2/projects/testString/training_data/queries/testString')
-        responses.add(responses.DELETE,
-                      url,
-                      status=204)
+        url = preprocess_url(
+            '/v2/projects/testString/training_data/queries/testString')
+        responses.add(responses.DELETE, url, status=204)
 
         # Set up parameter values
         project_id = 'testString'
         query_id = 'testString'
 
         # Invoke method
-        response = _service.delete_training_query(
-            project_id,
-            query_id,
-            headers={}
-        )
+        response = _service.delete_training_query(project_id,
+                                                  query_id,
+                                                  headers={})
 
         # Check for correct operation
         assert len(responses.calls) == 1
@@ -3474,10 +3516,9 @@ class TestDeleteTrainingQuery():
         test_delete_training_query_value_error()
         """
         # Set up mock
-        url = preprocess_url('/v2/projects/testString/training_data/queries/testString')
-        responses.add(responses.DELETE,
-                      url,
-                      status=204)
+        url = preprocess_url(
+            '/v2/projects/testString/training_data/queries/testString')
+        responses.add(responses.DELETE, url, status=204)
 
         # Set up parameter values
         project_id = 'testString'
@@ -3489,7 +3530,10 @@ class TestDeleteTrainingQuery():
             "query_id": query_id,
         }
         for param in req_param_dict.keys():
-            req_copy = {key:val if key is not param else None for (key,val) in req_param_dict.items()}
+            req_copy = {
+                key: val if key is not param else None
+                for (key, val) in req_param_dict.items()
+            }
             with pytest.raises(ValueError):
                 _service.delete_training_query(**req_copy)
 
@@ -3502,6 +3546,7 @@ class TestDeleteTrainingQuery():
         _service.disable_retries()
         self.test_delete_training_query_value_error()
 
+
 # endregion
 ##############################################################################
 # End of Service: TrainingData
@@ -3512,11 +3557,11 @@ class TestDeleteTrainingQuery():
 ##############################################################################
 # region
 
+
 class TestListEnrichments():
     """
     Test Class for list_enrichments
     """
-
     @responses.activate
     def test_list_enrichments_all_params(self):
         """
@@ -3535,10 +3580,7 @@ class TestListEnrichments():
         project_id = 'testString'
 
         # Invoke method
-        response = _service.list_enrichments(
-            project_id,
-            headers={}
-        )
+        response = _service.list_enrichments(project_id, headers={})
 
         # Check for correct operation
         assert len(responses.calls) == 1
@@ -3575,7 +3617,10 @@ class TestListEnrichments():
             "project_id": project_id,
         }
         for param in req_param_dict.keys():
-            req_copy = {key:val if key is not param else None for (key,val) in req_param_dict.items()}
+            req_copy = {
+                key: val if key is not param else None
+                for (key, val) in req_param_dict.items()
+            }
             with pytest.raises(ValueError):
                 _service.list_enrichments(**req_copy)
 
@@ -3588,11 +3633,11 @@ class TestListEnrichments():
         _service.disable_retries()
         self.test_list_enrichments_value_error()
 
+
 class TestCreateEnrichment():
     """
     Test Class for create_enrichment
     """
-
     @responses.activate
     def test_create_enrichment_all_params(self):
         """
@@ -3631,12 +3676,10 @@ class TestCreateEnrichment():
         file = io.BytesIO(b'This is a mock file.').getvalue()
 
         # Invoke method
-        response = _service.create_enrichment(
-            project_id,
-            enrichment,
-            file=file,
-            headers={}
-        )
+        response = _service.create_enrichment(project_id,
+                                              enrichment,
+                                              file=file,
+                                              headers={})
 
         # Check for correct operation
         assert len(responses.calls) == 1
@@ -3688,11 +3731,9 @@ class TestCreateEnrichment():
         enrichment = create_enrichment_model
 
         # Invoke method
-        response = _service.create_enrichment(
-            project_id,
-            enrichment,
-            headers={}
-        )
+        response = _service.create_enrichment(project_id,
+                                              enrichment,
+                                              headers={})
 
         # Check for correct operation
         assert len(responses.calls) == 1
@@ -3749,7 +3790,10 @@ class TestCreateEnrichment():
             "enrichment": enrichment,
         }
         for param in req_param_dict.keys():
-            req_copy = {key:val if key is not param else None for (key,val) in req_param_dict.items()}
+            req_copy = {
+                key: val if key is not param else None
+                for (key, val) in req_param_dict.items()
+            }
             with pytest.raises(ValueError):
                 _service.create_enrichment(**req_copy)
 
@@ -3762,11 +3806,11 @@ class TestCreateEnrichment():
         _service.disable_retries()
         self.test_create_enrichment_value_error()
 
+
 class TestGetEnrichment():
     """
     Test Class for get_enrichment
     """
-
     @responses.activate
     def test_get_enrichment_all_params(self):
         """
@@ -3786,11 +3830,9 @@ class TestGetEnrichment():
         enrichment_id = 'testString'
 
         # Invoke method
-        response = _service.get_enrichment(
-            project_id,
-            enrichment_id,
-            headers={}
-        )
+        response = _service.get_enrichment(project_id,
+                                           enrichment_id,
+                                           headers={})
 
         # Check for correct operation
         assert len(responses.calls) == 1
@@ -3829,7 +3871,10 @@ class TestGetEnrichment():
             "enrichment_id": enrichment_id,
         }
         for param in req_param_dict.keys():
-            req_copy = {key:val if key is not param else None for (key,val) in req_param_dict.items()}
+            req_copy = {
+                key: val if key is not param else None
+                for (key, val) in req_param_dict.items()
+            }
             with pytest.raises(ValueError):
                 _service.get_enrichment(**req_copy)
 
@@ -3842,11 +3887,11 @@ class TestGetEnrichment():
         _service.disable_retries()
         self.test_get_enrichment_value_error()
 
+
 class TestUpdateEnrichment():
     """
     Test Class for update_enrichment
     """
-
     @responses.activate
     def test_update_enrichment_all_params(self):
         """
@@ -3868,13 +3913,11 @@ class TestUpdateEnrichment():
         description = 'testString'
 
         # Invoke method
-        response = _service.update_enrichment(
-            project_id,
-            enrichment_id,
-            name,
-            description=description,
-            headers={}
-        )
+        response = _service.update_enrichment(project_id,
+                                              enrichment_id,
+                                              name,
+                                              description=description,
+                                              headers={})
 
         # Check for correct operation
         assert len(responses.calls) == 1
@@ -3920,7 +3963,10 @@ class TestUpdateEnrichment():
             "name": name,
         }
         for param in req_param_dict.keys():
-            req_copy = {key:val if key is not param else None for (key,val) in req_param_dict.items()}
+            req_copy = {
+                key: val if key is not param else None
+                for (key, val) in req_param_dict.items()
+            }
             with pytest.raises(ValueError):
                 _service.update_enrichment(**req_copy)
 
@@ -3933,11 +3979,11 @@ class TestUpdateEnrichment():
         _service.disable_retries()
         self.test_update_enrichment_value_error()
 
+
 class TestDeleteEnrichment():
     """
     Test Class for delete_enrichment
     """
-
     @responses.activate
     def test_delete_enrichment_all_params(self):
         """
@@ -3945,20 +3991,16 @@ class TestDeleteEnrichment():
         """
         # Set up mock
         url = preprocess_url('/v2/projects/testString/enrichments/testString')
-        responses.add(responses.DELETE,
-                      url,
-                      status=204)
+        responses.add(responses.DELETE, url, status=204)
 
         # Set up parameter values
         project_id = 'testString'
         enrichment_id = 'testString'
 
         # Invoke method
-        response = _service.delete_enrichment(
-            project_id,
-            enrichment_id,
-            headers={}
-        )
+        response = _service.delete_enrichment(project_id,
+                                              enrichment_id,
+                                              headers={})
 
         # Check for correct operation
         assert len(responses.calls) == 1
@@ -3980,9 +4022,7 @@ class TestDeleteEnrichment():
         """
         # Set up mock
         url = preprocess_url('/v2/projects/testString/enrichments/testString')
-        responses.add(responses.DELETE,
-                      url,
-                      status=204)
+        responses.add(responses.DELETE, url, status=204)
 
         # Set up parameter values
         project_id = 'testString'
@@ -3994,7 +4034,10 @@ class TestDeleteEnrichment():
             "enrichment_id": enrichment_id,
         }
         for param in req_param_dict.keys():
-            req_copy = {key:val if key is not param else None for (key,val) in req_param_dict.items()}
+            req_copy = {
+                key: val if key is not param else None
+                for (key, val) in req_param_dict.items()
+            }
             with pytest.raises(ValueError):
                 _service.delete_enrichment(**req_copy)
 
@@ -4007,6 +4050,7 @@ class TestDeleteEnrichment():
         _service.disable_retries()
         self.test_delete_enrichment_value_error()
 
+
 # endregion
 ##############################################################################
 # End of Service: Enrichments
@@ -4017,11 +4061,11 @@ class TestDeleteEnrichment():
 ##############################################################################
 # region
 
+
 class TestListDocumentClassifiers():
     """
     Test Class for list_document_classifiers
     """
-
     @responses.activate
     def test_list_document_classifiers_all_params(self):
         """
@@ -4040,10 +4084,7 @@ class TestListDocumentClassifiers():
         project_id = 'testString'
 
         # Invoke method
-        response = _service.list_document_classifiers(
-            project_id,
-            headers={}
-        )
+        response = _service.list_document_classifiers(project_id, headers={})
 
         # Check for correct operation
         assert len(responses.calls) == 1
@@ -4080,7 +4121,10 @@ class TestListDocumentClassifiers():
             "project_id": project_id,
         }
         for param in req_param_dict.keys():
-            req_copy = {key:val if key is not param else None for (key,val) in req_param_dict.items()}
+            req_copy = {
+                key: val if key is not param else None
+                for (key, val) in req_param_dict.items()
+            }
             with pytest.raises(ValueError):
                 _service.list_document_classifiers(**req_copy)
 
@@ -4093,11 +4137,11 @@ class TestListDocumentClassifiers():
         _service.disable_retries()
         self.test_list_document_classifiers_value_error()
 
+
 class TestCreateDocumentClassifier():
     """
     Test Class for create_document_classifier
     """
-
     @responses.activate
     def test_create_document_classifier_all_params(self):
         """
@@ -4127,8 +4171,11 @@ class TestCreateDocumentClassifier():
         create_document_classifier_model['description'] = 'testString'
         create_document_classifier_model['language'] = 'en'
         create_document_classifier_model['answer_field'] = 'testString'
-        create_document_classifier_model['enrichments'] = [document_classifier_enrichment_model]
-        create_document_classifier_model['federated_classification'] = classifier_federated_model_model
+        create_document_classifier_model['enrichments'] = [
+            document_classifier_enrichment_model
+        ]
+        create_document_classifier_model[
+            'federated_classification'] = classifier_federated_model_model
 
         # Set up parameter values
         project_id = 'testString'
@@ -4137,13 +4184,11 @@ class TestCreateDocumentClassifier():
         test_data = io.BytesIO(b'This is a mock file.').getvalue()
 
         # Invoke method
-        response = _service.create_document_classifier(
-            project_id,
-            training_data,
-            classifier,
-            test_data=test_data,
-            headers={}
-        )
+        response = _service.create_document_classifier(project_id,
+                                                       training_data,
+                                                       classifier,
+                                                       test_data=test_data,
+                                                       headers={})
 
         # Check for correct operation
         assert len(responses.calls) == 1
@@ -4187,8 +4232,11 @@ class TestCreateDocumentClassifier():
         create_document_classifier_model['description'] = 'testString'
         create_document_classifier_model['language'] = 'en'
         create_document_classifier_model['answer_field'] = 'testString'
-        create_document_classifier_model['enrichments'] = [document_classifier_enrichment_model]
-        create_document_classifier_model['federated_classification'] = classifier_federated_model_model
+        create_document_classifier_model['enrichments'] = [
+            document_classifier_enrichment_model
+        ]
+        create_document_classifier_model[
+            'federated_classification'] = classifier_federated_model_model
 
         # Set up parameter values
         project_id = 'testString'
@@ -4196,12 +4244,10 @@ class TestCreateDocumentClassifier():
         classifier = create_document_classifier_model
 
         # Invoke method
-        response = _service.create_document_classifier(
-            project_id,
-            training_data,
-            classifier,
-            headers={}
-        )
+        response = _service.create_document_classifier(project_id,
+                                                       training_data,
+                                                       classifier,
+                                                       headers={})
 
         # Check for correct operation
         assert len(responses.calls) == 1
@@ -4245,8 +4291,11 @@ class TestCreateDocumentClassifier():
         create_document_classifier_model['description'] = 'testString'
         create_document_classifier_model['language'] = 'en'
         create_document_classifier_model['answer_field'] = 'testString'
-        create_document_classifier_model['enrichments'] = [document_classifier_enrichment_model]
-        create_document_classifier_model['federated_classification'] = classifier_federated_model_model
+        create_document_classifier_model['enrichments'] = [
+            document_classifier_enrichment_model
+        ]
+        create_document_classifier_model[
+            'federated_classification'] = classifier_federated_model_model
 
         # Set up parameter values
         project_id = 'testString'
@@ -4260,7 +4309,10 @@ class TestCreateDocumentClassifier():
             "classifier": classifier,
         }
         for param in req_param_dict.keys():
-            req_copy = {key:val if key is not param else None for (key,val) in req_param_dict.items()}
+            req_copy = {
+                key: val if key is not param else None
+                for (key, val) in req_param_dict.items()
+            }
             with pytest.raises(ValueError):
                 _service.create_document_classifier(**req_copy)
 
@@ -4273,18 +4325,19 @@ class TestCreateDocumentClassifier():
         _service.disable_retries()
         self.test_create_document_classifier_value_error()
 
+
 class TestGetDocumentClassifier():
     """
     Test Class for get_document_classifier
     """
-
     @responses.activate
     def test_get_document_classifier_all_params(self):
         """
         get_document_classifier()
         """
         # Set up mock
-        url = preprocess_url('/v2/projects/testString/document_classifiers/testString')
+        url = preprocess_url(
+            '/v2/projects/testString/document_classifiers/testString')
         mock_response = '{"classifier_id": "classifier_id", "name": "name", "description": "description", "created": "2019-01-01T12:00:00.000Z", "language": "en", "enrichments": [{"enrichment_id": "enrichment_id", "fields": ["fields"]}], "recognized_fields": ["recognized_fields"], "answer_field": "answer_field", "training_data_file": "training_data_file", "test_data_file": "test_data_file", "federated_classification": {"field": "field"}}'
         responses.add(responses.GET,
                       url,
@@ -4297,11 +4350,9 @@ class TestGetDocumentClassifier():
         classifier_id = 'testString'
 
         # Invoke method
-        response = _service.get_document_classifier(
-            project_id,
-            classifier_id,
-            headers={}
-        )
+        response = _service.get_document_classifier(project_id,
+                                                    classifier_id,
+                                                    headers={})
 
         # Check for correct operation
         assert len(responses.calls) == 1
@@ -4322,7 +4373,8 @@ class TestGetDocumentClassifier():
         test_get_document_classifier_value_error()
         """
         # Set up mock
-        url = preprocess_url('/v2/projects/testString/document_classifiers/testString')
+        url = preprocess_url(
+            '/v2/projects/testString/document_classifiers/testString')
         mock_response = '{"classifier_id": "classifier_id", "name": "name", "description": "description", "created": "2019-01-01T12:00:00.000Z", "language": "en", "enrichments": [{"enrichment_id": "enrichment_id", "fields": ["fields"]}], "recognized_fields": ["recognized_fields"], "answer_field": "answer_field", "training_data_file": "training_data_file", "test_data_file": "test_data_file", "federated_classification": {"field": "field"}}'
         responses.add(responses.GET,
                       url,
@@ -4340,7 +4392,10 @@ class TestGetDocumentClassifier():
             "classifier_id": classifier_id,
         }
         for param in req_param_dict.keys():
-            req_copy = {key:val if key is not param else None for (key,val) in req_param_dict.items()}
+            req_copy = {
+                key: val if key is not param else None
+                for (key, val) in req_param_dict.items()
+            }
             with pytest.raises(ValueError):
                 _service.get_document_classifier(**req_copy)
 
@@ -4353,18 +4408,19 @@ class TestGetDocumentClassifier():
         _service.disable_retries()
         self.test_get_document_classifier_value_error()
 
+
 class TestUpdateDocumentClassifier():
     """
     Test Class for update_document_classifier
     """
-
     @responses.activate
     def test_update_document_classifier_all_params(self):
         """
         update_document_classifier()
         """
         # Set up mock
-        url = preprocess_url('/v2/projects/testString/document_classifiers/testString')
+        url = preprocess_url(
+            '/v2/projects/testString/document_classifiers/testString')
         mock_response = '{"classifier_id": "classifier_id", "name": "name", "description": "description", "created": "2019-01-01T12:00:00.000Z", "language": "en", "enrichments": [{"enrichment_id": "enrichment_id", "fields": ["fields"]}], "recognized_fields": ["recognized_fields"], "answer_field": "answer_field", "training_data_file": "training_data_file", "test_data_file": "test_data_file", "federated_classification": {"field": "field"}}'
         responses.add(responses.POST,
                       url,
@@ -4391,8 +4447,7 @@ class TestUpdateDocumentClassifier():
             classifier,
             training_data=training_data,
             test_data=test_data,
-            headers={}
-        )
+            headers={})
 
         # Check for correct operation
         assert len(responses.calls) == 1
@@ -4413,7 +4468,8 @@ class TestUpdateDocumentClassifier():
         test_update_document_classifier_required_params()
         """
         # Set up mock
-        url = preprocess_url('/v2/projects/testString/document_classifiers/testString')
+        url = preprocess_url(
+            '/v2/projects/testString/document_classifiers/testString')
         mock_response = '{"classifier_id": "classifier_id", "name": "name", "description": "description", "created": "2019-01-01T12:00:00.000Z", "language": "en", "enrichments": [{"enrichment_id": "enrichment_id", "fields": ["fields"]}], "recognized_fields": ["recognized_fields"], "answer_field": "answer_field", "training_data_file": "training_data_file", "test_data_file": "test_data_file", "federated_classification": {"field": "field"}}'
         responses.add(responses.POST,
                       url,
@@ -4432,12 +4488,10 @@ class TestUpdateDocumentClassifier():
         classifier = update_document_classifier_model
 
         # Invoke method
-        response = _service.update_document_classifier(
-            project_id,
-            classifier_id,
-            classifier,
-            headers={}
-        )
+        response = _service.update_document_classifier(project_id,
+                                                       classifier_id,
+                                                       classifier,
+                                                       headers={})
 
         # Check for correct operation
         assert len(responses.calls) == 1
@@ -4458,7 +4512,8 @@ class TestUpdateDocumentClassifier():
         test_update_document_classifier_value_error()
         """
         # Set up mock
-        url = preprocess_url('/v2/projects/testString/document_classifiers/testString')
+        url = preprocess_url(
+            '/v2/projects/testString/document_classifiers/testString')
         mock_response = '{"classifier_id": "classifier_id", "name": "name", "description": "description", "created": "2019-01-01T12:00:00.000Z", "language": "en", "enrichments": [{"enrichment_id": "enrichment_id", "fields": ["fields"]}], "recognized_fields": ["recognized_fields"], "answer_field": "answer_field", "training_data_file": "training_data_file", "test_data_file": "test_data_file", "federated_classification": {"field": "field"}}'
         responses.add(responses.POST,
                       url,
@@ -4483,7 +4538,10 @@ class TestUpdateDocumentClassifier():
             "classifier": classifier,
         }
         for param in req_param_dict.keys():
-            req_copy = {key:val if key is not param else None for (key,val) in req_param_dict.items()}
+            req_copy = {
+                key: val if key is not param else None
+                for (key, val) in req_param_dict.items()
+            }
             with pytest.raises(ValueError):
                 _service.update_document_classifier(**req_copy)
 
@@ -4496,32 +4554,29 @@ class TestUpdateDocumentClassifier():
         _service.disable_retries()
         self.test_update_document_classifier_value_error()
 
+
 class TestDeleteDocumentClassifier():
     """
     Test Class for delete_document_classifier
     """
-
     @responses.activate
     def test_delete_document_classifier_all_params(self):
         """
         delete_document_classifier()
         """
         # Set up mock
-        url = preprocess_url('/v2/projects/testString/document_classifiers/testString')
-        responses.add(responses.DELETE,
-                      url,
-                      status=204)
+        url = preprocess_url(
+            '/v2/projects/testString/document_classifiers/testString')
+        responses.add(responses.DELETE, url, status=204)
 
         # Set up parameter values
         project_id = 'testString'
         classifier_id = 'testString'
 
         # Invoke method
-        response = _service.delete_document_classifier(
-            project_id,
-            classifier_id,
-            headers={}
-        )
+        response = _service.delete_document_classifier(project_id,
+                                                       classifier_id,
+                                                       headers={})
 
         # Check for correct operation
         assert len(responses.calls) == 1
@@ -4542,10 +4597,9 @@ class TestDeleteDocumentClassifier():
         test_delete_document_classifier_value_error()
         """
         # Set up mock
-        url = preprocess_url('/v2/projects/testString/document_classifiers/testString')
-        responses.add(responses.DELETE,
-                      url,
-                      status=204)
+        url = preprocess_url(
+            '/v2/projects/testString/document_classifiers/testString')
+        responses.add(responses.DELETE, url, status=204)
 
         # Set up parameter values
         project_id = 'testString'
@@ -4557,7 +4611,10 @@ class TestDeleteDocumentClassifier():
             "classifier_id": classifier_id,
         }
         for param in req_param_dict.keys():
-            req_copy = {key:val if key is not param else None for (key,val) in req_param_dict.items()}
+            req_copy = {
+                key: val if key is not param else None
+                for (key, val) in req_param_dict.items()
+            }
             with pytest.raises(ValueError):
                 _service.delete_document_classifier(**req_copy)
 
@@ -4570,6 +4627,7 @@ class TestDeleteDocumentClassifier():
         _service.disable_retries()
         self.test_delete_document_classifier_value_error()
 
+
 # endregion
 ##############################################################################
 # End of Service: DocumentClassifiers
@@ -4580,18 +4638,19 @@ class TestDeleteDocumentClassifier():
 ##############################################################################
 # region
 
+
 class TestListDocumentClassifierModels():
     """
     Test Class for list_document_classifier_models
     """
-
     @responses.activate
     def test_list_document_classifier_models_all_params(self):
         """
         list_document_classifier_models()
         """
         # Set up mock
-        url = preprocess_url('/v2/projects/testString/document_classifiers/testString/models')
+        url = preprocess_url(
+            '/v2/projects/testString/document_classifiers/testString/models')
         mock_response = '{"models": [{"model_id": "model_id", "name": "name", "description": "description", "created": "2019-01-01T12:00:00.000Z", "updated": "2019-01-01T12:00:00.000Z", "training_data_file": "training_data_file", "test_data_file": "test_data_file", "status": "training", "evaluation": {"micro_average": {"precision": 0, "recall": 0, "f1": 0}, "macro_average": {"precision": 0, "recall": 0, "f1": 0}, "per_class": [{"name": "name", "precision": 0, "recall": 0, "f1": 0}]}, "enrichment_id": "enrichment_id", "deployed_at": "2019-01-01T12:00:00.000Z"}]}'
         responses.add(responses.GET,
                       url,
@@ -4604,11 +4663,9 @@ class TestListDocumentClassifierModels():
         classifier_id = 'testString'
 
         # Invoke method
-        response = _service.list_document_classifier_models(
-            project_id,
-            classifier_id,
-            headers={}
-        )
+        response = _service.list_document_classifier_models(project_id,
+                                                            classifier_id,
+                                                            headers={})
 
         # Check for correct operation
         assert len(responses.calls) == 1
@@ -4629,7 +4686,8 @@ class TestListDocumentClassifierModels():
         test_list_document_classifier_models_value_error()
         """
         # Set up mock
-        url = preprocess_url('/v2/projects/testString/document_classifiers/testString/models')
+        url = preprocess_url(
+            '/v2/projects/testString/document_classifiers/testString/models')
         mock_response = '{"models": [{"model_id": "model_id", "name": "name", "description": "description", "created": "2019-01-01T12:00:00.000Z", "updated": "2019-01-01T12:00:00.000Z", "training_data_file": "training_data_file", "test_data_file": "test_data_file", "status": "training", "evaluation": {"micro_average": {"precision": 0, "recall": 0, "f1": 0}, "macro_average": {"precision": 0, "recall": 0, "f1": 0}, "per_class": [{"name": "name", "precision": 0, "recall": 0, "f1": 0}]}, "enrichment_id": "enrichment_id", "deployed_at": "2019-01-01T12:00:00.000Z"}]}'
         responses.add(responses.GET,
                       url,
@@ -4647,7 +4705,10 @@ class TestListDocumentClassifierModels():
             "classifier_id": classifier_id,
         }
         for param in req_param_dict.keys():
-            req_copy = {key:val if key is not param else None for (key,val) in req_param_dict.items()}
+            req_copy = {
+                key: val if key is not param else None
+                for (key, val) in req_param_dict.items()
+            }
             with pytest.raises(ValueError):
                 _service.list_document_classifier_models(**req_copy)
 
@@ -4660,18 +4721,19 @@ class TestListDocumentClassifierModels():
         _service.disable_retries()
         self.test_list_document_classifier_models_value_error()
 
+
 class TestCreateDocumentClassifierModel():
     """
     Test Class for create_document_classifier_model
     """
-
     @responses.activate
     def test_create_document_classifier_model_all_params(self):
         """
         create_document_classifier_model()
         """
         # Set up mock
-        url = preprocess_url('/v2/projects/testString/document_classifiers/testString/models')
+        url = preprocess_url(
+            '/v2/projects/testString/document_classifiers/testString/models')
         mock_response = '{"model_id": "model_id", "name": "name", "description": "description", "created": "2019-01-01T12:00:00.000Z", "updated": "2019-01-01T12:00:00.000Z", "training_data_file": "training_data_file", "test_data_file": "test_data_file", "status": "training", "evaluation": {"micro_average": {"precision": 0, "recall": 0, "f1": 0}, "macro_average": {"precision": 0, "recall": 0, "f1": 0}, "per_class": [{"name": "name", "precision": 0, "recall": 0, "f1": 0}]}, "enrichment_id": "enrichment_id", "deployed_at": "2019-01-01T12:00:00.000Z"}'
         responses.add(responses.POST,
                       url,
@@ -4701,8 +4763,7 @@ class TestCreateDocumentClassifierModel():
             l2_regularization_strengths=l2_regularization_strengths,
             training_max_steps=training_max_steps,
             improvement_ratio=improvement_ratio,
-            headers={}
-        )
+            headers={})
 
         # Check for correct operation
         assert len(responses.calls) == 1
@@ -4732,7 +4793,8 @@ class TestCreateDocumentClassifierModel():
         test_create_document_classifier_model_value_error()
         """
         # Set up mock
-        url = preprocess_url('/v2/projects/testString/document_classifiers/testString/models')
+        url = preprocess_url(
+            '/v2/projects/testString/document_classifiers/testString/models')
         mock_response = '{"model_id": "model_id", "name": "name", "description": "description", "created": "2019-01-01T12:00:00.000Z", "updated": "2019-01-01T12:00:00.000Z", "training_data_file": "training_data_file", "test_data_file": "test_data_file", "status": "training", "evaluation": {"micro_average": {"precision": 0, "recall": 0, "f1": 0}, "macro_average": {"precision": 0, "recall": 0, "f1": 0}, "per_class": [{"name": "name", "precision": 0, "recall": 0, "f1": 0}]}, "enrichment_id": "enrichment_id", "deployed_at": "2019-01-01T12:00:00.000Z"}'
         responses.add(responses.POST,
                       url,
@@ -4758,7 +4820,10 @@ class TestCreateDocumentClassifierModel():
             "name": name,
         }
         for param in req_param_dict.keys():
-            req_copy = {key:val if key is not param else None for (key,val) in req_param_dict.items()}
+            req_copy = {
+                key: val if key is not param else None
+                for (key, val) in req_param_dict.items()
+            }
             with pytest.raises(ValueError):
                 _service.create_document_classifier_model(**req_copy)
 
@@ -4771,18 +4836,20 @@ class TestCreateDocumentClassifierModel():
         _service.disable_retries()
         self.test_create_document_classifier_model_value_error()
 
+
 class TestGetDocumentClassifierModel():
     """
     Test Class for get_document_classifier_model
     """
-
     @responses.activate
     def test_get_document_classifier_model_all_params(self):
         """
         get_document_classifier_model()
         """
         # Set up mock
-        url = preprocess_url('/v2/projects/testString/document_classifiers/testString/models/testString')
+        url = preprocess_url(
+            '/v2/projects/testString/document_classifiers/testString/models/testString'
+        )
         mock_response = '{"model_id": "model_id", "name": "name", "description": "description", "created": "2019-01-01T12:00:00.000Z", "updated": "2019-01-01T12:00:00.000Z", "training_data_file": "training_data_file", "test_data_file": "test_data_file", "status": "training", "evaluation": {"micro_average": {"precision": 0, "recall": 0, "f1": 0}, "macro_average": {"precision": 0, "recall": 0, "f1": 0}, "per_class": [{"name": "name", "precision": 0, "recall": 0, "f1": 0}]}, "enrichment_id": "enrichment_id", "deployed_at": "2019-01-01T12:00:00.000Z"}'
         responses.add(responses.GET,
                       url,
@@ -4796,12 +4863,10 @@ class TestGetDocumentClassifierModel():
         model_id = 'testString'
 
         # Invoke method
-        response = _service.get_document_classifier_model(
-            project_id,
-            classifier_id,
-            model_id,
-            headers={}
-        )
+        response = _service.get_document_classifier_model(project_id,
+                                                          classifier_id,
+                                                          model_id,
+                                                          headers={})
 
         # Check for correct operation
         assert len(responses.calls) == 1
@@ -4822,7 +4887,9 @@ class TestGetDocumentClassifierModel():
         test_get_document_classifier_model_value_error()
         """
         # Set up mock
-        url = preprocess_url('/v2/projects/testString/document_classifiers/testString/models/testString')
+        url = preprocess_url(
+            '/v2/projects/testString/document_classifiers/testString/models/testString'
+        )
         mock_response = '{"model_id": "model_id", "name": "name", "description": "description", "created": "2019-01-01T12:00:00.000Z", "updated": "2019-01-01T12:00:00.000Z", "training_data_file": "training_data_file", "test_data_file": "test_data_file", "status": "training", "evaluation": {"micro_average": {"precision": 0, "recall": 0, "f1": 0}, "macro_average": {"precision": 0, "recall": 0, "f1": 0}, "per_class": [{"name": "name", "precision": 0, "recall": 0, "f1": 0}]}, "enrichment_id": "enrichment_id", "deployed_at": "2019-01-01T12:00:00.000Z"}'
         responses.add(responses.GET,
                       url,
@@ -4842,7 +4909,10 @@ class TestGetDocumentClassifierModel():
             "model_id": model_id,
         }
         for param in req_param_dict.keys():
-            req_copy = {key:val if key is not param else None for (key,val) in req_param_dict.items()}
+            req_copy = {
+                key: val if key is not param else None
+                for (key, val) in req_param_dict.items()
+            }
             with pytest.raises(ValueError):
                 _service.get_document_classifier_model(**req_copy)
 
@@ -4855,18 +4925,20 @@ class TestGetDocumentClassifierModel():
         _service.disable_retries()
         self.test_get_document_classifier_model_value_error()
 
+
 class TestUpdateDocumentClassifierModel():
     """
     Test Class for update_document_classifier_model
     """
-
     @responses.activate
     def test_update_document_classifier_model_all_params(self):
         """
         update_document_classifier_model()
         """
         # Set up mock
-        url = preprocess_url('/v2/projects/testString/document_classifiers/testString/models/testString')
+        url = preprocess_url(
+            '/v2/projects/testString/document_classifiers/testString/models/testString'
+        )
         mock_response = '{"model_id": "model_id", "name": "name", "description": "description", "created": "2019-01-01T12:00:00.000Z", "updated": "2019-01-01T12:00:00.000Z", "training_data_file": "training_data_file", "test_data_file": "test_data_file", "status": "training", "evaluation": {"micro_average": {"precision": 0, "recall": 0, "f1": 0}, "macro_average": {"precision": 0, "recall": 0, "f1": 0}, "per_class": [{"name": "name", "precision": 0, "recall": 0, "f1": 0}]}, "enrichment_id": "enrichment_id", "deployed_at": "2019-01-01T12:00:00.000Z"}'
         responses.add(responses.POST,
                       url,
@@ -4888,8 +4960,7 @@ class TestUpdateDocumentClassifierModel():
             model_id,
             name=name,
             description=description,
-            headers={}
-        )
+            headers={})
 
         # Check for correct operation
         assert len(responses.calls) == 1
@@ -4914,7 +4985,9 @@ class TestUpdateDocumentClassifierModel():
         test_update_document_classifier_model_value_error()
         """
         # Set up mock
-        url = preprocess_url('/v2/projects/testString/document_classifiers/testString/models/testString')
+        url = preprocess_url(
+            '/v2/projects/testString/document_classifiers/testString/models/testString'
+        )
         mock_response = '{"model_id": "model_id", "name": "name", "description": "description", "created": "2019-01-01T12:00:00.000Z", "updated": "2019-01-01T12:00:00.000Z", "training_data_file": "training_data_file", "test_data_file": "test_data_file", "status": "training", "evaluation": {"micro_average": {"precision": 0, "recall": 0, "f1": 0}, "macro_average": {"precision": 0, "recall": 0, "f1": 0}, "per_class": [{"name": "name", "precision": 0, "recall": 0, "f1": 0}]}, "enrichment_id": "enrichment_id", "deployed_at": "2019-01-01T12:00:00.000Z"}'
         responses.add(responses.POST,
                       url,
@@ -4936,7 +5009,10 @@ class TestUpdateDocumentClassifierModel():
             "model_id": model_id,
         }
         for param in req_param_dict.keys():
-            req_copy = {key:val if key is not param else None for (key,val) in req_param_dict.items()}
+            req_copy = {
+                key: val if key is not param else None
+                for (key, val) in req_param_dict.items()
+            }
             with pytest.raises(ValueError):
                 _service.update_document_classifier_model(**req_copy)
 
@@ -4949,21 +5025,21 @@ class TestUpdateDocumentClassifierModel():
         _service.disable_retries()
         self.test_update_document_classifier_model_value_error()
 
+
 class TestDeleteDocumentClassifierModel():
     """
     Test Class for delete_document_classifier_model
     """
-
     @responses.activate
     def test_delete_document_classifier_model_all_params(self):
         """
         delete_document_classifier_model()
         """
         # Set up mock
-        url = preprocess_url('/v2/projects/testString/document_classifiers/testString/models/testString')
-        responses.add(responses.DELETE,
-                      url,
-                      status=204)
+        url = preprocess_url(
+            '/v2/projects/testString/document_classifiers/testString/models/testString'
+        )
+        responses.add(responses.DELETE, url, status=204)
 
         # Set up parameter values
         project_id = 'testString'
@@ -4971,12 +5047,10 @@ class TestDeleteDocumentClassifierModel():
         model_id = 'testString'
 
         # Invoke method
-        response = _service.delete_document_classifier_model(
-            project_id,
-            classifier_id,
-            model_id,
-            headers={}
-        )
+        response = _service.delete_document_classifier_model(project_id,
+                                                             classifier_id,
+                                                             model_id,
+                                                             headers={})
 
         # Check for correct operation
         assert len(responses.calls) == 1
@@ -4997,10 +5071,10 @@ class TestDeleteDocumentClassifierModel():
         test_delete_document_classifier_model_value_error()
         """
         # Set up mock
-        url = preprocess_url('/v2/projects/testString/document_classifiers/testString/models/testString')
-        responses.add(responses.DELETE,
-                      url,
-                      status=204)
+        url = preprocess_url(
+            '/v2/projects/testString/document_classifiers/testString/models/testString'
+        )
+        responses.add(responses.DELETE, url, status=204)
 
         # Set up parameter values
         project_id = 'testString'
@@ -5014,7 +5088,10 @@ class TestDeleteDocumentClassifierModel():
             "model_id": model_id,
         }
         for param in req_param_dict.keys():
-            req_copy = {key:val if key is not param else None for (key,val) in req_param_dict.items()}
+            req_copy = {
+                key: val if key is not param else None
+                for (key, val) in req_param_dict.items()
+            }
             with pytest.raises(ValueError):
                 _service.delete_document_classifier_model(**req_copy)
 
@@ -5027,6 +5104,7 @@ class TestDeleteDocumentClassifierModel():
         _service.disable_retries()
         self.test_delete_document_classifier_model_value_error()
 
+
 # endregion
 ##############################################################################
 # End of Service: DocumentClassifierModels
@@ -5037,18 +5115,19 @@ class TestDeleteDocumentClassifierModel():
 ##############################################################################
 # region
 
+
 class TestAnalyzeDocument():
     """
     Test Class for analyze_document
     """
-
     @responses.activate
     def test_analyze_document_all_params(self):
         """
         analyze_document()
         """
         # Set up mock
-        url = preprocess_url('/v2/projects/testString/collections/testString/analyze')
+        url = preprocess_url(
+            '/v2/projects/testString/collections/testString/analyze')
         mock_response = '{"notices": [{"notice_id": "notice_id", "created": "2019-01-01T12:00:00.000Z", "document_id": "document_id", "collection_id": "collection_id", "query_id": "query_id", "severity": "warning", "step": "step", "description": "description"}], "result": {"metadata": {"mapKey": "anyValue"}}}'
         responses.add(responses.POST,
                       url,
@@ -5072,8 +5151,7 @@ class TestAnalyzeDocument():
             filename=filename,
             file_content_type=file_content_type,
             metadata=metadata,
-            headers={}
-        )
+            headers={})
 
         # Check for correct operation
         assert len(responses.calls) == 1
@@ -5094,7 +5172,8 @@ class TestAnalyzeDocument():
         test_analyze_document_required_params()
         """
         # Set up mock
-        url = preprocess_url('/v2/projects/testString/collections/testString/analyze')
+        url = preprocess_url(
+            '/v2/projects/testString/collections/testString/analyze')
         mock_response = '{"notices": [{"notice_id": "notice_id", "created": "2019-01-01T12:00:00.000Z", "document_id": "document_id", "collection_id": "collection_id", "query_id": "query_id", "severity": "warning", "step": "step", "description": "description"}], "result": {"metadata": {"mapKey": "anyValue"}}}'
         responses.add(responses.POST,
                       url,
@@ -5107,11 +5186,9 @@ class TestAnalyzeDocument():
         collection_id = 'testString'
 
         # Invoke method
-        response = _service.analyze_document(
-            project_id,
-            collection_id,
-            headers={}
-        )
+        response = _service.analyze_document(project_id,
+                                             collection_id,
+                                             headers={})
 
         # Check for correct operation
         assert len(responses.calls) == 1
@@ -5132,7 +5209,8 @@ class TestAnalyzeDocument():
         test_analyze_document_value_error()
         """
         # Set up mock
-        url = preprocess_url('/v2/projects/testString/collections/testString/analyze')
+        url = preprocess_url(
+            '/v2/projects/testString/collections/testString/analyze')
         mock_response = '{"notices": [{"notice_id": "notice_id", "created": "2019-01-01T12:00:00.000Z", "document_id": "document_id", "collection_id": "collection_id", "query_id": "query_id", "severity": "warning", "step": "step", "description": "description"}], "result": {"metadata": {"mapKey": "anyValue"}}}'
         responses.add(responses.POST,
                       url,
@@ -5150,7 +5228,10 @@ class TestAnalyzeDocument():
             "collection_id": collection_id,
         }
         for param in req_param_dict.keys():
-            req_copy = {key:val if key is not param else None for (key,val) in req_param_dict.items()}
+            req_copy = {
+                key: val if key is not param else None
+                for (key, val) in req_param_dict.items()
+            }
             with pytest.raises(ValueError):
                 _service.analyze_document(**req_copy)
 
@@ -5163,6 +5244,7 @@ class TestAnalyzeDocument():
         _service.disable_retries()
         self.test_analyze_document_value_error()
 
+
 # endregion
 ##############################################################################
 # End of Service: Analyze
@@ -5173,11 +5255,11 @@ class TestAnalyzeDocument():
 ##############################################################################
 # region
 
+
 class TestDeleteUserData():
     """
     Test Class for delete_user_data
     """
-
     @responses.activate
     def test_delete_user_data_all_params(self):
         """
@@ -5185,24 +5267,19 @@ class TestDeleteUserData():
         """
         # Set up mock
         url = preprocess_url('/v2/user_data')
-        responses.add(responses.DELETE,
-                      url,
-                      status=200)
+        responses.add(responses.DELETE, url, status=200)
 
         # Set up parameter values
         customer_id = 'testString'
 
         # Invoke method
-        response = _service.delete_user_data(
-            customer_id,
-            headers={}
-        )
+        response = _service.delete_user_data(customer_id, headers={})
 
         # Check for correct operation
         assert len(responses.calls) == 1
         assert response.status_code == 200
         # Validate query params
-        query_string = responses.calls[0].request.url.split('?',1)[1]
+        query_string = responses.calls[0].request.url.split('?', 1)[1]
         query_string = urllib.parse.unquote_plus(query_string)
         assert 'customer_id={}'.format(customer_id) in query_string
 
@@ -5222,9 +5299,7 @@ class TestDeleteUserData():
         """
         # Set up mock
         url = preprocess_url('/v2/user_data')
-        responses.add(responses.DELETE,
-                      url,
-                      status=200)
+        responses.add(responses.DELETE, url, status=200)
 
         # Set up parameter values
         customer_id = 'testString'
@@ -5234,7 +5309,10 @@ class TestDeleteUserData():
             "customer_id": customer_id,
         }
         for param in req_param_dict.keys():
-            req_copy = {key:val if key is not param else None for (key,val) in req_param_dict.items()}
+            req_copy = {
+                key: val if key is not param else None
+                for (key, val) in req_param_dict.items()
+            }
             with pytest.raises(ValueError):
                 _service.delete_user_data(**req_copy)
 
@@ -5246,6 +5324,7 @@ class TestDeleteUserData():
         # Disable retries and run test_delete_user_data_value_error.
         _service.disable_retries()
         self.test_delete_user_data_value_error()
+
 
 # endregion
 ##############################################################################
@@ -5261,7 +5340,6 @@ class TestModel_AnalyzedDocument():
     """
     Test Class for AnalyzedDocument
     """
-
     def test_analyzed_document_serialization(self):
         """
         Test serialization/deserialization for AnalyzedDocument
@@ -5269,7 +5347,7 @@ class TestModel_AnalyzedDocument():
 
         # Construct dict forms of any model objects needed in order to build this model.
 
-        notice_model = {} # Notice
+        notice_model = {}  # Notice
         notice_model['notice_id'] = 'testString'
         notice_model['created'] = '2019-01-01T12:00:00Z'
         notice_model['document_id'] = 'testString'
@@ -5279,7 +5357,7 @@ class TestModel_AnalyzedDocument():
         notice_model['step'] = 'testString'
         notice_model['description'] = 'testString'
 
-        analyzed_result_model = {} # AnalyzedResult
+        analyzed_result_model = {}  # AnalyzedResult
         analyzed_result_model['metadata'] = {'key1': 'testString'}
         analyzed_result_model['foo'] = {'foo': 'bar'}
 
@@ -5289,12 +5367,15 @@ class TestModel_AnalyzedDocument():
         analyzed_document_model_json['result'] = analyzed_result_model
 
         # Construct a model instance of AnalyzedDocument by calling from_dict on the json representation
-        analyzed_document_model = AnalyzedDocument.from_dict(analyzed_document_model_json)
+        analyzed_document_model = AnalyzedDocument.from_dict(
+            analyzed_document_model_json)
         assert analyzed_document_model != False
 
         # Construct a model instance of AnalyzedDocument by calling from_dict on the json representation
-        analyzed_document_model_dict = AnalyzedDocument.from_dict(analyzed_document_model_json).__dict__
-        analyzed_document_model2 = AnalyzedDocument(**analyzed_document_model_dict)
+        analyzed_document_model_dict = AnalyzedDocument.from_dict(
+            analyzed_document_model_json).__dict__
+        analyzed_document_model2 = AnalyzedDocument(
+            **analyzed_document_model_dict)
 
         # Verify the model instances are equivalent
         assert analyzed_document_model == analyzed_document_model2
@@ -5303,11 +5384,11 @@ class TestModel_AnalyzedDocument():
         analyzed_document_model_json2 = analyzed_document_model.to_dict()
         assert analyzed_document_model_json2 == analyzed_document_model_json
 
+
 class TestModel_AnalyzedResult():
     """
     Test Class for AnalyzedResult
     """
-
     def test_analyzed_result_serialization(self):
         """
         Test serialization/deserialization for AnalyzedResult
@@ -5319,11 +5400,13 @@ class TestModel_AnalyzedResult():
         analyzed_result_model_json['foo'] = {'foo': 'bar'}
 
         # Construct a model instance of AnalyzedResult by calling from_dict on the json representation
-        analyzed_result_model = AnalyzedResult.from_dict(analyzed_result_model_json)
+        analyzed_result_model = AnalyzedResult.from_dict(
+            analyzed_result_model_json)
         assert analyzed_result_model != False
 
         # Construct a model instance of AnalyzedResult by calling from_dict on the json representation
-        analyzed_result_model_dict = AnalyzedResult.from_dict(analyzed_result_model_json).__dict__
+        analyzed_result_model_dict = AnalyzedResult.from_dict(
+            analyzed_result_model_json).__dict__
         analyzed_result_model2 = AnalyzedResult(**analyzed_result_model_dict)
 
         # Verify the model instances are equivalent
@@ -5343,11 +5426,11 @@ class TestModel_AnalyzedResult():
         actual_dict = analyzed_result_model.get_properties()
         assert actual_dict == expected_dict
 
+
 class TestModel_ClassifierFederatedModel():
     """
     Test Class for ClassifierFederatedModel
     """
-
     def test_classifier_federated_model_serialization(self):
         """
         Test serialization/deserialization for ClassifierFederatedModel
@@ -5358,25 +5441,29 @@ class TestModel_ClassifierFederatedModel():
         classifier_federated_model_model_json['field'] = 'testString'
 
         # Construct a model instance of ClassifierFederatedModel by calling from_dict on the json representation
-        classifier_federated_model_model = ClassifierFederatedModel.from_dict(classifier_federated_model_model_json)
+        classifier_federated_model_model = ClassifierFederatedModel.from_dict(
+            classifier_federated_model_model_json)
         assert classifier_federated_model_model != False
 
         # Construct a model instance of ClassifierFederatedModel by calling from_dict on the json representation
-        classifier_federated_model_model_dict = ClassifierFederatedModel.from_dict(classifier_federated_model_model_json).__dict__
-        classifier_federated_model_model2 = ClassifierFederatedModel(**classifier_federated_model_model_dict)
+        classifier_federated_model_model_dict = ClassifierFederatedModel.from_dict(
+            classifier_federated_model_model_json).__dict__
+        classifier_federated_model_model2 = ClassifierFederatedModel(
+            **classifier_federated_model_model_dict)
 
         # Verify the model instances are equivalent
         assert classifier_federated_model_model == classifier_federated_model_model2
 
         # Convert model instance back to dict and verify no loss of data
-        classifier_federated_model_model_json2 = classifier_federated_model_model.to_dict()
+        classifier_federated_model_model_json2 = classifier_federated_model_model.to_dict(
+        )
         assert classifier_federated_model_model_json2 == classifier_federated_model_model_json
+
 
 class TestModel_ClassifierModelEvaluation():
     """
     Test Class for ClassifierModelEvaluation
     """
-
     def test_classifier_model_evaluation_serialization(self):
         """
         Test serialization/deserialization for ClassifierModelEvaluation
@@ -5384,17 +5471,19 @@ class TestModel_ClassifierModelEvaluation():
 
         # Construct dict forms of any model objects needed in order to build this model.
 
-        model_evaluation_micro_average_model = {} # ModelEvaluationMicroAverage
+        model_evaluation_micro_average_model = {
+        }  # ModelEvaluationMicroAverage
         model_evaluation_micro_average_model['precision'] = 0
         model_evaluation_micro_average_model['recall'] = 0
         model_evaluation_micro_average_model['f1'] = 0
 
-        model_evaluation_macro_average_model = {} # ModelEvaluationMacroAverage
+        model_evaluation_macro_average_model = {
+        }  # ModelEvaluationMacroAverage
         model_evaluation_macro_average_model['precision'] = 0
         model_evaluation_macro_average_model['recall'] = 0
         model_evaluation_macro_average_model['f1'] = 0
 
-        per_class_model_evaluation_model = {} # PerClassModelEvaluation
+        per_class_model_evaluation_model = {}  # PerClassModelEvaluation
         per_class_model_evaluation_model['name'] = 'testString'
         per_class_model_evaluation_model['precision'] = 0
         per_class_model_evaluation_model['recall'] = 0
@@ -5402,30 +5491,38 @@ class TestModel_ClassifierModelEvaluation():
 
         # Construct a json representation of a ClassifierModelEvaluation model
         classifier_model_evaluation_model_json = {}
-        classifier_model_evaluation_model_json['micro_average'] = model_evaluation_micro_average_model
-        classifier_model_evaluation_model_json['macro_average'] = model_evaluation_macro_average_model
-        classifier_model_evaluation_model_json['per_class'] = [per_class_model_evaluation_model]
+        classifier_model_evaluation_model_json[
+            'micro_average'] = model_evaluation_micro_average_model
+        classifier_model_evaluation_model_json[
+            'macro_average'] = model_evaluation_macro_average_model
+        classifier_model_evaluation_model_json['per_class'] = [
+            per_class_model_evaluation_model
+        ]
 
         # Construct a model instance of ClassifierModelEvaluation by calling from_dict on the json representation
-        classifier_model_evaluation_model = ClassifierModelEvaluation.from_dict(classifier_model_evaluation_model_json)
+        classifier_model_evaluation_model = ClassifierModelEvaluation.from_dict(
+            classifier_model_evaluation_model_json)
         assert classifier_model_evaluation_model != False
 
         # Construct a model instance of ClassifierModelEvaluation by calling from_dict on the json representation
-        classifier_model_evaluation_model_dict = ClassifierModelEvaluation.from_dict(classifier_model_evaluation_model_json).__dict__
-        classifier_model_evaluation_model2 = ClassifierModelEvaluation(**classifier_model_evaluation_model_dict)
+        classifier_model_evaluation_model_dict = ClassifierModelEvaluation.from_dict(
+            classifier_model_evaluation_model_json).__dict__
+        classifier_model_evaluation_model2 = ClassifierModelEvaluation(
+            **classifier_model_evaluation_model_dict)
 
         # Verify the model instances are equivalent
         assert classifier_model_evaluation_model == classifier_model_evaluation_model2
 
         # Convert model instance back to dict and verify no loss of data
-        classifier_model_evaluation_model_json2 = classifier_model_evaluation_model.to_dict()
+        classifier_model_evaluation_model_json2 = classifier_model_evaluation_model.to_dict(
+        )
         assert classifier_model_evaluation_model_json2 == classifier_model_evaluation_model_json
+
 
 class TestModel_Collection():
     """
     Test Class for Collection
     """
-
     def test_collection_serialization(self):
         """
         Test serialization/deserialization for Collection
@@ -5441,7 +5538,8 @@ class TestModel_Collection():
         assert collection_model != False
 
         # Construct a model instance of Collection by calling from_dict on the json representation
-        collection_model_dict = Collection.from_dict(collection_model_json).__dict__
+        collection_model_dict = Collection.from_dict(
+            collection_model_json).__dict__
         collection_model2 = Collection(**collection_model_dict)
 
         # Verify the model instances are equivalent
@@ -5451,11 +5549,11 @@ class TestModel_Collection():
         collection_model_json2 = collection_model.to_dict()
         assert collection_model_json2 == collection_model_json
 
+
 class TestModel_CollectionDetails():
     """
     Test Class for CollectionDetails
     """
-
     def test_collection_details_serialization(self):
         """
         Test serialization/deserialization for CollectionDetails
@@ -5463,13 +5561,15 @@ class TestModel_CollectionDetails():
 
         # Construct dict forms of any model objects needed in order to build this model.
 
-        collection_enrichment_model = {} # CollectionEnrichment
+        collection_enrichment_model = {}  # CollectionEnrichment
         collection_enrichment_model['enrichment_id'] = 'testString'
         collection_enrichment_model['fields'] = ['testString']
 
-        collection_details_smart_document_understanding_model = {} # CollectionDetailsSmartDocumentUnderstanding
+        collection_details_smart_document_understanding_model = {
+        }  # CollectionDetailsSmartDocumentUnderstanding
         collection_details_smart_document_understanding_model['enabled'] = True
-        collection_details_smart_document_understanding_model['model'] = 'custom'
+        collection_details_smart_document_understanding_model[
+            'model'] = 'custom'
 
         # Construct a json representation of a CollectionDetails model
         collection_details_model_json = {}
@@ -5478,16 +5578,22 @@ class TestModel_CollectionDetails():
         collection_details_model_json['description'] = 'testString'
         collection_details_model_json['created'] = '2019-01-01T12:00:00Z'
         collection_details_model_json['language'] = 'en'
-        collection_details_model_json['enrichments'] = [collection_enrichment_model]
-        collection_details_model_json['smart_document_understanding'] = collection_details_smart_document_understanding_model
+        collection_details_model_json['enrichments'] = [
+            collection_enrichment_model
+        ]
+        collection_details_model_json[
+            'smart_document_understanding'] = collection_details_smart_document_understanding_model
 
         # Construct a model instance of CollectionDetails by calling from_dict on the json representation
-        collection_details_model = CollectionDetails.from_dict(collection_details_model_json)
+        collection_details_model = CollectionDetails.from_dict(
+            collection_details_model_json)
         assert collection_details_model != False
 
         # Construct a model instance of CollectionDetails by calling from_dict on the json representation
-        collection_details_model_dict = CollectionDetails.from_dict(collection_details_model_json).__dict__
-        collection_details_model2 = CollectionDetails(**collection_details_model_dict)
+        collection_details_model_dict = CollectionDetails.from_dict(
+            collection_details_model_json).__dict__
+        collection_details_model2 = CollectionDetails(
+            **collection_details_model_dict)
 
         # Verify the model instances are equivalent
         assert collection_details_model == collection_details_model2
@@ -5496,41 +5602,49 @@ class TestModel_CollectionDetails():
         collection_details_model_json2 = collection_details_model.to_dict()
         assert collection_details_model_json2 == collection_details_model_json
 
+
 class TestModel_CollectionDetailsSmartDocumentUnderstanding():
     """
     Test Class for CollectionDetailsSmartDocumentUnderstanding
     """
-
-    def test_collection_details_smart_document_understanding_serialization(self):
+    def test_collection_details_smart_document_understanding_serialization(
+            self):
         """
         Test serialization/deserialization for CollectionDetailsSmartDocumentUnderstanding
         """
 
         # Construct a json representation of a CollectionDetailsSmartDocumentUnderstanding model
         collection_details_smart_document_understanding_model_json = {}
-        collection_details_smart_document_understanding_model_json['enabled'] = True
-        collection_details_smart_document_understanding_model_json['model'] = 'custom'
+        collection_details_smart_document_understanding_model_json[
+            'enabled'] = True
+        collection_details_smart_document_understanding_model_json[
+            'model'] = 'custom'
 
         # Construct a model instance of CollectionDetailsSmartDocumentUnderstanding by calling from_dict on the json representation
-        collection_details_smart_document_understanding_model = CollectionDetailsSmartDocumentUnderstanding.from_dict(collection_details_smart_document_understanding_model_json)
+        collection_details_smart_document_understanding_model = CollectionDetailsSmartDocumentUnderstanding.from_dict(
+            collection_details_smart_document_understanding_model_json)
         assert collection_details_smart_document_understanding_model != False
 
         # Construct a model instance of CollectionDetailsSmartDocumentUnderstanding by calling from_dict on the json representation
-        collection_details_smart_document_understanding_model_dict = CollectionDetailsSmartDocumentUnderstanding.from_dict(collection_details_smart_document_understanding_model_json).__dict__
-        collection_details_smart_document_understanding_model2 = CollectionDetailsSmartDocumentUnderstanding(**collection_details_smart_document_understanding_model_dict)
+        collection_details_smart_document_understanding_model_dict = CollectionDetailsSmartDocumentUnderstanding.from_dict(
+            collection_details_smart_document_understanding_model_json
+        ).__dict__
+        collection_details_smart_document_understanding_model2 = CollectionDetailsSmartDocumentUnderstanding(
+            **collection_details_smart_document_understanding_model_dict)
 
         # Verify the model instances are equivalent
         assert collection_details_smart_document_understanding_model == collection_details_smart_document_understanding_model2
 
         # Convert model instance back to dict and verify no loss of data
-        collection_details_smart_document_understanding_model_json2 = collection_details_smart_document_understanding_model.to_dict()
+        collection_details_smart_document_understanding_model_json2 = collection_details_smart_document_understanding_model.to_dict(
+        )
         assert collection_details_smart_document_understanding_model_json2 == collection_details_smart_document_understanding_model_json
+
 
 class TestModel_CollectionEnrichment():
     """
     Test Class for CollectionEnrichment
     """
-
     def test_collection_enrichment_serialization(self):
         """
         Test serialization/deserialization for CollectionEnrichment
@@ -5542,25 +5656,29 @@ class TestModel_CollectionEnrichment():
         collection_enrichment_model_json['fields'] = ['testString']
 
         # Construct a model instance of CollectionEnrichment by calling from_dict on the json representation
-        collection_enrichment_model = CollectionEnrichment.from_dict(collection_enrichment_model_json)
+        collection_enrichment_model = CollectionEnrichment.from_dict(
+            collection_enrichment_model_json)
         assert collection_enrichment_model != False
 
         # Construct a model instance of CollectionEnrichment by calling from_dict on the json representation
-        collection_enrichment_model_dict = CollectionEnrichment.from_dict(collection_enrichment_model_json).__dict__
-        collection_enrichment_model2 = CollectionEnrichment(**collection_enrichment_model_dict)
+        collection_enrichment_model_dict = CollectionEnrichment.from_dict(
+            collection_enrichment_model_json).__dict__
+        collection_enrichment_model2 = CollectionEnrichment(
+            **collection_enrichment_model_dict)
 
         # Verify the model instances are equivalent
         assert collection_enrichment_model == collection_enrichment_model2
 
         # Convert model instance back to dict and verify no loss of data
-        collection_enrichment_model_json2 = collection_enrichment_model.to_dict()
+        collection_enrichment_model_json2 = collection_enrichment_model.to_dict(
+        )
         assert collection_enrichment_model_json2 == collection_enrichment_model_json
+
 
 class TestModel_Completions():
     """
     Test Class for Completions
     """
-
     def test_completions_serialization(self):
         """
         Test serialization/deserialization for Completions
@@ -5575,7 +5693,8 @@ class TestModel_Completions():
         assert completions_model != False
 
         # Construct a model instance of Completions by calling from_dict on the json representation
-        completions_model_dict = Completions.from_dict(completions_model_json).__dict__
+        completions_model_dict = Completions.from_dict(
+            completions_model_json).__dict__
         completions_model2 = Completions(**completions_model_dict)
 
         # Verify the model instances are equivalent
@@ -5585,11 +5704,11 @@ class TestModel_Completions():
         completions_model_json2 = completions_model.to_dict()
         assert completions_model_json2 == completions_model_json
 
+
 class TestModel_ComponentSettingsAggregation():
     """
     Test Class for ComponentSettingsAggregation
     """
-
     def test_component_settings_aggregation_serialization(self):
         """
         Test serialization/deserialization for ComponentSettingsAggregation
@@ -5599,29 +5718,35 @@ class TestModel_ComponentSettingsAggregation():
         component_settings_aggregation_model_json = {}
         component_settings_aggregation_model_json['name'] = 'testString'
         component_settings_aggregation_model_json['label'] = 'testString'
-        component_settings_aggregation_model_json['multiple_selections_allowed'] = True
-        component_settings_aggregation_model_json['visualization_type'] = 'auto'
+        component_settings_aggregation_model_json[
+            'multiple_selections_allowed'] = True
+        component_settings_aggregation_model_json[
+            'visualization_type'] = 'auto'
 
         # Construct a model instance of ComponentSettingsAggregation by calling from_dict on the json representation
-        component_settings_aggregation_model = ComponentSettingsAggregation.from_dict(component_settings_aggregation_model_json)
+        component_settings_aggregation_model = ComponentSettingsAggregation.from_dict(
+            component_settings_aggregation_model_json)
         assert component_settings_aggregation_model != False
 
         # Construct a model instance of ComponentSettingsAggregation by calling from_dict on the json representation
-        component_settings_aggregation_model_dict = ComponentSettingsAggregation.from_dict(component_settings_aggregation_model_json).__dict__
-        component_settings_aggregation_model2 = ComponentSettingsAggregation(**component_settings_aggregation_model_dict)
+        component_settings_aggregation_model_dict = ComponentSettingsAggregation.from_dict(
+            component_settings_aggregation_model_json).__dict__
+        component_settings_aggregation_model2 = ComponentSettingsAggregation(
+            **component_settings_aggregation_model_dict)
 
         # Verify the model instances are equivalent
         assert component_settings_aggregation_model == component_settings_aggregation_model2
 
         # Convert model instance back to dict and verify no loss of data
-        component_settings_aggregation_model_json2 = component_settings_aggregation_model.to_dict()
+        component_settings_aggregation_model_json2 = component_settings_aggregation_model.to_dict(
+        )
         assert component_settings_aggregation_model_json2 == component_settings_aggregation_model_json
+
 
 class TestModel_ComponentSettingsFieldsShown():
     """
     Test Class for ComponentSettingsFieldsShown
     """
-
     def test_component_settings_fields_shown_serialization(self):
         """
         Test serialization/deserialization for ComponentSettingsFieldsShown
@@ -5629,38 +5754,46 @@ class TestModel_ComponentSettingsFieldsShown():
 
         # Construct dict forms of any model objects needed in order to build this model.
 
-        component_settings_fields_shown_body_model = {} # ComponentSettingsFieldsShownBody
+        component_settings_fields_shown_body_model = {
+        }  # ComponentSettingsFieldsShownBody
         component_settings_fields_shown_body_model['use_passage'] = True
         component_settings_fields_shown_body_model['field'] = 'testString'
 
-        component_settings_fields_shown_title_model = {} # ComponentSettingsFieldsShownTitle
+        component_settings_fields_shown_title_model = {
+        }  # ComponentSettingsFieldsShownTitle
         component_settings_fields_shown_title_model['field'] = 'testString'
 
         # Construct a json representation of a ComponentSettingsFieldsShown model
         component_settings_fields_shown_model_json = {}
-        component_settings_fields_shown_model_json['body'] = component_settings_fields_shown_body_model
-        component_settings_fields_shown_model_json['title'] = component_settings_fields_shown_title_model
+        component_settings_fields_shown_model_json[
+            'body'] = component_settings_fields_shown_body_model
+        component_settings_fields_shown_model_json[
+            'title'] = component_settings_fields_shown_title_model
 
         # Construct a model instance of ComponentSettingsFieldsShown by calling from_dict on the json representation
-        component_settings_fields_shown_model = ComponentSettingsFieldsShown.from_dict(component_settings_fields_shown_model_json)
+        component_settings_fields_shown_model = ComponentSettingsFieldsShown.from_dict(
+            component_settings_fields_shown_model_json)
         assert component_settings_fields_shown_model != False
 
         # Construct a model instance of ComponentSettingsFieldsShown by calling from_dict on the json representation
-        component_settings_fields_shown_model_dict = ComponentSettingsFieldsShown.from_dict(component_settings_fields_shown_model_json).__dict__
-        component_settings_fields_shown_model2 = ComponentSettingsFieldsShown(**component_settings_fields_shown_model_dict)
+        component_settings_fields_shown_model_dict = ComponentSettingsFieldsShown.from_dict(
+            component_settings_fields_shown_model_json).__dict__
+        component_settings_fields_shown_model2 = ComponentSettingsFieldsShown(
+            **component_settings_fields_shown_model_dict)
 
         # Verify the model instances are equivalent
         assert component_settings_fields_shown_model == component_settings_fields_shown_model2
 
         # Convert model instance back to dict and verify no loss of data
-        component_settings_fields_shown_model_json2 = component_settings_fields_shown_model.to_dict()
+        component_settings_fields_shown_model_json2 = component_settings_fields_shown_model.to_dict(
+        )
         assert component_settings_fields_shown_model_json2 == component_settings_fields_shown_model_json
+
 
 class TestModel_ComponentSettingsFieldsShownBody():
     """
     Test Class for ComponentSettingsFieldsShownBody
     """
-
     def test_component_settings_fields_shown_body_serialization(self):
         """
         Test serialization/deserialization for ComponentSettingsFieldsShownBody
@@ -5672,25 +5805,29 @@ class TestModel_ComponentSettingsFieldsShownBody():
         component_settings_fields_shown_body_model_json['field'] = 'testString'
 
         # Construct a model instance of ComponentSettingsFieldsShownBody by calling from_dict on the json representation
-        component_settings_fields_shown_body_model = ComponentSettingsFieldsShownBody.from_dict(component_settings_fields_shown_body_model_json)
+        component_settings_fields_shown_body_model = ComponentSettingsFieldsShownBody.from_dict(
+            component_settings_fields_shown_body_model_json)
         assert component_settings_fields_shown_body_model != False
 
         # Construct a model instance of ComponentSettingsFieldsShownBody by calling from_dict on the json representation
-        component_settings_fields_shown_body_model_dict = ComponentSettingsFieldsShownBody.from_dict(component_settings_fields_shown_body_model_json).__dict__
-        component_settings_fields_shown_body_model2 = ComponentSettingsFieldsShownBody(**component_settings_fields_shown_body_model_dict)
+        component_settings_fields_shown_body_model_dict = ComponentSettingsFieldsShownBody.from_dict(
+            component_settings_fields_shown_body_model_json).__dict__
+        component_settings_fields_shown_body_model2 = ComponentSettingsFieldsShownBody(
+            **component_settings_fields_shown_body_model_dict)
 
         # Verify the model instances are equivalent
         assert component_settings_fields_shown_body_model == component_settings_fields_shown_body_model2
 
         # Convert model instance back to dict and verify no loss of data
-        component_settings_fields_shown_body_model_json2 = component_settings_fields_shown_body_model.to_dict()
+        component_settings_fields_shown_body_model_json2 = component_settings_fields_shown_body_model.to_dict(
+        )
         assert component_settings_fields_shown_body_model_json2 == component_settings_fields_shown_body_model_json
+
 
 class TestModel_ComponentSettingsFieldsShownTitle():
     """
     Test Class for ComponentSettingsFieldsShownTitle
     """
-
     def test_component_settings_fields_shown_title_serialization(self):
         """
         Test serialization/deserialization for ComponentSettingsFieldsShownTitle
@@ -5698,28 +5835,33 @@ class TestModel_ComponentSettingsFieldsShownTitle():
 
         # Construct a json representation of a ComponentSettingsFieldsShownTitle model
         component_settings_fields_shown_title_model_json = {}
-        component_settings_fields_shown_title_model_json['field'] = 'testString'
+        component_settings_fields_shown_title_model_json[
+            'field'] = 'testString'
 
         # Construct a model instance of ComponentSettingsFieldsShownTitle by calling from_dict on the json representation
-        component_settings_fields_shown_title_model = ComponentSettingsFieldsShownTitle.from_dict(component_settings_fields_shown_title_model_json)
+        component_settings_fields_shown_title_model = ComponentSettingsFieldsShownTitle.from_dict(
+            component_settings_fields_shown_title_model_json)
         assert component_settings_fields_shown_title_model != False
 
         # Construct a model instance of ComponentSettingsFieldsShownTitle by calling from_dict on the json representation
-        component_settings_fields_shown_title_model_dict = ComponentSettingsFieldsShownTitle.from_dict(component_settings_fields_shown_title_model_json).__dict__
-        component_settings_fields_shown_title_model2 = ComponentSettingsFieldsShownTitle(**component_settings_fields_shown_title_model_dict)
+        component_settings_fields_shown_title_model_dict = ComponentSettingsFieldsShownTitle.from_dict(
+            component_settings_fields_shown_title_model_json).__dict__
+        component_settings_fields_shown_title_model2 = ComponentSettingsFieldsShownTitle(
+            **component_settings_fields_shown_title_model_dict)
 
         # Verify the model instances are equivalent
         assert component_settings_fields_shown_title_model == component_settings_fields_shown_title_model2
 
         # Convert model instance back to dict and verify no loss of data
-        component_settings_fields_shown_title_model_json2 = component_settings_fields_shown_title_model.to_dict()
+        component_settings_fields_shown_title_model_json2 = component_settings_fields_shown_title_model.to_dict(
+        )
         assert component_settings_fields_shown_title_model_json2 == component_settings_fields_shown_title_model_json
+
 
 class TestModel_ComponentSettingsResponse():
     """
     Test Class for ComponentSettingsResponse
     """
-
     def test_component_settings_response_serialization(self):
         """
         Test serialization/deserialization for ComponentSettingsResponse
@@ -5727,51 +5869,65 @@ class TestModel_ComponentSettingsResponse():
 
         # Construct dict forms of any model objects needed in order to build this model.
 
-        component_settings_fields_shown_body_model = {} # ComponentSettingsFieldsShownBody
+        component_settings_fields_shown_body_model = {
+        }  # ComponentSettingsFieldsShownBody
         component_settings_fields_shown_body_model['use_passage'] = True
         component_settings_fields_shown_body_model['field'] = 'testString'
 
-        component_settings_fields_shown_title_model = {} # ComponentSettingsFieldsShownTitle
+        component_settings_fields_shown_title_model = {
+        }  # ComponentSettingsFieldsShownTitle
         component_settings_fields_shown_title_model['field'] = 'testString'
 
-        component_settings_fields_shown_model = {} # ComponentSettingsFieldsShown
-        component_settings_fields_shown_model['body'] = component_settings_fields_shown_body_model
-        component_settings_fields_shown_model['title'] = component_settings_fields_shown_title_model
+        component_settings_fields_shown_model = {
+        }  # ComponentSettingsFieldsShown
+        component_settings_fields_shown_model[
+            'body'] = component_settings_fields_shown_body_model
+        component_settings_fields_shown_model[
+            'title'] = component_settings_fields_shown_title_model
 
-        component_settings_aggregation_model = {} # ComponentSettingsAggregation
+        component_settings_aggregation_model = {
+        }  # ComponentSettingsAggregation
         component_settings_aggregation_model['name'] = 'testString'
         component_settings_aggregation_model['label'] = 'testString'
-        component_settings_aggregation_model['multiple_selections_allowed'] = True
+        component_settings_aggregation_model[
+            'multiple_selections_allowed'] = True
         component_settings_aggregation_model['visualization_type'] = 'auto'
 
         # Construct a json representation of a ComponentSettingsResponse model
         component_settings_response_model_json = {}
-        component_settings_response_model_json['fields_shown'] = component_settings_fields_shown_model
+        component_settings_response_model_json[
+            'fields_shown'] = component_settings_fields_shown_model
         component_settings_response_model_json['autocomplete'] = True
         component_settings_response_model_json['structured_search'] = True
         component_settings_response_model_json['results_per_page'] = 38
-        component_settings_response_model_json['aggregations'] = [component_settings_aggregation_model]
+        component_settings_response_model_json['aggregations'] = [
+            component_settings_aggregation_model
+        ]
 
         # Construct a model instance of ComponentSettingsResponse by calling from_dict on the json representation
-        component_settings_response_model = ComponentSettingsResponse.from_dict(component_settings_response_model_json)
+        component_settings_response_model = ComponentSettingsResponse.from_dict(
+            component_settings_response_model_json)
         assert component_settings_response_model != False
 
         # Construct a model instance of ComponentSettingsResponse by calling from_dict on the json representation
-        component_settings_response_model_dict = ComponentSettingsResponse.from_dict(component_settings_response_model_json).__dict__
-        component_settings_response_model2 = ComponentSettingsResponse(**component_settings_response_model_dict)
+        component_settings_response_model_dict = ComponentSettingsResponse.from_dict(
+            component_settings_response_model_json).__dict__
+        component_settings_response_model2 = ComponentSettingsResponse(
+            **component_settings_response_model_dict)
 
         # Verify the model instances are equivalent
         assert component_settings_response_model == component_settings_response_model2
 
         # Convert model instance back to dict and verify no loss of data
-        component_settings_response_model_json2 = component_settings_response_model.to_dict()
+        component_settings_response_model_json2 = component_settings_response_model.to_dict(
+        )
         assert component_settings_response_model_json2 == component_settings_response_model_json
+
 
 class TestModel_CreateDocumentClassifier():
     """
     Test Class for CreateDocumentClassifier
     """
-
     def test_create_document_classifier_serialization(self):
         """
         Test serialization/deserialization for CreateDocumentClassifier
@@ -5779,11 +5935,12 @@ class TestModel_CreateDocumentClassifier():
 
         # Construct dict forms of any model objects needed in order to build this model.
 
-        document_classifier_enrichment_model = {} # DocumentClassifierEnrichment
+        document_classifier_enrichment_model = {
+        }  # DocumentClassifierEnrichment
         document_classifier_enrichment_model['enrichment_id'] = 'testString'
         document_classifier_enrichment_model['fields'] = ['testString']
 
-        classifier_federated_model_model = {} # ClassifierFederatedModel
+        classifier_federated_model_model = {}  # ClassifierFederatedModel
         classifier_federated_model_model['field'] = 'testString'
 
         # Construct a json representation of a CreateDocumentClassifier model
@@ -5792,29 +5949,36 @@ class TestModel_CreateDocumentClassifier():
         create_document_classifier_model_json['description'] = 'testString'
         create_document_classifier_model_json['language'] = 'en'
         create_document_classifier_model_json['answer_field'] = 'testString'
-        create_document_classifier_model_json['enrichments'] = [document_classifier_enrichment_model]
-        create_document_classifier_model_json['federated_classification'] = classifier_federated_model_model
+        create_document_classifier_model_json['enrichments'] = [
+            document_classifier_enrichment_model
+        ]
+        create_document_classifier_model_json[
+            'federated_classification'] = classifier_federated_model_model
 
         # Construct a model instance of CreateDocumentClassifier by calling from_dict on the json representation
-        create_document_classifier_model = CreateDocumentClassifier.from_dict(create_document_classifier_model_json)
+        create_document_classifier_model = CreateDocumentClassifier.from_dict(
+            create_document_classifier_model_json)
         assert create_document_classifier_model != False
 
         # Construct a model instance of CreateDocumentClassifier by calling from_dict on the json representation
-        create_document_classifier_model_dict = CreateDocumentClassifier.from_dict(create_document_classifier_model_json).__dict__
-        create_document_classifier_model2 = CreateDocumentClassifier(**create_document_classifier_model_dict)
+        create_document_classifier_model_dict = CreateDocumentClassifier.from_dict(
+            create_document_classifier_model_json).__dict__
+        create_document_classifier_model2 = CreateDocumentClassifier(
+            **create_document_classifier_model_dict)
 
         # Verify the model instances are equivalent
         assert create_document_classifier_model == create_document_classifier_model2
 
         # Convert model instance back to dict and verify no loss of data
-        create_document_classifier_model_json2 = create_document_classifier_model.to_dict()
+        create_document_classifier_model_json2 = create_document_classifier_model.to_dict(
+        )
         assert create_document_classifier_model_json2 == create_document_classifier_model_json
+
 
 class TestModel_CreateEnrichment():
     """
     Test Class for CreateEnrichment
     """
-
     def test_create_enrichment_serialization(self):
         """
         Test serialization/deserialization for CreateEnrichment
@@ -5822,7 +5986,7 @@ class TestModel_CreateEnrichment():
 
         # Construct dict forms of any model objects needed in order to build this model.
 
-        enrichment_options_model = {} # EnrichmentOptions
+        enrichment_options_model = {}  # EnrichmentOptions
         enrichment_options_model['languages'] = ['testString']
         enrichment_options_model['entity_type'] = 'testString'
         enrichment_options_model['regular_expression'] = 'testString'
@@ -5840,12 +6004,15 @@ class TestModel_CreateEnrichment():
         create_enrichment_model_json['options'] = enrichment_options_model
 
         # Construct a model instance of CreateEnrichment by calling from_dict on the json representation
-        create_enrichment_model = CreateEnrichment.from_dict(create_enrichment_model_json)
+        create_enrichment_model = CreateEnrichment.from_dict(
+            create_enrichment_model_json)
         assert create_enrichment_model != False
 
         # Construct a model instance of CreateEnrichment by calling from_dict on the json representation
-        create_enrichment_model_dict = CreateEnrichment.from_dict(create_enrichment_model_json).__dict__
-        create_enrichment_model2 = CreateEnrichment(**create_enrichment_model_dict)
+        create_enrichment_model_dict = CreateEnrichment.from_dict(
+            create_enrichment_model_json).__dict__
+        create_enrichment_model2 = CreateEnrichment(
+            **create_enrichment_model_dict)
 
         # Verify the model instances are equivalent
         assert create_enrichment_model == create_enrichment_model2
@@ -5854,11 +6021,11 @@ class TestModel_CreateEnrichment():
         create_enrichment_model_json2 = create_enrichment_model.to_dict()
         assert create_enrichment_model_json2 == create_enrichment_model_json
 
+
 class TestModel_DefaultQueryParams():
     """
     Test Class for DefaultQueryParams
     """
-
     def test_default_query_params_serialization(self):
         """
         Test serialization/deserialization for DefaultQueryParams
@@ -5866,7 +6033,7 @@ class TestModel_DefaultQueryParams():
 
         # Construct dict forms of any model objects needed in order to build this model.
 
-        default_query_params_passages_model = {} # DefaultQueryParamsPassages
+        default_query_params_passages_model = {}  # DefaultQueryParamsPassages
         default_query_params_passages_model['enabled'] = True
         default_query_params_passages_model['count'] = 38
         default_query_params_passages_model['fields'] = ['testString']
@@ -5874,22 +6041,27 @@ class TestModel_DefaultQueryParams():
         default_query_params_passages_model['per_document'] = True
         default_query_params_passages_model['max_per_document'] = 38
 
-        default_query_params_table_results_model = {} # DefaultQueryParamsTableResults
+        default_query_params_table_results_model = {
+        }  # DefaultQueryParamsTableResults
         default_query_params_table_results_model['enabled'] = True
         default_query_params_table_results_model['count'] = 38
         default_query_params_table_results_model['per_document'] = 38
 
-        default_query_params_suggested_refinements_model = {} # DefaultQueryParamsSuggestedRefinements
+        default_query_params_suggested_refinements_model = {
+        }  # DefaultQueryParamsSuggestedRefinements
         default_query_params_suggested_refinements_model['enabled'] = True
         default_query_params_suggested_refinements_model['count'] = 38
 
         # Construct a json representation of a DefaultQueryParams model
         default_query_params_model_json = {}
         default_query_params_model_json['collection_ids'] = ['testString']
-        default_query_params_model_json['passages'] = default_query_params_passages_model
-        default_query_params_model_json['table_results'] = default_query_params_table_results_model
+        default_query_params_model_json[
+            'passages'] = default_query_params_passages_model
+        default_query_params_model_json[
+            'table_results'] = default_query_params_table_results_model
         default_query_params_model_json['aggregation'] = 'testString'
-        default_query_params_model_json['suggested_refinements'] = default_query_params_suggested_refinements_model
+        default_query_params_model_json[
+            'suggested_refinements'] = default_query_params_suggested_refinements_model
         default_query_params_model_json['spelling_suggestions'] = True
         default_query_params_model_json['highlight'] = True
         default_query_params_model_json['count'] = 38
@@ -5897,12 +6069,15 @@ class TestModel_DefaultQueryParams():
         default_query_params_model_json['return'] = ['testString']
 
         # Construct a model instance of DefaultQueryParams by calling from_dict on the json representation
-        default_query_params_model = DefaultQueryParams.from_dict(default_query_params_model_json)
+        default_query_params_model = DefaultQueryParams.from_dict(
+            default_query_params_model_json)
         assert default_query_params_model != False
 
         # Construct a model instance of DefaultQueryParams by calling from_dict on the json representation
-        default_query_params_model_dict = DefaultQueryParams.from_dict(default_query_params_model_json).__dict__
-        default_query_params_model2 = DefaultQueryParams(**default_query_params_model_dict)
+        default_query_params_model_dict = DefaultQueryParams.from_dict(
+            default_query_params_model_json).__dict__
+        default_query_params_model2 = DefaultQueryParams(
+            **default_query_params_model_dict)
 
         # Verify the model instances are equivalent
         assert default_query_params_model == default_query_params_model2
@@ -5911,11 +6086,11 @@ class TestModel_DefaultQueryParams():
         default_query_params_model_json2 = default_query_params_model.to_dict()
         assert default_query_params_model_json2 == default_query_params_model_json
 
+
 class TestModel_DefaultQueryParamsPassages():
     """
     Test Class for DefaultQueryParamsPassages
     """
-
     def test_default_query_params_passages_serialization(self):
         """
         Test serialization/deserialization for DefaultQueryParamsPassages
@@ -5931,25 +6106,29 @@ class TestModel_DefaultQueryParamsPassages():
         default_query_params_passages_model_json['max_per_document'] = 38
 
         # Construct a model instance of DefaultQueryParamsPassages by calling from_dict on the json representation
-        default_query_params_passages_model = DefaultQueryParamsPassages.from_dict(default_query_params_passages_model_json)
+        default_query_params_passages_model = DefaultQueryParamsPassages.from_dict(
+            default_query_params_passages_model_json)
         assert default_query_params_passages_model != False
 
         # Construct a model instance of DefaultQueryParamsPassages by calling from_dict on the json representation
-        default_query_params_passages_model_dict = DefaultQueryParamsPassages.from_dict(default_query_params_passages_model_json).__dict__
-        default_query_params_passages_model2 = DefaultQueryParamsPassages(**default_query_params_passages_model_dict)
+        default_query_params_passages_model_dict = DefaultQueryParamsPassages.from_dict(
+            default_query_params_passages_model_json).__dict__
+        default_query_params_passages_model2 = DefaultQueryParamsPassages(
+            **default_query_params_passages_model_dict)
 
         # Verify the model instances are equivalent
         assert default_query_params_passages_model == default_query_params_passages_model2
 
         # Convert model instance back to dict and verify no loss of data
-        default_query_params_passages_model_json2 = default_query_params_passages_model.to_dict()
+        default_query_params_passages_model_json2 = default_query_params_passages_model.to_dict(
+        )
         assert default_query_params_passages_model_json2 == default_query_params_passages_model_json
+
 
 class TestModel_DefaultQueryParamsSuggestedRefinements():
     """
     Test Class for DefaultQueryParamsSuggestedRefinements
     """
-
     def test_default_query_params_suggested_refinements_serialization(self):
         """
         Test serialization/deserialization for DefaultQueryParamsSuggestedRefinements
@@ -5961,25 +6140,29 @@ class TestModel_DefaultQueryParamsSuggestedRefinements():
         default_query_params_suggested_refinements_model_json['count'] = 38
 
         # Construct a model instance of DefaultQueryParamsSuggestedRefinements by calling from_dict on the json representation
-        default_query_params_suggested_refinements_model = DefaultQueryParamsSuggestedRefinements.from_dict(default_query_params_suggested_refinements_model_json)
+        default_query_params_suggested_refinements_model = DefaultQueryParamsSuggestedRefinements.from_dict(
+            default_query_params_suggested_refinements_model_json)
         assert default_query_params_suggested_refinements_model != False
 
         # Construct a model instance of DefaultQueryParamsSuggestedRefinements by calling from_dict on the json representation
-        default_query_params_suggested_refinements_model_dict = DefaultQueryParamsSuggestedRefinements.from_dict(default_query_params_suggested_refinements_model_json).__dict__
-        default_query_params_suggested_refinements_model2 = DefaultQueryParamsSuggestedRefinements(**default_query_params_suggested_refinements_model_dict)
+        default_query_params_suggested_refinements_model_dict = DefaultQueryParamsSuggestedRefinements.from_dict(
+            default_query_params_suggested_refinements_model_json).__dict__
+        default_query_params_suggested_refinements_model2 = DefaultQueryParamsSuggestedRefinements(
+            **default_query_params_suggested_refinements_model_dict)
 
         # Verify the model instances are equivalent
         assert default_query_params_suggested_refinements_model == default_query_params_suggested_refinements_model2
 
         # Convert model instance back to dict and verify no loss of data
-        default_query_params_suggested_refinements_model_json2 = default_query_params_suggested_refinements_model.to_dict()
+        default_query_params_suggested_refinements_model_json2 = default_query_params_suggested_refinements_model.to_dict(
+        )
         assert default_query_params_suggested_refinements_model_json2 == default_query_params_suggested_refinements_model_json
+
 
 class TestModel_DefaultQueryParamsTableResults():
     """
     Test Class for DefaultQueryParamsTableResults
     """
-
     def test_default_query_params_table_results_serialization(self):
         """
         Test serialization/deserialization for DefaultQueryParamsTableResults
@@ -5992,25 +6175,29 @@ class TestModel_DefaultQueryParamsTableResults():
         default_query_params_table_results_model_json['per_document'] = 38
 
         # Construct a model instance of DefaultQueryParamsTableResults by calling from_dict on the json representation
-        default_query_params_table_results_model = DefaultQueryParamsTableResults.from_dict(default_query_params_table_results_model_json)
+        default_query_params_table_results_model = DefaultQueryParamsTableResults.from_dict(
+            default_query_params_table_results_model_json)
         assert default_query_params_table_results_model != False
 
         # Construct a model instance of DefaultQueryParamsTableResults by calling from_dict on the json representation
-        default_query_params_table_results_model_dict = DefaultQueryParamsTableResults.from_dict(default_query_params_table_results_model_json).__dict__
-        default_query_params_table_results_model2 = DefaultQueryParamsTableResults(**default_query_params_table_results_model_dict)
+        default_query_params_table_results_model_dict = DefaultQueryParamsTableResults.from_dict(
+            default_query_params_table_results_model_json).__dict__
+        default_query_params_table_results_model2 = DefaultQueryParamsTableResults(
+            **default_query_params_table_results_model_dict)
 
         # Verify the model instances are equivalent
         assert default_query_params_table_results_model == default_query_params_table_results_model2
 
         # Convert model instance back to dict and verify no loss of data
-        default_query_params_table_results_model_json2 = default_query_params_table_results_model.to_dict()
+        default_query_params_table_results_model_json2 = default_query_params_table_results_model.to_dict(
+        )
         assert default_query_params_table_results_model_json2 == default_query_params_table_results_model_json
+
 
 class TestModel_DeleteDocumentResponse():
     """
     Test Class for DeleteDocumentResponse
     """
-
     def test_delete_document_response_serialization(self):
         """
         Test serialization/deserialization for DeleteDocumentResponse
@@ -6022,25 +6209,29 @@ class TestModel_DeleteDocumentResponse():
         delete_document_response_model_json['status'] = 'deleted'
 
         # Construct a model instance of DeleteDocumentResponse by calling from_dict on the json representation
-        delete_document_response_model = DeleteDocumentResponse.from_dict(delete_document_response_model_json)
+        delete_document_response_model = DeleteDocumentResponse.from_dict(
+            delete_document_response_model_json)
         assert delete_document_response_model != False
 
         # Construct a model instance of DeleteDocumentResponse by calling from_dict on the json representation
-        delete_document_response_model_dict = DeleteDocumentResponse.from_dict(delete_document_response_model_json).__dict__
-        delete_document_response_model2 = DeleteDocumentResponse(**delete_document_response_model_dict)
+        delete_document_response_model_dict = DeleteDocumentResponse.from_dict(
+            delete_document_response_model_json).__dict__
+        delete_document_response_model2 = DeleteDocumentResponse(
+            **delete_document_response_model_dict)
 
         # Verify the model instances are equivalent
         assert delete_document_response_model == delete_document_response_model2
 
         # Convert model instance back to dict and verify no loss of data
-        delete_document_response_model_json2 = delete_document_response_model.to_dict()
+        delete_document_response_model_json2 = delete_document_response_model.to_dict(
+        )
         assert delete_document_response_model_json2 == delete_document_response_model_json
+
 
 class TestModel_DocumentAccepted():
     """
     Test Class for DocumentAccepted
     """
-
     def test_document_accepted_serialization(self):
         """
         Test serialization/deserialization for DocumentAccepted
@@ -6052,12 +6243,15 @@ class TestModel_DocumentAccepted():
         document_accepted_model_json['status'] = 'processing'
 
         # Construct a model instance of DocumentAccepted by calling from_dict on the json representation
-        document_accepted_model = DocumentAccepted.from_dict(document_accepted_model_json)
+        document_accepted_model = DocumentAccepted.from_dict(
+            document_accepted_model_json)
         assert document_accepted_model != False
 
         # Construct a model instance of DocumentAccepted by calling from_dict on the json representation
-        document_accepted_model_dict = DocumentAccepted.from_dict(document_accepted_model_json).__dict__
-        document_accepted_model2 = DocumentAccepted(**document_accepted_model_dict)
+        document_accepted_model_dict = DocumentAccepted.from_dict(
+            document_accepted_model_json).__dict__
+        document_accepted_model2 = DocumentAccepted(
+            **document_accepted_model_dict)
 
         # Verify the model instances are equivalent
         assert document_accepted_model == document_accepted_model2
@@ -6066,11 +6260,11 @@ class TestModel_DocumentAccepted():
         document_accepted_model_json2 = document_accepted_model.to_dict()
         assert document_accepted_model_json2 == document_accepted_model_json
 
+
 class TestModel_DocumentAttribute():
     """
     Test Class for DocumentAttribute
     """
-
     def test_document_attribute_serialization(self):
         """
         Test serialization/deserialization for DocumentAttribute
@@ -6078,7 +6272,7 @@ class TestModel_DocumentAttribute():
 
         # Construct dict forms of any model objects needed in order to build this model.
 
-        table_element_location_model = {} # TableElementLocation
+        table_element_location_model = {}  # TableElementLocation
         table_element_location_model['begin'] = 26
         table_element_location_model['end'] = 26
 
@@ -6086,15 +6280,19 @@ class TestModel_DocumentAttribute():
         document_attribute_model_json = {}
         document_attribute_model_json['type'] = 'testString'
         document_attribute_model_json['text'] = 'testString'
-        document_attribute_model_json['location'] = table_element_location_model
+        document_attribute_model_json[
+            'location'] = table_element_location_model
 
         # Construct a model instance of DocumentAttribute by calling from_dict on the json representation
-        document_attribute_model = DocumentAttribute.from_dict(document_attribute_model_json)
+        document_attribute_model = DocumentAttribute.from_dict(
+            document_attribute_model_json)
         assert document_attribute_model != False
 
         # Construct a model instance of DocumentAttribute by calling from_dict on the json representation
-        document_attribute_model_dict = DocumentAttribute.from_dict(document_attribute_model_json).__dict__
-        document_attribute_model2 = DocumentAttribute(**document_attribute_model_dict)
+        document_attribute_model_dict = DocumentAttribute.from_dict(
+            document_attribute_model_json).__dict__
+        document_attribute_model2 = DocumentAttribute(
+            **document_attribute_model_dict)
 
         # Verify the model instances are equivalent
         assert document_attribute_model == document_attribute_model2
@@ -6103,11 +6301,11 @@ class TestModel_DocumentAttribute():
         document_attribute_model_json2 = document_attribute_model.to_dict()
         assert document_attribute_model_json2 == document_attribute_model_json
 
+
 class TestModel_DocumentClassifier():
     """
     Test Class for DocumentClassifier
     """
-
     def test_document_classifier_serialization(self):
         """
         Test serialization/deserialization for DocumentClassifier
@@ -6115,11 +6313,12 @@ class TestModel_DocumentClassifier():
 
         # Construct dict forms of any model objects needed in order to build this model.
 
-        document_classifier_enrichment_model = {} # DocumentClassifierEnrichment
+        document_classifier_enrichment_model = {
+        }  # DocumentClassifierEnrichment
         document_classifier_enrichment_model['enrichment_id'] = 'testString'
         document_classifier_enrichment_model['fields'] = ['testString']
 
-        classifier_federated_model_model = {} # ClassifierFederatedModel
+        classifier_federated_model_model = {}  # ClassifierFederatedModel
         classifier_federated_model_model['field'] = 'testString'
 
         # Construct a json representation of a DocumentClassifier model
@@ -6129,20 +6328,26 @@ class TestModel_DocumentClassifier():
         document_classifier_model_json['description'] = 'testString'
         document_classifier_model_json['created'] = '2019-01-01T12:00:00Z'
         document_classifier_model_json['language'] = 'en'
-        document_classifier_model_json['enrichments'] = [document_classifier_enrichment_model]
+        document_classifier_model_json['enrichments'] = [
+            document_classifier_enrichment_model
+        ]
         document_classifier_model_json['recognized_fields'] = ['testString']
         document_classifier_model_json['answer_field'] = 'testString'
         document_classifier_model_json['training_data_file'] = 'testString'
         document_classifier_model_json['test_data_file'] = 'testString'
-        document_classifier_model_json['federated_classification'] = classifier_federated_model_model
+        document_classifier_model_json[
+            'federated_classification'] = classifier_federated_model_model
 
         # Construct a model instance of DocumentClassifier by calling from_dict on the json representation
-        document_classifier_model = DocumentClassifier.from_dict(document_classifier_model_json)
+        document_classifier_model = DocumentClassifier.from_dict(
+            document_classifier_model_json)
         assert document_classifier_model != False
 
         # Construct a model instance of DocumentClassifier by calling from_dict on the json representation
-        document_classifier_model_dict = DocumentClassifier.from_dict(document_classifier_model_json).__dict__
-        document_classifier_model2 = DocumentClassifier(**document_classifier_model_dict)
+        document_classifier_model_dict = DocumentClassifier.from_dict(
+            document_classifier_model_json).__dict__
+        document_classifier_model2 = DocumentClassifier(
+            **document_classifier_model_dict)
 
         # Verify the model instances are equivalent
         assert document_classifier_model == document_classifier_model2
@@ -6151,11 +6356,11 @@ class TestModel_DocumentClassifier():
         document_classifier_model_json2 = document_classifier_model.to_dict()
         assert document_classifier_model_json2 == document_classifier_model_json
 
+
 class TestModel_DocumentClassifierEnrichment():
     """
     Test Class for DocumentClassifierEnrichment
     """
-
     def test_document_classifier_enrichment_serialization(self):
         """
         Test serialization/deserialization for DocumentClassifierEnrichment
@@ -6163,29 +6368,34 @@ class TestModel_DocumentClassifierEnrichment():
 
         # Construct a json representation of a DocumentClassifierEnrichment model
         document_classifier_enrichment_model_json = {}
-        document_classifier_enrichment_model_json['enrichment_id'] = 'testString'
+        document_classifier_enrichment_model_json[
+            'enrichment_id'] = 'testString'
         document_classifier_enrichment_model_json['fields'] = ['testString']
 
         # Construct a model instance of DocumentClassifierEnrichment by calling from_dict on the json representation
-        document_classifier_enrichment_model = DocumentClassifierEnrichment.from_dict(document_classifier_enrichment_model_json)
+        document_classifier_enrichment_model = DocumentClassifierEnrichment.from_dict(
+            document_classifier_enrichment_model_json)
         assert document_classifier_enrichment_model != False
 
         # Construct a model instance of DocumentClassifierEnrichment by calling from_dict on the json representation
-        document_classifier_enrichment_model_dict = DocumentClassifierEnrichment.from_dict(document_classifier_enrichment_model_json).__dict__
-        document_classifier_enrichment_model2 = DocumentClassifierEnrichment(**document_classifier_enrichment_model_dict)
+        document_classifier_enrichment_model_dict = DocumentClassifierEnrichment.from_dict(
+            document_classifier_enrichment_model_json).__dict__
+        document_classifier_enrichment_model2 = DocumentClassifierEnrichment(
+            **document_classifier_enrichment_model_dict)
 
         # Verify the model instances are equivalent
         assert document_classifier_enrichment_model == document_classifier_enrichment_model2
 
         # Convert model instance back to dict and verify no loss of data
-        document_classifier_enrichment_model_json2 = document_classifier_enrichment_model.to_dict()
+        document_classifier_enrichment_model_json2 = document_classifier_enrichment_model.to_dict(
+        )
         assert document_classifier_enrichment_model_json2 == document_classifier_enrichment_model_json
+
 
 class TestModel_DocumentClassifierModel():
     """
     Test Class for DocumentClassifierModel
     """
-
     def test_document_classifier_model_serialization(self):
         """
         Test serialization/deserialization for DocumentClassifierModel
@@ -6193,61 +6403,76 @@ class TestModel_DocumentClassifierModel():
 
         # Construct dict forms of any model objects needed in order to build this model.
 
-        model_evaluation_micro_average_model = {} # ModelEvaluationMicroAverage
+        model_evaluation_micro_average_model = {
+        }  # ModelEvaluationMicroAverage
         model_evaluation_micro_average_model['precision'] = 0
         model_evaluation_micro_average_model['recall'] = 0
         model_evaluation_micro_average_model['f1'] = 0
 
-        model_evaluation_macro_average_model = {} # ModelEvaluationMacroAverage
+        model_evaluation_macro_average_model = {
+        }  # ModelEvaluationMacroAverage
         model_evaluation_macro_average_model['precision'] = 0
         model_evaluation_macro_average_model['recall'] = 0
         model_evaluation_macro_average_model['f1'] = 0
 
-        per_class_model_evaluation_model = {} # PerClassModelEvaluation
+        per_class_model_evaluation_model = {}  # PerClassModelEvaluation
         per_class_model_evaluation_model['name'] = 'testString'
         per_class_model_evaluation_model['precision'] = 0
         per_class_model_evaluation_model['recall'] = 0
         per_class_model_evaluation_model['f1'] = 0
 
-        classifier_model_evaluation_model = {} # ClassifierModelEvaluation
-        classifier_model_evaluation_model['micro_average'] = model_evaluation_micro_average_model
-        classifier_model_evaluation_model['macro_average'] = model_evaluation_macro_average_model
-        classifier_model_evaluation_model['per_class'] = [per_class_model_evaluation_model]
+        classifier_model_evaluation_model = {}  # ClassifierModelEvaluation
+        classifier_model_evaluation_model[
+            'micro_average'] = model_evaluation_micro_average_model
+        classifier_model_evaluation_model[
+            'macro_average'] = model_evaluation_macro_average_model
+        classifier_model_evaluation_model['per_class'] = [
+            per_class_model_evaluation_model
+        ]
 
         # Construct a json representation of a DocumentClassifierModel model
         document_classifier_model_model_json = {}
         document_classifier_model_model_json['model_id'] = 'testString'
         document_classifier_model_model_json['name'] = 'testString'
         document_classifier_model_model_json['description'] = 'testString'
-        document_classifier_model_model_json['created'] = '2019-01-01T12:00:00Z'
-        document_classifier_model_model_json['updated'] = '2019-01-01T12:00:00Z'
-        document_classifier_model_model_json['training_data_file'] = 'testString'
+        document_classifier_model_model_json[
+            'created'] = '2019-01-01T12:00:00Z'
+        document_classifier_model_model_json[
+            'updated'] = '2019-01-01T12:00:00Z'
+        document_classifier_model_model_json[
+            'training_data_file'] = 'testString'
         document_classifier_model_model_json['test_data_file'] = 'testString'
         document_classifier_model_model_json['status'] = 'training'
-        document_classifier_model_model_json['evaluation'] = classifier_model_evaluation_model
+        document_classifier_model_model_json[
+            'evaluation'] = classifier_model_evaluation_model
         document_classifier_model_model_json['enrichment_id'] = 'testString'
-        document_classifier_model_model_json['deployed_at'] = '2019-01-01T12:00:00Z'
+        document_classifier_model_model_json[
+            'deployed_at'] = '2019-01-01T12:00:00Z'
 
         # Construct a model instance of DocumentClassifierModel by calling from_dict on the json representation
-        document_classifier_model_model = DocumentClassifierModel.from_dict(document_classifier_model_model_json)
+        document_classifier_model_model = DocumentClassifierModel.from_dict(
+            document_classifier_model_model_json)
         assert document_classifier_model_model != False
 
         # Construct a model instance of DocumentClassifierModel by calling from_dict on the json representation
-        document_classifier_model_model_dict = DocumentClassifierModel.from_dict(document_classifier_model_model_json).__dict__
-        document_classifier_model_model2 = DocumentClassifierModel(**document_classifier_model_model_dict)
+        document_classifier_model_model_dict = DocumentClassifierModel.from_dict(
+            document_classifier_model_model_json).__dict__
+        document_classifier_model_model2 = DocumentClassifierModel(
+            **document_classifier_model_model_dict)
 
         # Verify the model instances are equivalent
         assert document_classifier_model_model == document_classifier_model_model2
 
         # Convert model instance back to dict and verify no loss of data
-        document_classifier_model_model_json2 = document_classifier_model_model.to_dict()
+        document_classifier_model_model_json2 = document_classifier_model_model.to_dict(
+        )
         assert document_classifier_model_model_json2 == document_classifier_model_model_json
+
 
 class TestModel_DocumentClassifierModels():
     """
     Test Class for DocumentClassifierModels
     """
-
     def test_document_classifier_models_serialization(self):
         """
         Test serialization/deserialization for DocumentClassifierModels
@@ -6255,28 +6480,34 @@ class TestModel_DocumentClassifierModels():
 
         # Construct dict forms of any model objects needed in order to build this model.
 
-        model_evaluation_micro_average_model = {} # ModelEvaluationMicroAverage
+        model_evaluation_micro_average_model = {
+        }  # ModelEvaluationMicroAverage
         model_evaluation_micro_average_model['precision'] = 0
         model_evaluation_micro_average_model['recall'] = 0
         model_evaluation_micro_average_model['f1'] = 0
 
-        model_evaluation_macro_average_model = {} # ModelEvaluationMacroAverage
+        model_evaluation_macro_average_model = {
+        }  # ModelEvaluationMacroAverage
         model_evaluation_macro_average_model['precision'] = 0
         model_evaluation_macro_average_model['recall'] = 0
         model_evaluation_macro_average_model['f1'] = 0
 
-        per_class_model_evaluation_model = {} # PerClassModelEvaluation
+        per_class_model_evaluation_model = {}  # PerClassModelEvaluation
         per_class_model_evaluation_model['name'] = 'testString'
         per_class_model_evaluation_model['precision'] = 0
         per_class_model_evaluation_model['recall'] = 0
         per_class_model_evaluation_model['f1'] = 0
 
-        classifier_model_evaluation_model = {} # ClassifierModelEvaluation
-        classifier_model_evaluation_model['micro_average'] = model_evaluation_micro_average_model
-        classifier_model_evaluation_model['macro_average'] = model_evaluation_macro_average_model
-        classifier_model_evaluation_model['per_class'] = [per_class_model_evaluation_model]
+        classifier_model_evaluation_model = {}  # ClassifierModelEvaluation
+        classifier_model_evaluation_model[
+            'micro_average'] = model_evaluation_micro_average_model
+        classifier_model_evaluation_model[
+            'macro_average'] = model_evaluation_macro_average_model
+        classifier_model_evaluation_model['per_class'] = [
+            per_class_model_evaluation_model
+        ]
 
-        document_classifier_model_model = {} # DocumentClassifierModel
+        document_classifier_model_model = {}  # DocumentClassifierModel
         document_classifier_model_model['model_id'] = 'testString'
         document_classifier_model_model['name'] = 'testString'
         document_classifier_model_model['description'] = 'testString'
@@ -6285,34 +6516,41 @@ class TestModel_DocumentClassifierModels():
         document_classifier_model_model['training_data_file'] = 'testString'
         document_classifier_model_model['test_data_file'] = 'testString'
         document_classifier_model_model['status'] = 'training'
-        document_classifier_model_model['evaluation'] = classifier_model_evaluation_model
+        document_classifier_model_model[
+            'evaluation'] = classifier_model_evaluation_model
         document_classifier_model_model['enrichment_id'] = 'testString'
         document_classifier_model_model['deployed_at'] = '2019-01-01T12:00:00Z'
 
         # Construct a json representation of a DocumentClassifierModels model
         document_classifier_models_model_json = {}
-        document_classifier_models_model_json['models'] = [document_classifier_model_model]
+        document_classifier_models_model_json['models'] = [
+            document_classifier_model_model
+        ]
 
         # Construct a model instance of DocumentClassifierModels by calling from_dict on the json representation
-        document_classifier_models_model = DocumentClassifierModels.from_dict(document_classifier_models_model_json)
+        document_classifier_models_model = DocumentClassifierModels.from_dict(
+            document_classifier_models_model_json)
         assert document_classifier_models_model != False
 
         # Construct a model instance of DocumentClassifierModels by calling from_dict on the json representation
-        document_classifier_models_model_dict = DocumentClassifierModels.from_dict(document_classifier_models_model_json).__dict__
-        document_classifier_models_model2 = DocumentClassifierModels(**document_classifier_models_model_dict)
+        document_classifier_models_model_dict = DocumentClassifierModels.from_dict(
+            document_classifier_models_model_json).__dict__
+        document_classifier_models_model2 = DocumentClassifierModels(
+            **document_classifier_models_model_dict)
 
         # Verify the model instances are equivalent
         assert document_classifier_models_model == document_classifier_models_model2
 
         # Convert model instance back to dict and verify no loss of data
-        document_classifier_models_model_json2 = document_classifier_models_model.to_dict()
+        document_classifier_models_model_json2 = document_classifier_models_model.to_dict(
+        )
         assert document_classifier_models_model_json2 == document_classifier_models_model_json
+
 
 class TestModel_DocumentClassifiers():
     """
     Test Class for DocumentClassifiers
     """
-
     def test_document_classifiers_serialization(self):
         """
         Test serialization/deserialization for DocumentClassifiers
@@ -6320,37 +6558,46 @@ class TestModel_DocumentClassifiers():
 
         # Construct dict forms of any model objects needed in order to build this model.
 
-        document_classifier_enrichment_model = {} # DocumentClassifierEnrichment
+        document_classifier_enrichment_model = {
+        }  # DocumentClassifierEnrichment
         document_classifier_enrichment_model['enrichment_id'] = 'testString'
         document_classifier_enrichment_model['fields'] = ['testString']
 
-        classifier_federated_model_model = {} # ClassifierFederatedModel
+        classifier_federated_model_model = {}  # ClassifierFederatedModel
         classifier_federated_model_model['field'] = 'testString'
 
-        document_classifier_model = {} # DocumentClassifier
+        document_classifier_model = {}  # DocumentClassifier
         document_classifier_model['classifier_id'] = 'testString'
         document_classifier_model['name'] = 'testString'
         document_classifier_model['description'] = 'testString'
         document_classifier_model['created'] = '2019-01-01T12:00:00Z'
         document_classifier_model['language'] = 'en'
-        document_classifier_model['enrichments'] = [document_classifier_enrichment_model]
+        document_classifier_model['enrichments'] = [
+            document_classifier_enrichment_model
+        ]
         document_classifier_model['recognized_fields'] = ['testString']
         document_classifier_model['answer_field'] = 'testString'
         document_classifier_model['training_data_file'] = 'testString'
         document_classifier_model['test_data_file'] = 'testString'
-        document_classifier_model['federated_classification'] = classifier_federated_model_model
+        document_classifier_model[
+            'federated_classification'] = classifier_federated_model_model
 
         # Construct a json representation of a DocumentClassifiers model
         document_classifiers_model_json = {}
-        document_classifiers_model_json['classifiers'] = [document_classifier_model]
+        document_classifiers_model_json['classifiers'] = [
+            document_classifier_model
+        ]
 
         # Construct a model instance of DocumentClassifiers by calling from_dict on the json representation
-        document_classifiers_model = DocumentClassifiers.from_dict(document_classifiers_model_json)
+        document_classifiers_model = DocumentClassifiers.from_dict(
+            document_classifiers_model_json)
         assert document_classifiers_model != False
 
         # Construct a model instance of DocumentClassifiers by calling from_dict on the json representation
-        document_classifiers_model_dict = DocumentClassifiers.from_dict(document_classifiers_model_json).__dict__
-        document_classifiers_model2 = DocumentClassifiers(**document_classifiers_model_dict)
+        document_classifiers_model_dict = DocumentClassifiers.from_dict(
+            document_classifiers_model_json).__dict__
+        document_classifiers_model2 = DocumentClassifiers(
+            **document_classifiers_model_dict)
 
         # Verify the model instances are equivalent
         assert document_classifiers_model == document_classifiers_model2
@@ -6359,11 +6606,11 @@ class TestModel_DocumentClassifiers():
         document_classifiers_model_json2 = document_classifiers_model.to_dict()
         assert document_classifiers_model_json2 == document_classifiers_model_json
 
+
 class TestModel_DocumentDetails():
     """
     Test Class for DocumentDetails
     """
-
     def test_document_details_serialization(self):
         """
         Test serialization/deserialization for DocumentDetails
@@ -6371,7 +6618,7 @@ class TestModel_DocumentDetails():
 
         # Construct dict forms of any model objects needed in order to build this model.
 
-        notice_model = {} # Notice
+        notice_model = {}  # Notice
         notice_model['notice_id'] = 'testString'
         notice_model['created'] = '2019-01-01T12:00:00Z'
         notice_model['document_id'] = 'testString'
@@ -6381,7 +6628,7 @@ class TestModel_DocumentDetails():
         notice_model['step'] = 'testString'
         notice_model['description'] = 'testString'
 
-        document_details_children_model = {} # DocumentDetailsChildren
+        document_details_children_model = {}  # DocumentDetailsChildren
         document_details_children_model['have_notices'] = True
         document_details_children_model['count'] = 38
 
@@ -6392,18 +6639,22 @@ class TestModel_DocumentDetails():
         document_details_model_json['updated'] = '2019-01-01T12:00:00Z'
         document_details_model_json['status'] = 'available'
         document_details_model_json['notices'] = [notice_model]
-        document_details_model_json['children'] = document_details_children_model
+        document_details_model_json[
+            'children'] = document_details_children_model
         document_details_model_json['filename'] = 'testString'
         document_details_model_json['file_type'] = 'testString'
         document_details_model_json['sha256'] = 'testString'
 
         # Construct a model instance of DocumentDetails by calling from_dict on the json representation
-        document_details_model = DocumentDetails.from_dict(document_details_model_json)
+        document_details_model = DocumentDetails.from_dict(
+            document_details_model_json)
         assert document_details_model != False
 
         # Construct a model instance of DocumentDetails by calling from_dict on the json representation
-        document_details_model_dict = DocumentDetails.from_dict(document_details_model_json).__dict__
-        document_details_model2 = DocumentDetails(**document_details_model_dict)
+        document_details_model_dict = DocumentDetails.from_dict(
+            document_details_model_json).__dict__
+        document_details_model2 = DocumentDetails(
+            **document_details_model_dict)
 
         # Verify the model instances are equivalent
         assert document_details_model == document_details_model2
@@ -6412,11 +6663,11 @@ class TestModel_DocumentDetails():
         document_details_model_json2 = document_details_model.to_dict()
         assert document_details_model_json2 == document_details_model_json
 
+
 class TestModel_DocumentDetailsChildren():
     """
     Test Class for DocumentDetailsChildren
     """
-
     def test_document_details_children_serialization(self):
         """
         Test serialization/deserialization for DocumentDetailsChildren
@@ -6428,25 +6679,29 @@ class TestModel_DocumentDetailsChildren():
         document_details_children_model_json['count'] = 38
 
         # Construct a model instance of DocumentDetailsChildren by calling from_dict on the json representation
-        document_details_children_model = DocumentDetailsChildren.from_dict(document_details_children_model_json)
+        document_details_children_model = DocumentDetailsChildren.from_dict(
+            document_details_children_model_json)
         assert document_details_children_model != False
 
         # Construct a model instance of DocumentDetailsChildren by calling from_dict on the json representation
-        document_details_children_model_dict = DocumentDetailsChildren.from_dict(document_details_children_model_json).__dict__
-        document_details_children_model2 = DocumentDetailsChildren(**document_details_children_model_dict)
+        document_details_children_model_dict = DocumentDetailsChildren.from_dict(
+            document_details_children_model_json).__dict__
+        document_details_children_model2 = DocumentDetailsChildren(
+            **document_details_children_model_dict)
 
         # Verify the model instances are equivalent
         assert document_details_children_model == document_details_children_model2
 
         # Convert model instance back to dict and verify no loss of data
-        document_details_children_model_json2 = document_details_children_model.to_dict()
+        document_details_children_model_json2 = document_details_children_model.to_dict(
+        )
         assert document_details_children_model_json2 == document_details_children_model_json
+
 
 class TestModel_Enrichment():
     """
     Test Class for Enrichment
     """
-
     def test_enrichment_serialization(self):
         """
         Test serialization/deserialization for Enrichment
@@ -6454,7 +6709,7 @@ class TestModel_Enrichment():
 
         # Construct dict forms of any model objects needed in order to build this model.
 
-        enrichment_options_model = {} # EnrichmentOptions
+        enrichment_options_model = {}  # EnrichmentOptions
         enrichment_options_model['languages'] = ['testString']
         enrichment_options_model['entity_type'] = 'testString'
         enrichment_options_model['regular_expression'] = 'testString'
@@ -6477,7 +6732,8 @@ class TestModel_Enrichment():
         assert enrichment_model != False
 
         # Construct a model instance of Enrichment by calling from_dict on the json representation
-        enrichment_model_dict = Enrichment.from_dict(enrichment_model_json).__dict__
+        enrichment_model_dict = Enrichment.from_dict(
+            enrichment_model_json).__dict__
         enrichment_model2 = Enrichment(**enrichment_model_dict)
 
         # Verify the model instances are equivalent
@@ -6487,11 +6743,11 @@ class TestModel_Enrichment():
         enrichment_model_json2 = enrichment_model.to_dict()
         assert enrichment_model_json2 == enrichment_model_json
 
+
 class TestModel_EnrichmentOptions():
     """
     Test Class for EnrichmentOptions
     """
-
     def test_enrichment_options_serialization(self):
         """
         Test serialization/deserialization for EnrichmentOptions
@@ -6509,12 +6765,15 @@ class TestModel_EnrichmentOptions():
         enrichment_options_model_json['top_k'] = 38
 
         # Construct a model instance of EnrichmentOptions by calling from_dict on the json representation
-        enrichment_options_model = EnrichmentOptions.from_dict(enrichment_options_model_json)
+        enrichment_options_model = EnrichmentOptions.from_dict(
+            enrichment_options_model_json)
         assert enrichment_options_model != False
 
         # Construct a model instance of EnrichmentOptions by calling from_dict on the json representation
-        enrichment_options_model_dict = EnrichmentOptions.from_dict(enrichment_options_model_json).__dict__
-        enrichment_options_model2 = EnrichmentOptions(**enrichment_options_model_dict)
+        enrichment_options_model_dict = EnrichmentOptions.from_dict(
+            enrichment_options_model_json).__dict__
+        enrichment_options_model2 = EnrichmentOptions(
+            **enrichment_options_model_dict)
 
         # Verify the model instances are equivalent
         assert enrichment_options_model == enrichment_options_model2
@@ -6523,11 +6782,11 @@ class TestModel_EnrichmentOptions():
         enrichment_options_model_json2 = enrichment_options_model.to_dict()
         assert enrichment_options_model_json2 == enrichment_options_model_json
 
+
 class TestModel_Enrichments():
     """
     Test Class for Enrichments
     """
-
     def test_enrichments_serialization(self):
         """
         Test serialization/deserialization for Enrichments
@@ -6535,7 +6794,7 @@ class TestModel_Enrichments():
 
         # Construct dict forms of any model objects needed in order to build this model.
 
-        enrichment_options_model = {} # EnrichmentOptions
+        enrichment_options_model = {}  # EnrichmentOptions
         enrichment_options_model['languages'] = ['testString']
         enrichment_options_model['entity_type'] = 'testString'
         enrichment_options_model['regular_expression'] = 'testString'
@@ -6545,7 +6804,7 @@ class TestModel_Enrichments():
         enrichment_options_model['confidence_threshold'] = 0
         enrichment_options_model['top_k'] = 38
 
-        enrichment_model = {} # Enrichment
+        enrichment_model = {}  # Enrichment
         enrichment_model['enrichment_id'] = 'testString'
         enrichment_model['name'] = 'testString'
         enrichment_model['description'] = 'testString'
@@ -6561,7 +6820,8 @@ class TestModel_Enrichments():
         assert enrichments_model != False
 
         # Construct a model instance of Enrichments by calling from_dict on the json representation
-        enrichments_model_dict = Enrichments.from_dict(enrichments_model_json).__dict__
+        enrichments_model_dict = Enrichments.from_dict(
+            enrichments_model_json).__dict__
         enrichments_model2 = Enrichments(**enrichments_model_dict)
 
         # Verify the model instances are equivalent
@@ -6571,11 +6831,11 @@ class TestModel_Enrichments():
         enrichments_model_json2 = enrichments_model.to_dict()
         assert enrichments_model_json2 == enrichments_model_json
 
+
 class TestModel_Expansion():
     """
     Test Class for Expansion
     """
-
     def test_expansion_serialization(self):
         """
         Test serialization/deserialization for Expansion
@@ -6591,7 +6851,8 @@ class TestModel_Expansion():
         assert expansion_model != False
 
         # Construct a model instance of Expansion by calling from_dict on the json representation
-        expansion_model_dict = Expansion.from_dict(expansion_model_json).__dict__
+        expansion_model_dict = Expansion.from_dict(
+            expansion_model_json).__dict__
         expansion_model2 = Expansion(**expansion_model_dict)
 
         # Verify the model instances are equivalent
@@ -6601,11 +6862,11 @@ class TestModel_Expansion():
         expansion_model_json2 = expansion_model.to_dict()
         assert expansion_model_json2 == expansion_model_json
 
+
 class TestModel_Expansions():
     """
     Test Class for Expansions
     """
-
     def test_expansions_serialization(self):
         """
         Test serialization/deserialization for Expansions
@@ -6613,7 +6874,7 @@ class TestModel_Expansions():
 
         # Construct dict forms of any model objects needed in order to build this model.
 
-        expansion_model = {} # Expansion
+        expansion_model = {}  # Expansion
         expansion_model['input_terms'] = ['testString']
         expansion_model['expanded_terms'] = ['testString']
 
@@ -6626,7 +6887,8 @@ class TestModel_Expansions():
         assert expansions_model != False
 
         # Construct a model instance of Expansions by calling from_dict on the json representation
-        expansions_model_dict = Expansions.from_dict(expansions_model_json).__dict__
+        expansions_model_dict = Expansions.from_dict(
+            expansions_model_json).__dict__
         expansions_model2 = Expansions(**expansions_model_dict)
 
         # Verify the model instances are equivalent
@@ -6636,11 +6898,11 @@ class TestModel_Expansions():
         expansions_model_json2 = expansions_model.to_dict()
         assert expansions_model_json2 == expansions_model_json
 
+
 class TestModel_Field():
     """
     Test Class for Field
     """
-
     def test_field_serialization(self):
         """
         Test serialization/deserialization for Field
@@ -6667,11 +6929,11 @@ class TestModel_Field():
         field_model_json2 = field_model.to_dict()
         assert field_model_json2 == field_model_json
 
+
 class TestModel_ListCollectionsResponse():
     """
     Test Class for ListCollectionsResponse
     """
-
     def test_list_collections_response_serialization(self):
         """
         Test serialization/deserialization for ListCollectionsResponse
@@ -6679,34 +6941,41 @@ class TestModel_ListCollectionsResponse():
 
         # Construct dict forms of any model objects needed in order to build this model.
 
-        collection_model = {} # Collection
-        collection_model['collection_id'] = 'f1360220-ea2d-4271-9d62-89a910b13c37'
+        collection_model = {}  # Collection
+        collection_model[
+            'collection_id'] = 'f1360220-ea2d-4271-9d62-89a910b13c37'
         collection_model['name'] = 'example'
 
         # Construct a json representation of a ListCollectionsResponse model
         list_collections_response_model_json = {}
-        list_collections_response_model_json['collections'] = [collection_model]
+        list_collections_response_model_json['collections'] = [
+            collection_model
+        ]
 
         # Construct a model instance of ListCollectionsResponse by calling from_dict on the json representation
-        list_collections_response_model = ListCollectionsResponse.from_dict(list_collections_response_model_json)
+        list_collections_response_model = ListCollectionsResponse.from_dict(
+            list_collections_response_model_json)
         assert list_collections_response_model != False
 
         # Construct a model instance of ListCollectionsResponse by calling from_dict on the json representation
-        list_collections_response_model_dict = ListCollectionsResponse.from_dict(list_collections_response_model_json).__dict__
-        list_collections_response_model2 = ListCollectionsResponse(**list_collections_response_model_dict)
+        list_collections_response_model_dict = ListCollectionsResponse.from_dict(
+            list_collections_response_model_json).__dict__
+        list_collections_response_model2 = ListCollectionsResponse(
+            **list_collections_response_model_dict)
 
         # Verify the model instances are equivalent
         assert list_collections_response_model == list_collections_response_model2
 
         # Convert model instance back to dict and verify no loss of data
-        list_collections_response_model_json2 = list_collections_response_model.to_dict()
+        list_collections_response_model_json2 = list_collections_response_model.to_dict(
+        )
         assert list_collections_response_model_json2 == list_collections_response_model_json
+
 
 class TestModel_ListDocumentsResponse():
     """
     Test Class for ListDocumentsResponse
     """
-
     def test_list_documents_response_serialization(self):
         """
         Test serialization/deserialization for ListDocumentsResponse
@@ -6714,7 +6983,7 @@ class TestModel_ListDocumentsResponse():
 
         # Construct dict forms of any model objects needed in order to build this model.
 
-        notice_model = {} # Notice
+        notice_model = {}  # Notice
         notice_model['notice_id'] = 'testString'
         notice_model['created'] = '2019-01-01T12:00:00Z'
         notice_model['document_id'] = 'testString'
@@ -6724,12 +6993,13 @@ class TestModel_ListDocumentsResponse():
         notice_model['step'] = 'testString'
         notice_model['description'] = 'testString'
 
-        document_details_children_model = {} # DocumentDetailsChildren
+        document_details_children_model = {}  # DocumentDetailsChildren
         document_details_children_model['have_notices'] = True
         document_details_children_model['count'] = 38
 
-        document_details_model = {} # DocumentDetails
-        document_details_model['document_id'] = '4ffcfd8052005b99469e632506763bac_0'
+        document_details_model = {}  # DocumentDetails
+        document_details_model[
+            'document_id'] = '4ffcfd8052005b99469e632506763bac_0'
         document_details_model['created'] = '2019-01-01T12:00:00Z'
         document_details_model['updated'] = '2019-01-01T12:00:00Z'
         document_details_model['status'] = 'available'
@@ -6742,28 +7012,34 @@ class TestModel_ListDocumentsResponse():
         # Construct a json representation of a ListDocumentsResponse model
         list_documents_response_model_json = {}
         list_documents_response_model_json['matching_results'] = 38
-        list_documents_response_model_json['documents'] = [document_details_model]
+        list_documents_response_model_json['documents'] = [
+            document_details_model
+        ]
 
         # Construct a model instance of ListDocumentsResponse by calling from_dict on the json representation
-        list_documents_response_model = ListDocumentsResponse.from_dict(list_documents_response_model_json)
+        list_documents_response_model = ListDocumentsResponse.from_dict(
+            list_documents_response_model_json)
         assert list_documents_response_model != False
 
         # Construct a model instance of ListDocumentsResponse by calling from_dict on the json representation
-        list_documents_response_model_dict = ListDocumentsResponse.from_dict(list_documents_response_model_json).__dict__
-        list_documents_response_model2 = ListDocumentsResponse(**list_documents_response_model_dict)
+        list_documents_response_model_dict = ListDocumentsResponse.from_dict(
+            list_documents_response_model_json).__dict__
+        list_documents_response_model2 = ListDocumentsResponse(
+            **list_documents_response_model_dict)
 
         # Verify the model instances are equivalent
         assert list_documents_response_model == list_documents_response_model2
 
         # Convert model instance back to dict and verify no loss of data
-        list_documents_response_model_json2 = list_documents_response_model.to_dict()
+        list_documents_response_model_json2 = list_documents_response_model.to_dict(
+        )
         assert list_documents_response_model_json2 == list_documents_response_model_json
+
 
 class TestModel_ListFieldsResponse():
     """
     Test Class for ListFieldsResponse
     """
-
     def test_list_fields_response_serialization(self):
         """
         Test serialization/deserialization for ListFieldsResponse
@@ -6771,7 +7047,7 @@ class TestModel_ListFieldsResponse():
 
         # Construct dict forms of any model objects needed in order to build this model.
 
-        field_model = {} # Field
+        field_model = {}  # Field
         field_model['field'] = 'testString'
         field_model['type'] = 'nested'
         field_model['collection_id'] = 'testString'
@@ -6781,12 +7057,15 @@ class TestModel_ListFieldsResponse():
         list_fields_response_model_json['fields'] = [field_model]
 
         # Construct a model instance of ListFieldsResponse by calling from_dict on the json representation
-        list_fields_response_model = ListFieldsResponse.from_dict(list_fields_response_model_json)
+        list_fields_response_model = ListFieldsResponse.from_dict(
+            list_fields_response_model_json)
         assert list_fields_response_model != False
 
         # Construct a model instance of ListFieldsResponse by calling from_dict on the json representation
-        list_fields_response_model_dict = ListFieldsResponse.from_dict(list_fields_response_model_json).__dict__
-        list_fields_response_model2 = ListFieldsResponse(**list_fields_response_model_dict)
+        list_fields_response_model_dict = ListFieldsResponse.from_dict(
+            list_fields_response_model_json).__dict__
+        list_fields_response_model2 = ListFieldsResponse(
+            **list_fields_response_model_dict)
 
         # Verify the model instances are equivalent
         assert list_fields_response_model == list_fields_response_model2
@@ -6795,11 +7074,11 @@ class TestModel_ListFieldsResponse():
         list_fields_response_model_json2 = list_fields_response_model.to_dict()
         assert list_fields_response_model_json2 == list_fields_response_model_json
 
+
 class TestModel_ListProjectsResponse():
     """
     Test Class for ListProjectsResponse
     """
-
     def test_list_projects_response_serialization(self):
         """
         Test serialization/deserialization for ListProjectsResponse
@@ -6807,48 +7086,64 @@ class TestModel_ListProjectsResponse():
 
         # Construct dict forms of any model objects needed in order to build this model.
 
-        project_list_details_relevancy_training_status_model = {} # ProjectListDetailsRelevancyTrainingStatus
-        project_list_details_relevancy_training_status_model['data_updated'] = 'testString'
-        project_list_details_relevancy_training_status_model['total_examples'] = 38
-        project_list_details_relevancy_training_status_model['sufficient_label_diversity'] = True
-        project_list_details_relevancy_training_status_model['processing'] = True
-        project_list_details_relevancy_training_status_model['minimum_examples_added'] = True
-        project_list_details_relevancy_training_status_model['successfully_trained'] = 'testString'
-        project_list_details_relevancy_training_status_model['available'] = True
+        project_list_details_relevancy_training_status_model = {
+        }  # ProjectListDetailsRelevancyTrainingStatus
+        project_list_details_relevancy_training_status_model[
+            'data_updated'] = 'testString'
+        project_list_details_relevancy_training_status_model[
+            'total_examples'] = 38
+        project_list_details_relevancy_training_status_model[
+            'sufficient_label_diversity'] = True
+        project_list_details_relevancy_training_status_model[
+            'processing'] = True
+        project_list_details_relevancy_training_status_model[
+            'minimum_examples_added'] = True
+        project_list_details_relevancy_training_status_model[
+            'successfully_trained'] = 'testString'
+        project_list_details_relevancy_training_status_model[
+            'available'] = True
         project_list_details_relevancy_training_status_model['notices'] = 38
-        project_list_details_relevancy_training_status_model['minimum_queries_added'] = True
+        project_list_details_relevancy_training_status_model[
+            'minimum_queries_added'] = True
 
-        project_list_details_model = {} # ProjectListDetails
+        project_list_details_model = {}  # ProjectListDetails
         project_list_details_model['project_id'] = 'testString'
         project_list_details_model['name'] = 'testString'
         project_list_details_model['type'] = 'document_retrieval'
-        project_list_details_model['relevancy_training_status'] = project_list_details_relevancy_training_status_model
+        project_list_details_model[
+            'relevancy_training_status'] = project_list_details_relevancy_training_status_model
         project_list_details_model['collection_count'] = 38
 
         # Construct a json representation of a ListProjectsResponse model
         list_projects_response_model_json = {}
-        list_projects_response_model_json['projects'] = [project_list_details_model]
+        list_projects_response_model_json['projects'] = [
+            project_list_details_model
+        ]
 
         # Construct a model instance of ListProjectsResponse by calling from_dict on the json representation
-        list_projects_response_model = ListProjectsResponse.from_dict(list_projects_response_model_json)
+        list_projects_response_model = ListProjectsResponse.from_dict(
+            list_projects_response_model_json)
         assert list_projects_response_model != False
 
         # Construct a model instance of ListProjectsResponse by calling from_dict on the json representation
-        list_projects_response_model_dict = ListProjectsResponse.from_dict(list_projects_response_model_json).__dict__
-        list_projects_response_model2 = ListProjectsResponse(**list_projects_response_model_dict)
+        list_projects_response_model_dict = ListProjectsResponse.from_dict(
+            list_projects_response_model_json).__dict__
+        list_projects_response_model2 = ListProjectsResponse(
+            **list_projects_response_model_dict)
 
         # Verify the model instances are equivalent
         assert list_projects_response_model == list_projects_response_model2
 
         # Convert model instance back to dict and verify no loss of data
-        list_projects_response_model_json2 = list_projects_response_model.to_dict()
+        list_projects_response_model_json2 = list_projects_response_model.to_dict(
+        )
         assert list_projects_response_model_json2 == list_projects_response_model_json
+
 
 class TestModel_ModelEvaluationMacroAverage():
     """
     Test Class for ModelEvaluationMacroAverage
     """
-
     def test_model_evaluation_macro_average_serialization(self):
         """
         Test serialization/deserialization for ModelEvaluationMacroAverage
@@ -6861,25 +7156,29 @@ class TestModel_ModelEvaluationMacroAverage():
         model_evaluation_macro_average_model_json['f1'] = 0
 
         # Construct a model instance of ModelEvaluationMacroAverage by calling from_dict on the json representation
-        model_evaluation_macro_average_model = ModelEvaluationMacroAverage.from_dict(model_evaluation_macro_average_model_json)
+        model_evaluation_macro_average_model = ModelEvaluationMacroAverage.from_dict(
+            model_evaluation_macro_average_model_json)
         assert model_evaluation_macro_average_model != False
 
         # Construct a model instance of ModelEvaluationMacroAverage by calling from_dict on the json representation
-        model_evaluation_macro_average_model_dict = ModelEvaluationMacroAverage.from_dict(model_evaluation_macro_average_model_json).__dict__
-        model_evaluation_macro_average_model2 = ModelEvaluationMacroAverage(**model_evaluation_macro_average_model_dict)
+        model_evaluation_macro_average_model_dict = ModelEvaluationMacroAverage.from_dict(
+            model_evaluation_macro_average_model_json).__dict__
+        model_evaluation_macro_average_model2 = ModelEvaluationMacroAverage(
+            **model_evaluation_macro_average_model_dict)
 
         # Verify the model instances are equivalent
         assert model_evaluation_macro_average_model == model_evaluation_macro_average_model2
 
         # Convert model instance back to dict and verify no loss of data
-        model_evaluation_macro_average_model_json2 = model_evaluation_macro_average_model.to_dict()
+        model_evaluation_macro_average_model_json2 = model_evaluation_macro_average_model.to_dict(
+        )
         assert model_evaluation_macro_average_model_json2 == model_evaluation_macro_average_model_json
+
 
 class TestModel_ModelEvaluationMicroAverage():
     """
     Test Class for ModelEvaluationMicroAverage
     """
-
     def test_model_evaluation_micro_average_serialization(self):
         """
         Test serialization/deserialization for ModelEvaluationMicroAverage
@@ -6892,25 +7191,29 @@ class TestModel_ModelEvaluationMicroAverage():
         model_evaluation_micro_average_model_json['f1'] = 0
 
         # Construct a model instance of ModelEvaluationMicroAverage by calling from_dict on the json representation
-        model_evaluation_micro_average_model = ModelEvaluationMicroAverage.from_dict(model_evaluation_micro_average_model_json)
+        model_evaluation_micro_average_model = ModelEvaluationMicroAverage.from_dict(
+            model_evaluation_micro_average_model_json)
         assert model_evaluation_micro_average_model != False
 
         # Construct a model instance of ModelEvaluationMicroAverage by calling from_dict on the json representation
-        model_evaluation_micro_average_model_dict = ModelEvaluationMicroAverage.from_dict(model_evaluation_micro_average_model_json).__dict__
-        model_evaluation_micro_average_model2 = ModelEvaluationMicroAverage(**model_evaluation_micro_average_model_dict)
+        model_evaluation_micro_average_model_dict = ModelEvaluationMicroAverage.from_dict(
+            model_evaluation_micro_average_model_json).__dict__
+        model_evaluation_micro_average_model2 = ModelEvaluationMicroAverage(
+            **model_evaluation_micro_average_model_dict)
 
         # Verify the model instances are equivalent
         assert model_evaluation_micro_average_model == model_evaluation_micro_average_model2
 
         # Convert model instance back to dict and verify no loss of data
-        model_evaluation_micro_average_model_json2 = model_evaluation_micro_average_model.to_dict()
+        model_evaluation_micro_average_model_json2 = model_evaluation_micro_average_model.to_dict(
+        )
         assert model_evaluation_micro_average_model_json2 == model_evaluation_micro_average_model_json
+
 
 class TestModel_Notice():
     """
     Test Class for Notice
     """
-
     def test_notice_serialization(self):
         """
         Test serialization/deserialization for Notice
@@ -6942,11 +7245,11 @@ class TestModel_Notice():
         notice_model_json2 = notice_model.to_dict()
         assert notice_model_json2 == notice_model_json
 
+
 class TestModel_PerClassModelEvaluation():
     """
     Test Class for PerClassModelEvaluation
     """
-
     def test_per_class_model_evaluation_serialization(self):
         """
         Test serialization/deserialization for PerClassModelEvaluation
@@ -6960,25 +7263,29 @@ class TestModel_PerClassModelEvaluation():
         per_class_model_evaluation_model_json['f1'] = 0
 
         # Construct a model instance of PerClassModelEvaluation by calling from_dict on the json representation
-        per_class_model_evaluation_model = PerClassModelEvaluation.from_dict(per_class_model_evaluation_model_json)
+        per_class_model_evaluation_model = PerClassModelEvaluation.from_dict(
+            per_class_model_evaluation_model_json)
         assert per_class_model_evaluation_model != False
 
         # Construct a model instance of PerClassModelEvaluation by calling from_dict on the json representation
-        per_class_model_evaluation_model_dict = PerClassModelEvaluation.from_dict(per_class_model_evaluation_model_json).__dict__
-        per_class_model_evaluation_model2 = PerClassModelEvaluation(**per_class_model_evaluation_model_dict)
+        per_class_model_evaluation_model_dict = PerClassModelEvaluation.from_dict(
+            per_class_model_evaluation_model_json).__dict__
+        per_class_model_evaluation_model2 = PerClassModelEvaluation(
+            **per_class_model_evaluation_model_dict)
 
         # Verify the model instances are equivalent
         assert per_class_model_evaluation_model == per_class_model_evaluation_model2
 
         # Convert model instance back to dict and verify no loss of data
-        per_class_model_evaluation_model_json2 = per_class_model_evaluation_model.to_dict()
+        per_class_model_evaluation_model_json2 = per_class_model_evaluation_model.to_dict(
+        )
         assert per_class_model_evaluation_model_json2 == per_class_model_evaluation_model_json
+
 
 class TestModel_ProjectDetails():
     """
     Test Class for ProjectDetails
     """
-
     def test_project_details_serialization(self):
         """
         Test serialization/deserialization for ProjectDetails
@@ -6986,18 +7293,27 @@ class TestModel_ProjectDetails():
 
         # Construct dict forms of any model objects needed in order to build this model.
 
-        project_list_details_relevancy_training_status_model = {} # ProjectListDetailsRelevancyTrainingStatus
-        project_list_details_relevancy_training_status_model['data_updated'] = 'testString'
-        project_list_details_relevancy_training_status_model['total_examples'] = 38
-        project_list_details_relevancy_training_status_model['sufficient_label_diversity'] = True
-        project_list_details_relevancy_training_status_model['processing'] = True
-        project_list_details_relevancy_training_status_model['minimum_examples_added'] = True
-        project_list_details_relevancy_training_status_model['successfully_trained'] = 'testString'
-        project_list_details_relevancy_training_status_model['available'] = True
+        project_list_details_relevancy_training_status_model = {
+        }  # ProjectListDetailsRelevancyTrainingStatus
+        project_list_details_relevancy_training_status_model[
+            'data_updated'] = 'testString'
+        project_list_details_relevancy_training_status_model[
+            'total_examples'] = 38
+        project_list_details_relevancy_training_status_model[
+            'sufficient_label_diversity'] = True
+        project_list_details_relevancy_training_status_model[
+            'processing'] = True
+        project_list_details_relevancy_training_status_model[
+            'minimum_examples_added'] = True
+        project_list_details_relevancy_training_status_model[
+            'successfully_trained'] = 'testString'
+        project_list_details_relevancy_training_status_model[
+            'available'] = True
         project_list_details_relevancy_training_status_model['notices'] = 38
-        project_list_details_relevancy_training_status_model['minimum_queries_added'] = True
+        project_list_details_relevancy_training_status_model[
+            'minimum_queries_added'] = True
 
-        default_query_params_passages_model = {} # DefaultQueryParamsPassages
+        default_query_params_passages_model = {}  # DefaultQueryParamsPassages
         default_query_params_passages_model['enabled'] = True
         default_query_params_passages_model['count'] = 38
         default_query_params_passages_model['fields'] = ['testString']
@@ -7005,21 +7321,26 @@ class TestModel_ProjectDetails():
         default_query_params_passages_model['per_document'] = True
         default_query_params_passages_model['max_per_document'] = 38
 
-        default_query_params_table_results_model = {} # DefaultQueryParamsTableResults
+        default_query_params_table_results_model = {
+        }  # DefaultQueryParamsTableResults
         default_query_params_table_results_model['enabled'] = True
         default_query_params_table_results_model['count'] = 38
         default_query_params_table_results_model['per_document'] = 38
 
-        default_query_params_suggested_refinements_model = {} # DefaultQueryParamsSuggestedRefinements
+        default_query_params_suggested_refinements_model = {
+        }  # DefaultQueryParamsSuggestedRefinements
         default_query_params_suggested_refinements_model['enabled'] = True
         default_query_params_suggested_refinements_model['count'] = 38
 
-        default_query_params_model = {} # DefaultQueryParams
+        default_query_params_model = {}  # DefaultQueryParams
         default_query_params_model['collection_ids'] = ['testString']
-        default_query_params_model['passages'] = default_query_params_passages_model
-        default_query_params_model['table_results'] = default_query_params_table_results_model
+        default_query_params_model[
+            'passages'] = default_query_params_passages_model
+        default_query_params_model[
+            'table_results'] = default_query_params_table_results_model
         default_query_params_model['aggregation'] = 'testString'
-        default_query_params_model['suggested_refinements'] = default_query_params_suggested_refinements_model
+        default_query_params_model[
+            'suggested_refinements'] = default_query_params_suggested_refinements_model
         default_query_params_model['spelling_suggestions'] = True
         default_query_params_model['highlight'] = True
         default_query_params_model['count'] = 38
@@ -7031,16 +7352,20 @@ class TestModel_ProjectDetails():
         project_details_model_json['project_id'] = 'testString'
         project_details_model_json['name'] = 'testString'
         project_details_model_json['type'] = 'document_retrieval'
-        project_details_model_json['relevancy_training_status'] = project_list_details_relevancy_training_status_model
+        project_details_model_json[
+            'relevancy_training_status'] = project_list_details_relevancy_training_status_model
         project_details_model_json['collection_count'] = 38
-        project_details_model_json['default_query_parameters'] = default_query_params_model
+        project_details_model_json[
+            'default_query_parameters'] = default_query_params_model
 
         # Construct a model instance of ProjectDetails by calling from_dict on the json representation
-        project_details_model = ProjectDetails.from_dict(project_details_model_json)
+        project_details_model = ProjectDetails.from_dict(
+            project_details_model_json)
         assert project_details_model != False
 
         # Construct a model instance of ProjectDetails by calling from_dict on the json representation
-        project_details_model_dict = ProjectDetails.from_dict(project_details_model_json).__dict__
+        project_details_model_dict = ProjectDetails.from_dict(
+            project_details_model_json).__dict__
         project_details_model2 = ProjectDetails(**project_details_model_dict)
 
         # Verify the model instances are equivalent
@@ -7050,11 +7375,11 @@ class TestModel_ProjectDetails():
         project_details_model_json2 = project_details_model.to_dict()
         assert project_details_model_json2 == project_details_model_json
 
+
 class TestModel_ProjectListDetails():
     """
     Test Class for ProjectListDetails
     """
-
     def test_project_list_details_serialization(self):
         """
         Test serialization/deserialization for ProjectListDetails
@@ -7062,32 +7387,45 @@ class TestModel_ProjectListDetails():
 
         # Construct dict forms of any model objects needed in order to build this model.
 
-        project_list_details_relevancy_training_status_model = {} # ProjectListDetailsRelevancyTrainingStatus
-        project_list_details_relevancy_training_status_model['data_updated'] = 'testString'
-        project_list_details_relevancy_training_status_model['total_examples'] = 38
-        project_list_details_relevancy_training_status_model['sufficient_label_diversity'] = True
-        project_list_details_relevancy_training_status_model['processing'] = True
-        project_list_details_relevancy_training_status_model['minimum_examples_added'] = True
-        project_list_details_relevancy_training_status_model['successfully_trained'] = 'testString'
-        project_list_details_relevancy_training_status_model['available'] = True
+        project_list_details_relevancy_training_status_model = {
+        }  # ProjectListDetailsRelevancyTrainingStatus
+        project_list_details_relevancy_training_status_model[
+            'data_updated'] = 'testString'
+        project_list_details_relevancy_training_status_model[
+            'total_examples'] = 38
+        project_list_details_relevancy_training_status_model[
+            'sufficient_label_diversity'] = True
+        project_list_details_relevancy_training_status_model[
+            'processing'] = True
+        project_list_details_relevancy_training_status_model[
+            'minimum_examples_added'] = True
+        project_list_details_relevancy_training_status_model[
+            'successfully_trained'] = 'testString'
+        project_list_details_relevancy_training_status_model[
+            'available'] = True
         project_list_details_relevancy_training_status_model['notices'] = 38
-        project_list_details_relevancy_training_status_model['minimum_queries_added'] = True
+        project_list_details_relevancy_training_status_model[
+            'minimum_queries_added'] = True
 
         # Construct a json representation of a ProjectListDetails model
         project_list_details_model_json = {}
         project_list_details_model_json['project_id'] = 'testString'
         project_list_details_model_json['name'] = 'testString'
         project_list_details_model_json['type'] = 'document_retrieval'
-        project_list_details_model_json['relevancy_training_status'] = project_list_details_relevancy_training_status_model
+        project_list_details_model_json[
+            'relevancy_training_status'] = project_list_details_relevancy_training_status_model
         project_list_details_model_json['collection_count'] = 38
 
         # Construct a model instance of ProjectListDetails by calling from_dict on the json representation
-        project_list_details_model = ProjectListDetails.from_dict(project_list_details_model_json)
+        project_list_details_model = ProjectListDetails.from_dict(
+            project_list_details_model_json)
         assert project_list_details_model != False
 
         # Construct a model instance of ProjectListDetails by calling from_dict on the json representation
-        project_list_details_model_dict = ProjectListDetails.from_dict(project_list_details_model_json).__dict__
-        project_list_details_model2 = ProjectListDetails(**project_list_details_model_dict)
+        project_list_details_model_dict = ProjectListDetails.from_dict(
+            project_list_details_model_json).__dict__
+        project_list_details_model2 = ProjectListDetails(
+            **project_list_details_model_dict)
 
         # Verify the model instances are equivalent
         assert project_list_details_model == project_list_details_model2
@@ -7096,48 +7434,62 @@ class TestModel_ProjectListDetails():
         project_list_details_model_json2 = project_list_details_model.to_dict()
         assert project_list_details_model_json2 == project_list_details_model_json
 
+
 class TestModel_ProjectListDetailsRelevancyTrainingStatus():
     """
     Test Class for ProjectListDetailsRelevancyTrainingStatus
     """
-
-    def test_project_list_details_relevancy_training_status_serialization(self):
+    def test_project_list_details_relevancy_training_status_serialization(
+            self):
         """
         Test serialization/deserialization for ProjectListDetailsRelevancyTrainingStatus
         """
 
         # Construct a json representation of a ProjectListDetailsRelevancyTrainingStatus model
         project_list_details_relevancy_training_status_model_json = {}
-        project_list_details_relevancy_training_status_model_json['data_updated'] = 'testString'
-        project_list_details_relevancy_training_status_model_json['total_examples'] = 38
-        project_list_details_relevancy_training_status_model_json['sufficient_label_diversity'] = True
-        project_list_details_relevancy_training_status_model_json['processing'] = True
-        project_list_details_relevancy_training_status_model_json['minimum_examples_added'] = True
-        project_list_details_relevancy_training_status_model_json['successfully_trained'] = 'testString'
-        project_list_details_relevancy_training_status_model_json['available'] = True
-        project_list_details_relevancy_training_status_model_json['notices'] = 38
-        project_list_details_relevancy_training_status_model_json['minimum_queries_added'] = True
+        project_list_details_relevancy_training_status_model_json[
+            'data_updated'] = 'testString'
+        project_list_details_relevancy_training_status_model_json[
+            'total_examples'] = 38
+        project_list_details_relevancy_training_status_model_json[
+            'sufficient_label_diversity'] = True
+        project_list_details_relevancy_training_status_model_json[
+            'processing'] = True
+        project_list_details_relevancy_training_status_model_json[
+            'minimum_examples_added'] = True
+        project_list_details_relevancy_training_status_model_json[
+            'successfully_trained'] = 'testString'
+        project_list_details_relevancy_training_status_model_json[
+            'available'] = True
+        project_list_details_relevancy_training_status_model_json[
+            'notices'] = 38
+        project_list_details_relevancy_training_status_model_json[
+            'minimum_queries_added'] = True
 
         # Construct a model instance of ProjectListDetailsRelevancyTrainingStatus by calling from_dict on the json representation
-        project_list_details_relevancy_training_status_model = ProjectListDetailsRelevancyTrainingStatus.from_dict(project_list_details_relevancy_training_status_model_json)
+        project_list_details_relevancy_training_status_model = ProjectListDetailsRelevancyTrainingStatus.from_dict(
+            project_list_details_relevancy_training_status_model_json)
         assert project_list_details_relevancy_training_status_model != False
 
         # Construct a model instance of ProjectListDetailsRelevancyTrainingStatus by calling from_dict on the json representation
-        project_list_details_relevancy_training_status_model_dict = ProjectListDetailsRelevancyTrainingStatus.from_dict(project_list_details_relevancy_training_status_model_json).__dict__
-        project_list_details_relevancy_training_status_model2 = ProjectListDetailsRelevancyTrainingStatus(**project_list_details_relevancy_training_status_model_dict)
+        project_list_details_relevancy_training_status_model_dict = ProjectListDetailsRelevancyTrainingStatus.from_dict(
+            project_list_details_relevancy_training_status_model_json).__dict__
+        project_list_details_relevancy_training_status_model2 = ProjectListDetailsRelevancyTrainingStatus(
+            **project_list_details_relevancy_training_status_model_dict)
 
         # Verify the model instances are equivalent
         assert project_list_details_relevancy_training_status_model == project_list_details_relevancy_training_status_model2
 
         # Convert model instance back to dict and verify no loss of data
-        project_list_details_relevancy_training_status_model_json2 = project_list_details_relevancy_training_status_model.to_dict()
+        project_list_details_relevancy_training_status_model_json2 = project_list_details_relevancy_training_status_model.to_dict(
+        )
         assert project_list_details_relevancy_training_status_model_json2 == project_list_details_relevancy_training_status_model_json
+
 
 class TestModel_QueryAggregation():
     """
     Test Class for QueryAggregation
     """
-
     def test_query_aggregation_serialization(self):
         """
         Test serialization/deserialization for QueryAggregation
@@ -7148,12 +7500,14 @@ class TestModel_QueryAggregation():
         query_aggregation_model_json['type'] = 'testString'
 
         # Construct a model instance of QueryAggregation by calling from_dict on the json representation
-        query_aggregation_model = QueryAggregation.from_dict(query_aggregation_model_json)
+        query_aggregation_model = QueryAggregation.from_dict(
+            query_aggregation_model_json)
         assert query_aggregation_model != False
 
         # Construct a copy of the model instance by calling from_dict on the output of to_dict
         query_aggregation_model_json2 = query_aggregation_model.to_dict()
-        query_aggregation_model2 = QueryAggregation.from_dict(query_aggregation_model_json2)
+        query_aggregation_model2 = QueryAggregation.from_dict(
+            query_aggregation_model_json2)
 
         # Verify the model instances are equivalent
         assert query_aggregation_model == query_aggregation_model2
@@ -7162,11 +7516,11 @@ class TestModel_QueryAggregation():
         query_aggregation_model_json2 = query_aggregation_model.to_dict()
         assert query_aggregation_model_json2 == query_aggregation_model_json
 
+
 class TestModel_QueryGroupByAggregationResult():
     """
     Test Class for QueryGroupByAggregationResult
     """
-
     def test_query_group_by_aggregation_result_serialization(self):
         """
         Test serialization/deserialization for QueryGroupByAggregationResult
@@ -7174,7 +7528,7 @@ class TestModel_QueryGroupByAggregationResult():
 
         # Construct dict forms of any model objects needed in order to build this model.
 
-        query_aggregation_model = {} # QueryFilterAggregation
+        query_aggregation_model = {}  # QueryFilterAggregation
         query_aggregation_model['type'] = 'filter'
         query_aggregation_model['match'] = 'testString'
         query_aggregation_model['matching_results'] = 26
@@ -7184,30 +7538,38 @@ class TestModel_QueryGroupByAggregationResult():
         query_group_by_aggregation_result_model_json['key'] = 'testString'
         query_group_by_aggregation_result_model_json['matching_results'] = 38
         query_group_by_aggregation_result_model_json['relevancy'] = 72.5
-        query_group_by_aggregation_result_model_json['total_matching_documents'] = 38
-        query_group_by_aggregation_result_model_json['estimated_matching_documents'] = 38
-        query_group_by_aggregation_result_model_json['aggregations'] = [query_aggregation_model]
+        query_group_by_aggregation_result_model_json[
+            'total_matching_documents'] = 38
+        query_group_by_aggregation_result_model_json[
+            'estimated_matching_documents'] = 38
+        query_group_by_aggregation_result_model_json['aggregations'] = [
+            query_aggregation_model
+        ]
 
         # Construct a model instance of QueryGroupByAggregationResult by calling from_dict on the json representation
-        query_group_by_aggregation_result_model = QueryGroupByAggregationResult.from_dict(query_group_by_aggregation_result_model_json)
+        query_group_by_aggregation_result_model = QueryGroupByAggregationResult.from_dict(
+            query_group_by_aggregation_result_model_json)
         assert query_group_by_aggregation_result_model != False
 
         # Construct a model instance of QueryGroupByAggregationResult by calling from_dict on the json representation
-        query_group_by_aggregation_result_model_dict = QueryGroupByAggregationResult.from_dict(query_group_by_aggregation_result_model_json).__dict__
-        query_group_by_aggregation_result_model2 = QueryGroupByAggregationResult(**query_group_by_aggregation_result_model_dict)
+        query_group_by_aggregation_result_model_dict = QueryGroupByAggregationResult.from_dict(
+            query_group_by_aggregation_result_model_json).__dict__
+        query_group_by_aggregation_result_model2 = QueryGroupByAggregationResult(
+            **query_group_by_aggregation_result_model_dict)
 
         # Verify the model instances are equivalent
         assert query_group_by_aggregation_result_model == query_group_by_aggregation_result_model2
 
         # Convert model instance back to dict and verify no loss of data
-        query_group_by_aggregation_result_model_json2 = query_group_by_aggregation_result_model.to_dict()
+        query_group_by_aggregation_result_model_json2 = query_group_by_aggregation_result_model.to_dict(
+        )
         assert query_group_by_aggregation_result_model_json2 == query_group_by_aggregation_result_model_json
+
 
 class TestModel_QueryHistogramAggregationResult():
     """
     Test Class for QueryHistogramAggregationResult
     """
-
     def test_query_histogram_aggregation_result_serialization(self):
         """
         Test serialization/deserialization for QueryHistogramAggregationResult
@@ -7215,7 +7577,7 @@ class TestModel_QueryHistogramAggregationResult():
 
         # Construct dict forms of any model objects needed in order to build this model.
 
-        query_aggregation_model = {} # QueryFilterAggregation
+        query_aggregation_model = {}  # QueryFilterAggregation
         query_aggregation_model['type'] = 'filter'
         query_aggregation_model['match'] = 'testString'
         query_aggregation_model['matching_results'] = 26
@@ -7224,28 +7586,34 @@ class TestModel_QueryHistogramAggregationResult():
         query_histogram_aggregation_result_model_json = {}
         query_histogram_aggregation_result_model_json['key'] = 26
         query_histogram_aggregation_result_model_json['matching_results'] = 38
-        query_histogram_aggregation_result_model_json['aggregations'] = [query_aggregation_model]
+        query_histogram_aggregation_result_model_json['aggregations'] = [
+            query_aggregation_model
+        ]
 
         # Construct a model instance of QueryHistogramAggregationResult by calling from_dict on the json representation
-        query_histogram_aggregation_result_model = QueryHistogramAggregationResult.from_dict(query_histogram_aggregation_result_model_json)
+        query_histogram_aggregation_result_model = QueryHistogramAggregationResult.from_dict(
+            query_histogram_aggregation_result_model_json)
         assert query_histogram_aggregation_result_model != False
 
         # Construct a model instance of QueryHistogramAggregationResult by calling from_dict on the json representation
-        query_histogram_aggregation_result_model_dict = QueryHistogramAggregationResult.from_dict(query_histogram_aggregation_result_model_json).__dict__
-        query_histogram_aggregation_result_model2 = QueryHistogramAggregationResult(**query_histogram_aggregation_result_model_dict)
+        query_histogram_aggregation_result_model_dict = QueryHistogramAggregationResult.from_dict(
+            query_histogram_aggregation_result_model_json).__dict__
+        query_histogram_aggregation_result_model2 = QueryHistogramAggregationResult(
+            **query_histogram_aggregation_result_model_dict)
 
         # Verify the model instances are equivalent
         assert query_histogram_aggregation_result_model == query_histogram_aggregation_result_model2
 
         # Convert model instance back to dict and verify no loss of data
-        query_histogram_aggregation_result_model_json2 = query_histogram_aggregation_result_model.to_dict()
+        query_histogram_aggregation_result_model_json2 = query_histogram_aggregation_result_model.to_dict(
+        )
         assert query_histogram_aggregation_result_model_json2 == query_histogram_aggregation_result_model_json
+
 
 class TestModel_QueryLargePassages():
     """
     Test Class for QueryLargePassages
     """
-
     def test_query_large_passages_serialization(self):
         """
         Test serialization/deserialization for QueryLargePassages
@@ -7263,12 +7631,15 @@ class TestModel_QueryLargePassages():
         query_large_passages_model_json['max_answers_per_passage'] = 38
 
         # Construct a model instance of QueryLargePassages by calling from_dict on the json representation
-        query_large_passages_model = QueryLargePassages.from_dict(query_large_passages_model_json)
+        query_large_passages_model = QueryLargePassages.from_dict(
+            query_large_passages_model_json)
         assert query_large_passages_model != False
 
         # Construct a model instance of QueryLargePassages by calling from_dict on the json representation
-        query_large_passages_model_dict = QueryLargePassages.from_dict(query_large_passages_model_json).__dict__
-        query_large_passages_model2 = QueryLargePassages(**query_large_passages_model_dict)
+        query_large_passages_model_dict = QueryLargePassages.from_dict(
+            query_large_passages_model_json).__dict__
+        query_large_passages_model2 = QueryLargePassages(
+            **query_large_passages_model_dict)
 
         # Verify the model instances are equivalent
         assert query_large_passages_model == query_large_passages_model2
@@ -7277,11 +7648,11 @@ class TestModel_QueryLargePassages():
         query_large_passages_model_json2 = query_large_passages_model.to_dict()
         assert query_large_passages_model_json2 == query_large_passages_model_json
 
+
 class TestModel_QueryLargeSimilar():
     """
     Test Class for QueryLargeSimilar
     """
-
     def test_query_large_similar_serialization(self):
         """
         Test serialization/deserialization for QueryLargeSimilar
@@ -7294,12 +7665,15 @@ class TestModel_QueryLargeSimilar():
         query_large_similar_model_json['fields'] = ['testString']
 
         # Construct a model instance of QueryLargeSimilar by calling from_dict on the json representation
-        query_large_similar_model = QueryLargeSimilar.from_dict(query_large_similar_model_json)
+        query_large_similar_model = QueryLargeSimilar.from_dict(
+            query_large_similar_model_json)
         assert query_large_similar_model != False
 
         # Construct a model instance of QueryLargeSimilar by calling from_dict on the json representation
-        query_large_similar_model_dict = QueryLargeSimilar.from_dict(query_large_similar_model_json).__dict__
-        query_large_similar_model2 = QueryLargeSimilar(**query_large_similar_model_dict)
+        query_large_similar_model_dict = QueryLargeSimilar.from_dict(
+            query_large_similar_model_json).__dict__
+        query_large_similar_model2 = QueryLargeSimilar(
+            **query_large_similar_model_dict)
 
         # Verify the model instances are equivalent
         assert query_large_similar_model == query_large_similar_model2
@@ -7308,11 +7682,11 @@ class TestModel_QueryLargeSimilar():
         query_large_similar_model_json2 = query_large_similar_model.to_dict()
         assert query_large_similar_model_json2 == query_large_similar_model_json
 
+
 class TestModel_QueryLargeSuggestedRefinements():
     """
     Test Class for QueryLargeSuggestedRefinements
     """
-
     def test_query_large_suggested_refinements_serialization(self):
         """
         Test serialization/deserialization for QueryLargeSuggestedRefinements
@@ -7324,25 +7698,29 @@ class TestModel_QueryLargeSuggestedRefinements():
         query_large_suggested_refinements_model_json['count'] = 1
 
         # Construct a model instance of QueryLargeSuggestedRefinements by calling from_dict on the json representation
-        query_large_suggested_refinements_model = QueryLargeSuggestedRefinements.from_dict(query_large_suggested_refinements_model_json)
+        query_large_suggested_refinements_model = QueryLargeSuggestedRefinements.from_dict(
+            query_large_suggested_refinements_model_json)
         assert query_large_suggested_refinements_model != False
 
         # Construct a model instance of QueryLargeSuggestedRefinements by calling from_dict on the json representation
-        query_large_suggested_refinements_model_dict = QueryLargeSuggestedRefinements.from_dict(query_large_suggested_refinements_model_json).__dict__
-        query_large_suggested_refinements_model2 = QueryLargeSuggestedRefinements(**query_large_suggested_refinements_model_dict)
+        query_large_suggested_refinements_model_dict = QueryLargeSuggestedRefinements.from_dict(
+            query_large_suggested_refinements_model_json).__dict__
+        query_large_suggested_refinements_model2 = QueryLargeSuggestedRefinements(
+            **query_large_suggested_refinements_model_dict)
 
         # Verify the model instances are equivalent
         assert query_large_suggested_refinements_model == query_large_suggested_refinements_model2
 
         # Convert model instance back to dict and verify no loss of data
-        query_large_suggested_refinements_model_json2 = query_large_suggested_refinements_model.to_dict()
+        query_large_suggested_refinements_model_json2 = query_large_suggested_refinements_model.to_dict(
+        )
         assert query_large_suggested_refinements_model_json2 == query_large_suggested_refinements_model_json
+
 
 class TestModel_QueryLargeTableResults():
     """
     Test Class for QueryLargeTableResults
     """
-
     def test_query_large_table_results_serialization(self):
         """
         Test serialization/deserialization for QueryLargeTableResults
@@ -7354,25 +7732,29 @@ class TestModel_QueryLargeTableResults():
         query_large_table_results_model_json['count'] = 38
 
         # Construct a model instance of QueryLargeTableResults by calling from_dict on the json representation
-        query_large_table_results_model = QueryLargeTableResults.from_dict(query_large_table_results_model_json)
+        query_large_table_results_model = QueryLargeTableResults.from_dict(
+            query_large_table_results_model_json)
         assert query_large_table_results_model != False
 
         # Construct a model instance of QueryLargeTableResults by calling from_dict on the json representation
-        query_large_table_results_model_dict = QueryLargeTableResults.from_dict(query_large_table_results_model_json).__dict__
-        query_large_table_results_model2 = QueryLargeTableResults(**query_large_table_results_model_dict)
+        query_large_table_results_model_dict = QueryLargeTableResults.from_dict(
+            query_large_table_results_model_json).__dict__
+        query_large_table_results_model2 = QueryLargeTableResults(
+            **query_large_table_results_model_dict)
 
         # Verify the model instances are equivalent
         assert query_large_table_results_model == query_large_table_results_model2
 
         # Convert model instance back to dict and verify no loss of data
-        query_large_table_results_model_json2 = query_large_table_results_model.to_dict()
+        query_large_table_results_model_json2 = query_large_table_results_model.to_dict(
+        )
         assert query_large_table_results_model_json2 == query_large_table_results_model_json
+
 
 class TestModel_QueryNoticesResponse():
     """
     Test Class for QueryNoticesResponse
     """
-
     def test_query_notices_response_serialization(self):
         """
         Test serialization/deserialization for QueryNoticesResponse
@@ -7380,7 +7762,7 @@ class TestModel_QueryNoticesResponse():
 
         # Construct dict forms of any model objects needed in order to build this model.
 
-        notice_model = {} # Notice
+        notice_model = {}  # Notice
         notice_model['notice_id'] = 'testString'
         notice_model['created'] = '2019-01-01T12:00:00Z'
         notice_model['document_id'] = 'testString'
@@ -7396,25 +7778,29 @@ class TestModel_QueryNoticesResponse():
         query_notices_response_model_json['notices'] = [notice_model]
 
         # Construct a model instance of QueryNoticesResponse by calling from_dict on the json representation
-        query_notices_response_model = QueryNoticesResponse.from_dict(query_notices_response_model_json)
+        query_notices_response_model = QueryNoticesResponse.from_dict(
+            query_notices_response_model_json)
         assert query_notices_response_model != False
 
         # Construct a model instance of QueryNoticesResponse by calling from_dict on the json representation
-        query_notices_response_model_dict = QueryNoticesResponse.from_dict(query_notices_response_model_json).__dict__
-        query_notices_response_model2 = QueryNoticesResponse(**query_notices_response_model_dict)
+        query_notices_response_model_dict = QueryNoticesResponse.from_dict(
+            query_notices_response_model_json).__dict__
+        query_notices_response_model2 = QueryNoticesResponse(
+            **query_notices_response_model_dict)
 
         # Verify the model instances are equivalent
         assert query_notices_response_model == query_notices_response_model2
 
         # Convert model instance back to dict and verify no loss of data
-        query_notices_response_model_json2 = query_notices_response_model.to_dict()
+        query_notices_response_model_json2 = query_notices_response_model.to_dict(
+        )
         assert query_notices_response_model_json2 == query_notices_response_model_json
+
 
 class TestModel_QueryResponse():
     """
     Test Class for QueryResponse
     """
-
     def test_query_response_serialization(self):
         """
         Test serialization/deserialization for QueryResponse
@@ -7422,18 +7808,18 @@ class TestModel_QueryResponse():
 
         # Construct dict forms of any model objects needed in order to build this model.
 
-        query_result_metadata_model = {} # QueryResultMetadata
+        query_result_metadata_model = {}  # QueryResultMetadata
         query_result_metadata_model['document_retrieval_source'] = 'search'
         query_result_metadata_model['collection_id'] = 'testString'
         query_result_metadata_model['confidence'] = 72.5
 
-        result_passage_answer_model = {} # ResultPassageAnswer
+        result_passage_answer_model = {}  # ResultPassageAnswer
         result_passage_answer_model['answer_text'] = 'testString'
         result_passage_answer_model['start_offset'] = 38
         result_passage_answer_model['end_offset'] = 38
         result_passage_answer_model['confidence'] = 0
 
-        query_result_passage_model = {} # QueryResultPassage
+        query_result_passage_model = {}  # QueryResultPassage
         query_result_passage_model['passage_text'] = 'testString'
         query_result_passage_model['start_offset'] = 38
         query_result_passage_model['end_offset'] = 38
@@ -7441,33 +7827,33 @@ class TestModel_QueryResponse():
         query_result_passage_model['confidence'] = 0
         query_result_passage_model['answers'] = [result_passage_answer_model]
 
-        query_result_model = {} # QueryResult
+        query_result_model = {}  # QueryResult
         query_result_model['document_id'] = 'testString'
         query_result_model['metadata'] = {'key1': 'testString'}
         query_result_model['result_metadata'] = query_result_metadata_model
         query_result_model['document_passages'] = [query_result_passage_model]
         query_result_model['id'] = {'foo': 'bar'}
 
-        query_aggregation_model = {} # QueryFilterAggregation
+        query_aggregation_model = {}  # QueryFilterAggregation
         query_aggregation_model['type'] = 'filter'
         query_aggregation_model['match'] = 'testString'
         query_aggregation_model['matching_results'] = 26
 
-        retrieval_details_model = {} # RetrievalDetails
+        retrieval_details_model = {}  # RetrievalDetails
         retrieval_details_model['document_retrieval_strategy'] = 'untrained'
 
-        query_suggested_refinement_model = {} # QuerySuggestedRefinement
+        query_suggested_refinement_model = {}  # QuerySuggestedRefinement
         query_suggested_refinement_model['text'] = 'testString'
 
-        table_element_location_model = {} # TableElementLocation
+        table_element_location_model = {}  # TableElementLocation
         table_element_location_model['begin'] = 26
         table_element_location_model['end'] = 26
 
-        table_text_location_model = {} # TableTextLocation
+        table_text_location_model = {}  # TableTextLocation
         table_text_location_model['text'] = 'testString'
         table_text_location_model['location'] = table_element_location_model
 
-        table_headers_model = {} # TableHeaders
+        table_headers_model = {}  # TableHeaders
         table_headers_model['cell_id'] = 'testString'
         table_headers_model['location'] = {'foo': 'bar'}
         table_headers_model['text'] = 'testString'
@@ -7476,7 +7862,7 @@ class TestModel_QueryResponse():
         table_headers_model['column_index_begin'] = 26
         table_headers_model['column_index_end'] = 26
 
-        table_row_headers_model = {} # TableRowHeaders
+        table_row_headers_model = {}  # TableRowHeaders
         table_row_headers_model['cell_id'] = 'testString'
         table_row_headers_model['location'] = table_element_location_model
         table_row_headers_model['text'] = 'testString'
@@ -7486,7 +7872,7 @@ class TestModel_QueryResponse():
         table_row_headers_model['column_index_begin'] = 26
         table_row_headers_model['column_index_end'] = 26
 
-        table_column_headers_model = {} # TableColumnHeaders
+        table_column_headers_model = {}  # TableColumnHeaders
         table_column_headers_model['cell_id'] = 'testString'
         table_column_headers_model['location'] = {'foo': 'bar'}
         table_column_headers_model['text'] = 'testString'
@@ -7496,44 +7882,48 @@ class TestModel_QueryResponse():
         table_column_headers_model['column_index_begin'] = 26
         table_column_headers_model['column_index_end'] = 26
 
-        table_cell_key_model = {} # TableCellKey
+        table_cell_key_model = {}  # TableCellKey
         table_cell_key_model['cell_id'] = 'testString'
         table_cell_key_model['location'] = table_element_location_model
         table_cell_key_model['text'] = 'testString'
 
-        table_cell_values_model = {} # TableCellValues
+        table_cell_values_model = {}  # TableCellValues
         table_cell_values_model['cell_id'] = 'testString'
         table_cell_values_model['location'] = table_element_location_model
         table_cell_values_model['text'] = 'testString'
 
-        table_key_value_pairs_model = {} # TableKeyValuePairs
+        table_key_value_pairs_model = {}  # TableKeyValuePairs
         table_key_value_pairs_model['key'] = table_cell_key_model
         table_key_value_pairs_model['value'] = [table_cell_values_model]
 
-        table_row_header_ids_model = {} # TableRowHeaderIds
+        table_row_header_ids_model = {}  # TableRowHeaderIds
         table_row_header_ids_model['id'] = 'testString'
 
-        table_row_header_texts_model = {} # TableRowHeaderTexts
+        table_row_header_texts_model = {}  # TableRowHeaderTexts
         table_row_header_texts_model['text'] = 'testString'
 
-        table_row_header_texts_normalized_model = {} # TableRowHeaderTextsNormalized
-        table_row_header_texts_normalized_model['text_normalized'] = 'testString'
+        table_row_header_texts_normalized_model = {
+        }  # TableRowHeaderTextsNormalized
+        table_row_header_texts_normalized_model[
+            'text_normalized'] = 'testString'
 
-        table_column_header_ids_model = {} # TableColumnHeaderIds
+        table_column_header_ids_model = {}  # TableColumnHeaderIds
         table_column_header_ids_model['id'] = 'testString'
 
-        table_column_header_texts_model = {} # TableColumnHeaderTexts
+        table_column_header_texts_model = {}  # TableColumnHeaderTexts
         table_column_header_texts_model['text'] = 'testString'
 
-        table_column_header_texts_normalized_model = {} # TableColumnHeaderTextsNormalized
-        table_column_header_texts_normalized_model['text_normalized'] = 'testString'
+        table_column_header_texts_normalized_model = {
+        }  # TableColumnHeaderTextsNormalized
+        table_column_header_texts_normalized_model[
+            'text_normalized'] = 'testString'
 
-        document_attribute_model = {} # DocumentAttribute
+        document_attribute_model = {}  # DocumentAttribute
         document_attribute_model['type'] = 'testString'
         document_attribute_model['text'] = 'testString'
         document_attribute_model['location'] = table_element_location_model
 
-        table_body_cells_model = {} # TableBodyCells
+        table_body_cells_model = {}  # TableBodyCells
         table_body_cells_model['cell_id'] = 'testString'
         table_body_cells_model['location'] = table_element_location_model
         table_body_cells_model['text'] = 'testString'
@@ -7542,26 +7932,40 @@ class TestModel_QueryResponse():
         table_body_cells_model['column_index_begin'] = 26
         table_body_cells_model['column_index_end'] = 26
         table_body_cells_model['row_header_ids'] = [table_row_header_ids_model]
-        table_body_cells_model['row_header_texts'] = [table_row_header_texts_model]
-        table_body_cells_model['row_header_texts_normalized'] = [table_row_header_texts_normalized_model]
-        table_body_cells_model['column_header_ids'] = [table_column_header_ids_model]
-        table_body_cells_model['column_header_texts'] = [table_column_header_texts_model]
-        table_body_cells_model['column_header_texts_normalized'] = [table_column_header_texts_normalized_model]
+        table_body_cells_model['row_header_texts'] = [
+            table_row_header_texts_model
+        ]
+        table_body_cells_model['row_header_texts_normalized'] = [
+            table_row_header_texts_normalized_model
+        ]
+        table_body_cells_model['column_header_ids'] = [
+            table_column_header_ids_model
+        ]
+        table_body_cells_model['column_header_texts'] = [
+            table_column_header_texts_model
+        ]
+        table_body_cells_model['column_header_texts_normalized'] = [
+            table_column_header_texts_normalized_model
+        ]
         table_body_cells_model['attributes'] = [document_attribute_model]
 
-        table_result_table_model = {} # TableResultTable
+        table_result_table_model = {}  # TableResultTable
         table_result_table_model['location'] = table_element_location_model
         table_result_table_model['text'] = 'testString'
         table_result_table_model['section_title'] = table_text_location_model
         table_result_table_model['title'] = table_text_location_model
         table_result_table_model['table_headers'] = [table_headers_model]
         table_result_table_model['row_headers'] = [table_row_headers_model]
-        table_result_table_model['column_headers'] = [table_column_headers_model]
-        table_result_table_model['key_value_pairs'] = [table_key_value_pairs_model]
+        table_result_table_model['column_headers'] = [
+            table_column_headers_model
+        ]
+        table_result_table_model['key_value_pairs'] = [
+            table_key_value_pairs_model
+        ]
         table_result_table_model['body_cells'] = [table_body_cells_model]
         table_result_table_model['contexts'] = [table_text_location_model]
 
-        query_table_result_model = {} # QueryTableResult
+        query_table_result_model = {}  # QueryTableResult
         query_table_result_model['table_id'] = 'testString'
         query_table_result_model['source_document_id'] = 'testString'
         query_table_result_model['collection_id'] = 'testString'
@@ -7569,7 +7973,7 @@ class TestModel_QueryResponse():
         query_table_result_model['table_html_offset'] = 38
         query_table_result_model['table'] = table_result_table_model
 
-        query_response_passage_model = {} # QueryResponsePassage
+        query_response_passage_model = {}  # QueryResponsePassage
         query_response_passage_model['passage_text'] = 'testString'
         query_response_passage_model['passage_score'] = 72.5
         query_response_passage_model['document_id'] = 'testString'
@@ -7585,18 +7989,23 @@ class TestModel_QueryResponse():
         query_response_model_json['matching_results'] = 38
         query_response_model_json['results'] = [query_result_model]
         query_response_model_json['aggregations'] = [query_aggregation_model]
-        query_response_model_json['retrieval_details'] = retrieval_details_model
+        query_response_model_json[
+            'retrieval_details'] = retrieval_details_model
         query_response_model_json['suggested_query'] = 'testString'
-        query_response_model_json['suggested_refinements'] = [query_suggested_refinement_model]
+        query_response_model_json['suggested_refinements'] = [
+            query_suggested_refinement_model
+        ]
         query_response_model_json['table_results'] = [query_table_result_model]
         query_response_model_json['passages'] = [query_response_passage_model]
 
         # Construct a model instance of QueryResponse by calling from_dict on the json representation
-        query_response_model = QueryResponse.from_dict(query_response_model_json)
+        query_response_model = QueryResponse.from_dict(
+            query_response_model_json)
         assert query_response_model != False
 
         # Construct a model instance of QueryResponse by calling from_dict on the json representation
-        query_response_model_dict = QueryResponse.from_dict(query_response_model_json).__dict__
+        query_response_model_dict = QueryResponse.from_dict(
+            query_response_model_json).__dict__
         query_response_model2 = QueryResponse(**query_response_model_dict)
 
         # Verify the model instances are equivalent
@@ -7606,11 +8015,11 @@ class TestModel_QueryResponse():
         query_response_model_json2 = query_response_model.to_dict()
         assert query_response_model_json2 == query_response_model_json
 
+
 class TestModel_QueryResponsePassage():
     """
     Test Class for QueryResponsePassage
     """
-
     def test_query_response_passage_serialization(self):
         """
         Test serialization/deserialization for QueryResponsePassage
@@ -7618,7 +8027,7 @@ class TestModel_QueryResponsePassage():
 
         # Construct dict forms of any model objects needed in order to build this model.
 
-        result_passage_answer_model = {} # ResultPassageAnswer
+        result_passage_answer_model = {}  # ResultPassageAnswer
         result_passage_answer_model['answer_text'] = 'testString'
         result_passage_answer_model['start_offset'] = 38
         result_passage_answer_model['end_offset'] = 38
@@ -7634,28 +8043,34 @@ class TestModel_QueryResponsePassage():
         query_response_passage_model_json['end_offset'] = 38
         query_response_passage_model_json['field'] = 'testString'
         query_response_passage_model_json['confidence'] = 0
-        query_response_passage_model_json['answers'] = [result_passage_answer_model]
+        query_response_passage_model_json['answers'] = [
+            result_passage_answer_model
+        ]
 
         # Construct a model instance of QueryResponsePassage by calling from_dict on the json representation
-        query_response_passage_model = QueryResponsePassage.from_dict(query_response_passage_model_json)
+        query_response_passage_model = QueryResponsePassage.from_dict(
+            query_response_passage_model_json)
         assert query_response_passage_model != False
 
         # Construct a model instance of QueryResponsePassage by calling from_dict on the json representation
-        query_response_passage_model_dict = QueryResponsePassage.from_dict(query_response_passage_model_json).__dict__
-        query_response_passage_model2 = QueryResponsePassage(**query_response_passage_model_dict)
+        query_response_passage_model_dict = QueryResponsePassage.from_dict(
+            query_response_passage_model_json).__dict__
+        query_response_passage_model2 = QueryResponsePassage(
+            **query_response_passage_model_dict)
 
         # Verify the model instances are equivalent
         assert query_response_passage_model == query_response_passage_model2
 
         # Convert model instance back to dict and verify no loss of data
-        query_response_passage_model_json2 = query_response_passage_model.to_dict()
+        query_response_passage_model_json2 = query_response_passage_model.to_dict(
+        )
         assert query_response_passage_model_json2 == query_response_passage_model_json
+
 
 class TestModel_QueryResult():
     """
     Test Class for QueryResult
     """
-
     def test_query_result_serialization(self):
         """
         Test serialization/deserialization for QueryResult
@@ -7663,18 +8078,18 @@ class TestModel_QueryResult():
 
         # Construct dict forms of any model objects needed in order to build this model.
 
-        query_result_metadata_model = {} # QueryResultMetadata
+        query_result_metadata_model = {}  # QueryResultMetadata
         query_result_metadata_model['document_retrieval_source'] = 'search'
         query_result_metadata_model['collection_id'] = 'testString'
         query_result_metadata_model['confidence'] = 72.5
 
-        result_passage_answer_model = {} # ResultPassageAnswer
+        result_passage_answer_model = {}  # ResultPassageAnswer
         result_passage_answer_model['answer_text'] = 'testString'
         result_passage_answer_model['start_offset'] = 38
         result_passage_answer_model['end_offset'] = 38
         result_passage_answer_model['confidence'] = 0
 
-        query_result_passage_model = {} # QueryResultPassage
+        query_result_passage_model = {}  # QueryResultPassage
         query_result_passage_model['passage_text'] = 'testString'
         query_result_passage_model['start_offset'] = 38
         query_result_passage_model['end_offset'] = 38
@@ -7686,8 +8101,11 @@ class TestModel_QueryResult():
         query_result_model_json = {}
         query_result_model_json['document_id'] = 'testString'
         query_result_model_json['metadata'] = {'key1': 'testString'}
-        query_result_model_json['result_metadata'] = query_result_metadata_model
-        query_result_model_json['document_passages'] = [query_result_passage_model]
+        query_result_model_json[
+            'result_metadata'] = query_result_metadata_model
+        query_result_model_json['document_passages'] = [
+            query_result_passage_model
+        ]
         query_result_model_json['foo'] = {'foo': 'bar'}
 
         # Construct a model instance of QueryResult by calling from_dict on the json representation
@@ -7695,7 +8113,8 @@ class TestModel_QueryResult():
         assert query_result_model != False
 
         # Construct a model instance of QueryResult by calling from_dict on the json representation
-        query_result_model_dict = QueryResult.from_dict(query_result_model_json).__dict__
+        query_result_model_dict = QueryResult.from_dict(
+            query_result_model_json).__dict__
         query_result_model2 = QueryResult(**query_result_model_dict)
 
         # Verify the model instances are equivalent
@@ -7715,11 +8134,11 @@ class TestModel_QueryResult():
         actual_dict = query_result_model.get_properties()
         assert actual_dict == expected_dict
 
+
 class TestModel_QueryResultMetadata():
     """
     Test Class for QueryResultMetadata
     """
-
     def test_query_result_metadata_serialization(self):
         """
         Test serialization/deserialization for QueryResultMetadata
@@ -7727,30 +8146,35 @@ class TestModel_QueryResultMetadata():
 
         # Construct a json representation of a QueryResultMetadata model
         query_result_metadata_model_json = {}
-        query_result_metadata_model_json['document_retrieval_source'] = 'search'
+        query_result_metadata_model_json[
+            'document_retrieval_source'] = 'search'
         query_result_metadata_model_json['collection_id'] = 'testString'
         query_result_metadata_model_json['confidence'] = 72.5
 
         # Construct a model instance of QueryResultMetadata by calling from_dict on the json representation
-        query_result_metadata_model = QueryResultMetadata.from_dict(query_result_metadata_model_json)
+        query_result_metadata_model = QueryResultMetadata.from_dict(
+            query_result_metadata_model_json)
         assert query_result_metadata_model != False
 
         # Construct a model instance of QueryResultMetadata by calling from_dict on the json representation
-        query_result_metadata_model_dict = QueryResultMetadata.from_dict(query_result_metadata_model_json).__dict__
-        query_result_metadata_model2 = QueryResultMetadata(**query_result_metadata_model_dict)
+        query_result_metadata_model_dict = QueryResultMetadata.from_dict(
+            query_result_metadata_model_json).__dict__
+        query_result_metadata_model2 = QueryResultMetadata(
+            **query_result_metadata_model_dict)
 
         # Verify the model instances are equivalent
         assert query_result_metadata_model == query_result_metadata_model2
 
         # Convert model instance back to dict and verify no loss of data
-        query_result_metadata_model_json2 = query_result_metadata_model.to_dict()
+        query_result_metadata_model_json2 = query_result_metadata_model.to_dict(
+        )
         assert query_result_metadata_model_json2 == query_result_metadata_model_json
+
 
 class TestModel_QueryResultPassage():
     """
     Test Class for QueryResultPassage
     """
-
     def test_query_result_passage_serialization(self):
         """
         Test serialization/deserialization for QueryResultPassage
@@ -7758,7 +8182,7 @@ class TestModel_QueryResultPassage():
 
         # Construct dict forms of any model objects needed in order to build this model.
 
-        result_passage_answer_model = {} # ResultPassageAnswer
+        result_passage_answer_model = {}  # ResultPassageAnswer
         result_passage_answer_model['answer_text'] = 'testString'
         result_passage_answer_model['start_offset'] = 38
         result_passage_answer_model['end_offset'] = 38
@@ -7771,15 +8195,20 @@ class TestModel_QueryResultPassage():
         query_result_passage_model_json['end_offset'] = 38
         query_result_passage_model_json['field'] = 'testString'
         query_result_passage_model_json['confidence'] = 0
-        query_result_passage_model_json['answers'] = [result_passage_answer_model]
+        query_result_passage_model_json['answers'] = [
+            result_passage_answer_model
+        ]
 
         # Construct a model instance of QueryResultPassage by calling from_dict on the json representation
-        query_result_passage_model = QueryResultPassage.from_dict(query_result_passage_model_json)
+        query_result_passage_model = QueryResultPassage.from_dict(
+            query_result_passage_model_json)
         assert query_result_passage_model != False
 
         # Construct a model instance of QueryResultPassage by calling from_dict on the json representation
-        query_result_passage_model_dict = QueryResultPassage.from_dict(query_result_passage_model_json).__dict__
-        query_result_passage_model2 = QueryResultPassage(**query_result_passage_model_dict)
+        query_result_passage_model_dict = QueryResultPassage.from_dict(
+            query_result_passage_model_json).__dict__
+        query_result_passage_model2 = QueryResultPassage(
+            **query_result_passage_model_dict)
 
         # Verify the model instances are equivalent
         assert query_result_passage_model == query_result_passage_model2
@@ -7788,11 +8217,11 @@ class TestModel_QueryResultPassage():
         query_result_passage_model_json2 = query_result_passage_model.to_dict()
         assert query_result_passage_model_json2 == query_result_passage_model_json
 
+
 class TestModel_QuerySuggestedRefinement():
     """
     Test Class for QuerySuggestedRefinement
     """
-
     def test_query_suggested_refinement_serialization(self):
         """
         Test serialization/deserialization for QuerySuggestedRefinement
@@ -7803,25 +8232,29 @@ class TestModel_QuerySuggestedRefinement():
         query_suggested_refinement_model_json['text'] = 'testString'
 
         # Construct a model instance of QuerySuggestedRefinement by calling from_dict on the json representation
-        query_suggested_refinement_model = QuerySuggestedRefinement.from_dict(query_suggested_refinement_model_json)
+        query_suggested_refinement_model = QuerySuggestedRefinement.from_dict(
+            query_suggested_refinement_model_json)
         assert query_suggested_refinement_model != False
 
         # Construct a model instance of QuerySuggestedRefinement by calling from_dict on the json representation
-        query_suggested_refinement_model_dict = QuerySuggestedRefinement.from_dict(query_suggested_refinement_model_json).__dict__
-        query_suggested_refinement_model2 = QuerySuggestedRefinement(**query_suggested_refinement_model_dict)
+        query_suggested_refinement_model_dict = QuerySuggestedRefinement.from_dict(
+            query_suggested_refinement_model_json).__dict__
+        query_suggested_refinement_model2 = QuerySuggestedRefinement(
+            **query_suggested_refinement_model_dict)
 
         # Verify the model instances are equivalent
         assert query_suggested_refinement_model == query_suggested_refinement_model2
 
         # Convert model instance back to dict and verify no loss of data
-        query_suggested_refinement_model_json2 = query_suggested_refinement_model.to_dict()
+        query_suggested_refinement_model_json2 = query_suggested_refinement_model.to_dict(
+        )
         assert query_suggested_refinement_model_json2 == query_suggested_refinement_model_json
+
 
 class TestModel_QueryTableResult():
     """
     Test Class for QueryTableResult
     """
-
     def test_query_table_result_serialization(self):
         """
         Test serialization/deserialization for QueryTableResult
@@ -7829,15 +8262,15 @@ class TestModel_QueryTableResult():
 
         # Construct dict forms of any model objects needed in order to build this model.
 
-        table_element_location_model = {} # TableElementLocation
+        table_element_location_model = {}  # TableElementLocation
         table_element_location_model['begin'] = 26
         table_element_location_model['end'] = 26
 
-        table_text_location_model = {} # TableTextLocation
+        table_text_location_model = {}  # TableTextLocation
         table_text_location_model['text'] = 'testString'
         table_text_location_model['location'] = table_element_location_model
 
-        table_headers_model = {} # TableHeaders
+        table_headers_model = {}  # TableHeaders
         table_headers_model['cell_id'] = 'testString'
         table_headers_model['location'] = {'foo': 'bar'}
         table_headers_model['text'] = 'testString'
@@ -7846,7 +8279,7 @@ class TestModel_QueryTableResult():
         table_headers_model['column_index_begin'] = 26
         table_headers_model['column_index_end'] = 26
 
-        table_row_headers_model = {} # TableRowHeaders
+        table_row_headers_model = {}  # TableRowHeaders
         table_row_headers_model['cell_id'] = 'testString'
         table_row_headers_model['location'] = table_element_location_model
         table_row_headers_model['text'] = 'testString'
@@ -7856,7 +8289,7 @@ class TestModel_QueryTableResult():
         table_row_headers_model['column_index_begin'] = 26
         table_row_headers_model['column_index_end'] = 26
 
-        table_column_headers_model = {} # TableColumnHeaders
+        table_column_headers_model = {}  # TableColumnHeaders
         table_column_headers_model['cell_id'] = 'testString'
         table_column_headers_model['location'] = {'foo': 'bar'}
         table_column_headers_model['text'] = 'testString'
@@ -7866,44 +8299,48 @@ class TestModel_QueryTableResult():
         table_column_headers_model['column_index_begin'] = 26
         table_column_headers_model['column_index_end'] = 26
 
-        table_cell_key_model = {} # TableCellKey
+        table_cell_key_model = {}  # TableCellKey
         table_cell_key_model['cell_id'] = 'testString'
         table_cell_key_model['location'] = table_element_location_model
         table_cell_key_model['text'] = 'testString'
 
-        table_cell_values_model = {} # TableCellValues
+        table_cell_values_model = {}  # TableCellValues
         table_cell_values_model['cell_id'] = 'testString'
         table_cell_values_model['location'] = table_element_location_model
         table_cell_values_model['text'] = 'testString'
 
-        table_key_value_pairs_model = {} # TableKeyValuePairs
+        table_key_value_pairs_model = {}  # TableKeyValuePairs
         table_key_value_pairs_model['key'] = table_cell_key_model
         table_key_value_pairs_model['value'] = [table_cell_values_model]
 
-        table_row_header_ids_model = {} # TableRowHeaderIds
+        table_row_header_ids_model = {}  # TableRowHeaderIds
         table_row_header_ids_model['id'] = 'testString'
 
-        table_row_header_texts_model = {} # TableRowHeaderTexts
+        table_row_header_texts_model = {}  # TableRowHeaderTexts
         table_row_header_texts_model['text'] = 'testString'
 
-        table_row_header_texts_normalized_model = {} # TableRowHeaderTextsNormalized
-        table_row_header_texts_normalized_model['text_normalized'] = 'testString'
+        table_row_header_texts_normalized_model = {
+        }  # TableRowHeaderTextsNormalized
+        table_row_header_texts_normalized_model[
+            'text_normalized'] = 'testString'
 
-        table_column_header_ids_model = {} # TableColumnHeaderIds
+        table_column_header_ids_model = {}  # TableColumnHeaderIds
         table_column_header_ids_model['id'] = 'testString'
 
-        table_column_header_texts_model = {} # TableColumnHeaderTexts
+        table_column_header_texts_model = {}  # TableColumnHeaderTexts
         table_column_header_texts_model['text'] = 'testString'
 
-        table_column_header_texts_normalized_model = {} # TableColumnHeaderTextsNormalized
-        table_column_header_texts_normalized_model['text_normalized'] = 'testString'
+        table_column_header_texts_normalized_model = {
+        }  # TableColumnHeaderTextsNormalized
+        table_column_header_texts_normalized_model[
+            'text_normalized'] = 'testString'
 
-        document_attribute_model = {} # DocumentAttribute
+        document_attribute_model = {}  # DocumentAttribute
         document_attribute_model['type'] = 'testString'
         document_attribute_model['text'] = 'testString'
         document_attribute_model['location'] = table_element_location_model
 
-        table_body_cells_model = {} # TableBodyCells
+        table_body_cells_model = {}  # TableBodyCells
         table_body_cells_model['cell_id'] = 'testString'
         table_body_cells_model['location'] = table_element_location_model
         table_body_cells_model['text'] = 'testString'
@@ -7912,22 +8349,36 @@ class TestModel_QueryTableResult():
         table_body_cells_model['column_index_begin'] = 26
         table_body_cells_model['column_index_end'] = 26
         table_body_cells_model['row_header_ids'] = [table_row_header_ids_model]
-        table_body_cells_model['row_header_texts'] = [table_row_header_texts_model]
-        table_body_cells_model['row_header_texts_normalized'] = [table_row_header_texts_normalized_model]
-        table_body_cells_model['column_header_ids'] = [table_column_header_ids_model]
-        table_body_cells_model['column_header_texts'] = [table_column_header_texts_model]
-        table_body_cells_model['column_header_texts_normalized'] = [table_column_header_texts_normalized_model]
+        table_body_cells_model['row_header_texts'] = [
+            table_row_header_texts_model
+        ]
+        table_body_cells_model['row_header_texts_normalized'] = [
+            table_row_header_texts_normalized_model
+        ]
+        table_body_cells_model['column_header_ids'] = [
+            table_column_header_ids_model
+        ]
+        table_body_cells_model['column_header_texts'] = [
+            table_column_header_texts_model
+        ]
+        table_body_cells_model['column_header_texts_normalized'] = [
+            table_column_header_texts_normalized_model
+        ]
         table_body_cells_model['attributes'] = [document_attribute_model]
 
-        table_result_table_model = {} # TableResultTable
+        table_result_table_model = {}  # TableResultTable
         table_result_table_model['location'] = table_element_location_model
         table_result_table_model['text'] = 'testString'
         table_result_table_model['section_title'] = table_text_location_model
         table_result_table_model['title'] = table_text_location_model
         table_result_table_model['table_headers'] = [table_headers_model]
         table_result_table_model['row_headers'] = [table_row_headers_model]
-        table_result_table_model['column_headers'] = [table_column_headers_model]
-        table_result_table_model['key_value_pairs'] = [table_key_value_pairs_model]
+        table_result_table_model['column_headers'] = [
+            table_column_headers_model
+        ]
+        table_result_table_model['key_value_pairs'] = [
+            table_key_value_pairs_model
+        ]
         table_result_table_model['body_cells'] = [table_body_cells_model]
         table_result_table_model['contexts'] = [table_text_location_model]
 
@@ -7941,12 +8392,15 @@ class TestModel_QueryTableResult():
         query_table_result_model_json['table'] = table_result_table_model
 
         # Construct a model instance of QueryTableResult by calling from_dict on the json representation
-        query_table_result_model = QueryTableResult.from_dict(query_table_result_model_json)
+        query_table_result_model = QueryTableResult.from_dict(
+            query_table_result_model_json)
         assert query_table_result_model != False
 
         # Construct a model instance of QueryTableResult by calling from_dict on the json representation
-        query_table_result_model_dict = QueryTableResult.from_dict(query_table_result_model_json).__dict__
-        query_table_result_model2 = QueryTableResult(**query_table_result_model_dict)
+        query_table_result_model_dict = QueryTableResult.from_dict(
+            query_table_result_model_json).__dict__
+        query_table_result_model2 = QueryTableResult(
+            **query_table_result_model_dict)
 
         # Verify the model instances are equivalent
         assert query_table_result_model == query_table_result_model2
@@ -7955,11 +8409,11 @@ class TestModel_QueryTableResult():
         query_table_result_model_json2 = query_table_result_model.to_dict()
         assert query_table_result_model_json2 == query_table_result_model_json
 
+
 class TestModel_QueryTermAggregationResult():
     """
     Test Class for QueryTermAggregationResult
     """
-
     def test_query_term_aggregation_result_serialization(self):
         """
         Test serialization/deserialization for QueryTermAggregationResult
@@ -7967,7 +8421,7 @@ class TestModel_QueryTermAggregationResult():
 
         # Construct dict forms of any model objects needed in order to build this model.
 
-        query_aggregation_model = {} # QueryFilterAggregation
+        query_aggregation_model = {}  # QueryFilterAggregation
         query_aggregation_model['type'] = 'filter'
         query_aggregation_model['match'] = 'testString'
         query_aggregation_model['matching_results'] = 26
@@ -7977,30 +8431,38 @@ class TestModel_QueryTermAggregationResult():
         query_term_aggregation_result_model_json['key'] = 'testString'
         query_term_aggregation_result_model_json['matching_results'] = 38
         query_term_aggregation_result_model_json['relevancy'] = 72.5
-        query_term_aggregation_result_model_json['total_matching_documents'] = 38
-        query_term_aggregation_result_model_json['estimated_matching_documents'] = 38
-        query_term_aggregation_result_model_json['aggregations'] = [query_aggregation_model]
+        query_term_aggregation_result_model_json[
+            'total_matching_documents'] = 38
+        query_term_aggregation_result_model_json[
+            'estimated_matching_documents'] = 38
+        query_term_aggregation_result_model_json['aggregations'] = [
+            query_aggregation_model
+        ]
 
         # Construct a model instance of QueryTermAggregationResult by calling from_dict on the json representation
-        query_term_aggregation_result_model = QueryTermAggregationResult.from_dict(query_term_aggregation_result_model_json)
+        query_term_aggregation_result_model = QueryTermAggregationResult.from_dict(
+            query_term_aggregation_result_model_json)
         assert query_term_aggregation_result_model != False
 
         # Construct a model instance of QueryTermAggregationResult by calling from_dict on the json representation
-        query_term_aggregation_result_model_dict = QueryTermAggregationResult.from_dict(query_term_aggregation_result_model_json).__dict__
-        query_term_aggregation_result_model2 = QueryTermAggregationResult(**query_term_aggregation_result_model_dict)
+        query_term_aggregation_result_model_dict = QueryTermAggregationResult.from_dict(
+            query_term_aggregation_result_model_json).__dict__
+        query_term_aggregation_result_model2 = QueryTermAggregationResult(
+            **query_term_aggregation_result_model_dict)
 
         # Verify the model instances are equivalent
         assert query_term_aggregation_result_model == query_term_aggregation_result_model2
 
         # Convert model instance back to dict and verify no loss of data
-        query_term_aggregation_result_model_json2 = query_term_aggregation_result_model.to_dict()
+        query_term_aggregation_result_model_json2 = query_term_aggregation_result_model.to_dict(
+        )
         assert query_term_aggregation_result_model_json2 == query_term_aggregation_result_model_json
+
 
 class TestModel_QueryTimesliceAggregationResult():
     """
     Test Class for QueryTimesliceAggregationResult
     """
-
     def test_query_timeslice_aggregation_result_serialization(self):
         """
         Test serialization/deserialization for QueryTimesliceAggregationResult
@@ -8008,38 +8470,45 @@ class TestModel_QueryTimesliceAggregationResult():
 
         # Construct dict forms of any model objects needed in order to build this model.
 
-        query_aggregation_model = {} # QueryFilterAggregation
+        query_aggregation_model = {}  # QueryFilterAggregation
         query_aggregation_model['type'] = 'filter'
         query_aggregation_model['match'] = 'testString'
         query_aggregation_model['matching_results'] = 26
 
         # Construct a json representation of a QueryTimesliceAggregationResult model
         query_timeslice_aggregation_result_model_json = {}
-        query_timeslice_aggregation_result_model_json['key_as_string'] = 'testString'
+        query_timeslice_aggregation_result_model_json[
+            'key_as_string'] = 'testString'
         query_timeslice_aggregation_result_model_json['key'] = 26
         query_timeslice_aggregation_result_model_json['matching_results'] = 26
-        query_timeslice_aggregation_result_model_json['aggregations'] = [query_aggregation_model]
+        query_timeslice_aggregation_result_model_json['aggregations'] = [
+            query_aggregation_model
+        ]
 
         # Construct a model instance of QueryTimesliceAggregationResult by calling from_dict on the json representation
-        query_timeslice_aggregation_result_model = QueryTimesliceAggregationResult.from_dict(query_timeslice_aggregation_result_model_json)
+        query_timeslice_aggregation_result_model = QueryTimesliceAggregationResult.from_dict(
+            query_timeslice_aggregation_result_model_json)
         assert query_timeslice_aggregation_result_model != False
 
         # Construct a model instance of QueryTimesliceAggregationResult by calling from_dict on the json representation
-        query_timeslice_aggregation_result_model_dict = QueryTimesliceAggregationResult.from_dict(query_timeslice_aggregation_result_model_json).__dict__
-        query_timeslice_aggregation_result_model2 = QueryTimesliceAggregationResult(**query_timeslice_aggregation_result_model_dict)
+        query_timeslice_aggregation_result_model_dict = QueryTimesliceAggregationResult.from_dict(
+            query_timeslice_aggregation_result_model_json).__dict__
+        query_timeslice_aggregation_result_model2 = QueryTimesliceAggregationResult(
+            **query_timeslice_aggregation_result_model_dict)
 
         # Verify the model instances are equivalent
         assert query_timeslice_aggregation_result_model == query_timeslice_aggregation_result_model2
 
         # Convert model instance back to dict and verify no loss of data
-        query_timeslice_aggregation_result_model_json2 = query_timeslice_aggregation_result_model.to_dict()
+        query_timeslice_aggregation_result_model_json2 = query_timeslice_aggregation_result_model.to_dict(
+        )
         assert query_timeslice_aggregation_result_model_json2 == query_timeslice_aggregation_result_model_json
+
 
 class TestModel_QueryTopHitsAggregationResult():
     """
     Test Class for QueryTopHitsAggregationResult
     """
-
     def test_query_top_hits_aggregation_result_serialization(self):
         """
         Test serialization/deserialization for QueryTopHitsAggregationResult
@@ -8048,28 +8517,35 @@ class TestModel_QueryTopHitsAggregationResult():
         # Construct a json representation of a QueryTopHitsAggregationResult model
         query_top_hits_aggregation_result_model_json = {}
         query_top_hits_aggregation_result_model_json['matching_results'] = 38
-        query_top_hits_aggregation_result_model_json['hits'] = [{'key1': 'testString'}]
+        query_top_hits_aggregation_result_model_json['hits'] = [{
+            'key1':
+            'testString'
+        }]
 
         # Construct a model instance of QueryTopHitsAggregationResult by calling from_dict on the json representation
-        query_top_hits_aggregation_result_model = QueryTopHitsAggregationResult.from_dict(query_top_hits_aggregation_result_model_json)
+        query_top_hits_aggregation_result_model = QueryTopHitsAggregationResult.from_dict(
+            query_top_hits_aggregation_result_model_json)
         assert query_top_hits_aggregation_result_model != False
 
         # Construct a model instance of QueryTopHitsAggregationResult by calling from_dict on the json representation
-        query_top_hits_aggregation_result_model_dict = QueryTopHitsAggregationResult.from_dict(query_top_hits_aggregation_result_model_json).__dict__
-        query_top_hits_aggregation_result_model2 = QueryTopHitsAggregationResult(**query_top_hits_aggregation_result_model_dict)
+        query_top_hits_aggregation_result_model_dict = QueryTopHitsAggregationResult.from_dict(
+            query_top_hits_aggregation_result_model_json).__dict__
+        query_top_hits_aggregation_result_model2 = QueryTopHitsAggregationResult(
+            **query_top_hits_aggregation_result_model_dict)
 
         # Verify the model instances are equivalent
         assert query_top_hits_aggregation_result_model == query_top_hits_aggregation_result_model2
 
         # Convert model instance back to dict and verify no loss of data
-        query_top_hits_aggregation_result_model_json2 = query_top_hits_aggregation_result_model.to_dict()
+        query_top_hits_aggregation_result_model_json2 = query_top_hits_aggregation_result_model.to_dict(
+        )
         assert query_top_hits_aggregation_result_model_json2 == query_top_hits_aggregation_result_model_json
+
 
 class TestModel_ResultPassageAnswer():
     """
     Test Class for ResultPassageAnswer
     """
-
     def test_result_passage_answer_serialization(self):
         """
         Test serialization/deserialization for ResultPassageAnswer
@@ -8083,25 +8559,29 @@ class TestModel_ResultPassageAnswer():
         result_passage_answer_model_json['confidence'] = 0
 
         # Construct a model instance of ResultPassageAnswer by calling from_dict on the json representation
-        result_passage_answer_model = ResultPassageAnswer.from_dict(result_passage_answer_model_json)
+        result_passage_answer_model = ResultPassageAnswer.from_dict(
+            result_passage_answer_model_json)
         assert result_passage_answer_model != False
 
         # Construct a model instance of ResultPassageAnswer by calling from_dict on the json representation
-        result_passage_answer_model_dict = ResultPassageAnswer.from_dict(result_passage_answer_model_json).__dict__
-        result_passage_answer_model2 = ResultPassageAnswer(**result_passage_answer_model_dict)
+        result_passage_answer_model_dict = ResultPassageAnswer.from_dict(
+            result_passage_answer_model_json).__dict__
+        result_passage_answer_model2 = ResultPassageAnswer(
+            **result_passage_answer_model_dict)
 
         # Verify the model instances are equivalent
         assert result_passage_answer_model == result_passage_answer_model2
 
         # Convert model instance back to dict and verify no loss of data
-        result_passage_answer_model_json2 = result_passage_answer_model.to_dict()
+        result_passage_answer_model_json2 = result_passage_answer_model.to_dict(
+        )
         assert result_passage_answer_model_json2 == result_passage_answer_model_json
+
 
 class TestModel_RetrievalDetails():
     """
     Test Class for RetrievalDetails
     """
-
     def test_retrieval_details_serialization(self):
         """
         Test serialization/deserialization for RetrievalDetails
@@ -8109,15 +8589,19 @@ class TestModel_RetrievalDetails():
 
         # Construct a json representation of a RetrievalDetails model
         retrieval_details_model_json = {}
-        retrieval_details_model_json['document_retrieval_strategy'] = 'untrained'
+        retrieval_details_model_json[
+            'document_retrieval_strategy'] = 'untrained'
 
         # Construct a model instance of RetrievalDetails by calling from_dict on the json representation
-        retrieval_details_model = RetrievalDetails.from_dict(retrieval_details_model_json)
+        retrieval_details_model = RetrievalDetails.from_dict(
+            retrieval_details_model_json)
         assert retrieval_details_model != False
 
         # Construct a model instance of RetrievalDetails by calling from_dict on the json representation
-        retrieval_details_model_dict = RetrievalDetails.from_dict(retrieval_details_model_json).__dict__
-        retrieval_details_model2 = RetrievalDetails(**retrieval_details_model_dict)
+        retrieval_details_model_dict = RetrievalDetails.from_dict(
+            retrieval_details_model_json).__dict__
+        retrieval_details_model2 = RetrievalDetails(
+            **retrieval_details_model_dict)
 
         # Verify the model instances are equivalent
         assert retrieval_details_model == retrieval_details_model2
@@ -8126,11 +8610,11 @@ class TestModel_RetrievalDetails():
         retrieval_details_model_json2 = retrieval_details_model.to_dict()
         assert retrieval_details_model_json2 == retrieval_details_model_json
 
+
 class TestModel_StopWordList():
     """
     Test Class for StopWordList
     """
-
     def test_stop_word_list_serialization(self):
         """
         Test serialization/deserialization for StopWordList
@@ -8141,11 +8625,13 @@ class TestModel_StopWordList():
         stop_word_list_model_json['stopwords'] = ['testString']
 
         # Construct a model instance of StopWordList by calling from_dict on the json representation
-        stop_word_list_model = StopWordList.from_dict(stop_word_list_model_json)
+        stop_word_list_model = StopWordList.from_dict(
+            stop_word_list_model_json)
         assert stop_word_list_model != False
 
         # Construct a model instance of StopWordList by calling from_dict on the json representation
-        stop_word_list_model_dict = StopWordList.from_dict(stop_word_list_model_json).__dict__
+        stop_word_list_model_dict = StopWordList.from_dict(
+            stop_word_list_model_json).__dict__
         stop_word_list_model2 = StopWordList(**stop_word_list_model_dict)
 
         # Verify the model instances are equivalent
@@ -8155,11 +8641,11 @@ class TestModel_StopWordList():
         stop_word_list_model_json2 = stop_word_list_model.to_dict()
         assert stop_word_list_model_json2 == stop_word_list_model_json
 
+
 class TestModel_TableBodyCells():
     """
     Test Class for TableBodyCells
     """
-
     def test_table_body_cells_serialization(self):
         """
         Test serialization/deserialization for TableBodyCells
@@ -8167,29 +8653,33 @@ class TestModel_TableBodyCells():
 
         # Construct dict forms of any model objects needed in order to build this model.
 
-        table_element_location_model = {} # TableElementLocation
+        table_element_location_model = {}  # TableElementLocation
         table_element_location_model['begin'] = 26
         table_element_location_model['end'] = 26
 
-        table_row_header_ids_model = {} # TableRowHeaderIds
+        table_row_header_ids_model = {}  # TableRowHeaderIds
         table_row_header_ids_model['id'] = 'testString'
 
-        table_row_header_texts_model = {} # TableRowHeaderTexts
+        table_row_header_texts_model = {}  # TableRowHeaderTexts
         table_row_header_texts_model['text'] = 'testString'
 
-        table_row_header_texts_normalized_model = {} # TableRowHeaderTextsNormalized
-        table_row_header_texts_normalized_model['text_normalized'] = 'testString'
+        table_row_header_texts_normalized_model = {
+        }  # TableRowHeaderTextsNormalized
+        table_row_header_texts_normalized_model[
+            'text_normalized'] = 'testString'
 
-        table_column_header_ids_model = {} # TableColumnHeaderIds
+        table_column_header_ids_model = {}  # TableColumnHeaderIds
         table_column_header_ids_model['id'] = 'testString'
 
-        table_column_header_texts_model = {} # TableColumnHeaderTexts
+        table_column_header_texts_model = {}  # TableColumnHeaderTexts
         table_column_header_texts_model['text'] = 'testString'
 
-        table_column_header_texts_normalized_model = {} # TableColumnHeaderTextsNormalized
-        table_column_header_texts_normalized_model['text_normalized'] = 'testString'
+        table_column_header_texts_normalized_model = {
+        }  # TableColumnHeaderTextsNormalized
+        table_column_header_texts_normalized_model[
+            'text_normalized'] = 'testString'
 
-        document_attribute_model = {} # DocumentAttribute
+        document_attribute_model = {}  # DocumentAttribute
         document_attribute_model['type'] = 'testString'
         document_attribute_model['text'] = 'testString'
         document_attribute_model['location'] = table_element_location_model
@@ -8203,20 +8693,34 @@ class TestModel_TableBodyCells():
         table_body_cells_model_json['row_index_end'] = 26
         table_body_cells_model_json['column_index_begin'] = 26
         table_body_cells_model_json['column_index_end'] = 26
-        table_body_cells_model_json['row_header_ids'] = [table_row_header_ids_model]
-        table_body_cells_model_json['row_header_texts'] = [table_row_header_texts_model]
-        table_body_cells_model_json['row_header_texts_normalized'] = [table_row_header_texts_normalized_model]
-        table_body_cells_model_json['column_header_ids'] = [table_column_header_ids_model]
-        table_body_cells_model_json['column_header_texts'] = [table_column_header_texts_model]
-        table_body_cells_model_json['column_header_texts_normalized'] = [table_column_header_texts_normalized_model]
+        table_body_cells_model_json['row_header_ids'] = [
+            table_row_header_ids_model
+        ]
+        table_body_cells_model_json['row_header_texts'] = [
+            table_row_header_texts_model
+        ]
+        table_body_cells_model_json['row_header_texts_normalized'] = [
+            table_row_header_texts_normalized_model
+        ]
+        table_body_cells_model_json['column_header_ids'] = [
+            table_column_header_ids_model
+        ]
+        table_body_cells_model_json['column_header_texts'] = [
+            table_column_header_texts_model
+        ]
+        table_body_cells_model_json['column_header_texts_normalized'] = [
+            table_column_header_texts_normalized_model
+        ]
         table_body_cells_model_json['attributes'] = [document_attribute_model]
 
         # Construct a model instance of TableBodyCells by calling from_dict on the json representation
-        table_body_cells_model = TableBodyCells.from_dict(table_body_cells_model_json)
+        table_body_cells_model = TableBodyCells.from_dict(
+            table_body_cells_model_json)
         assert table_body_cells_model != False
 
         # Construct a model instance of TableBodyCells by calling from_dict on the json representation
-        table_body_cells_model_dict = TableBodyCells.from_dict(table_body_cells_model_json).__dict__
+        table_body_cells_model_dict = TableBodyCells.from_dict(
+            table_body_cells_model_json).__dict__
         table_body_cells_model2 = TableBodyCells(**table_body_cells_model_dict)
 
         # Verify the model instances are equivalent
@@ -8226,11 +8730,11 @@ class TestModel_TableBodyCells():
         table_body_cells_model_json2 = table_body_cells_model.to_dict()
         assert table_body_cells_model_json2 == table_body_cells_model_json
 
+
 class TestModel_TableCellKey():
     """
     Test Class for TableCellKey
     """
-
     def test_table_cell_key_serialization(self):
         """
         Test serialization/deserialization for TableCellKey
@@ -8238,7 +8742,7 @@ class TestModel_TableCellKey():
 
         # Construct dict forms of any model objects needed in order to build this model.
 
-        table_element_location_model = {} # TableElementLocation
+        table_element_location_model = {}  # TableElementLocation
         table_element_location_model['begin'] = 26
         table_element_location_model['end'] = 26
 
@@ -8249,11 +8753,13 @@ class TestModel_TableCellKey():
         table_cell_key_model_json['text'] = 'testString'
 
         # Construct a model instance of TableCellKey by calling from_dict on the json representation
-        table_cell_key_model = TableCellKey.from_dict(table_cell_key_model_json)
+        table_cell_key_model = TableCellKey.from_dict(
+            table_cell_key_model_json)
         assert table_cell_key_model != False
 
         # Construct a model instance of TableCellKey by calling from_dict on the json representation
-        table_cell_key_model_dict = TableCellKey.from_dict(table_cell_key_model_json).__dict__
+        table_cell_key_model_dict = TableCellKey.from_dict(
+            table_cell_key_model_json).__dict__
         table_cell_key_model2 = TableCellKey(**table_cell_key_model_dict)
 
         # Verify the model instances are equivalent
@@ -8263,11 +8769,11 @@ class TestModel_TableCellKey():
         table_cell_key_model_json2 = table_cell_key_model.to_dict()
         assert table_cell_key_model_json2 == table_cell_key_model_json
 
+
 class TestModel_TableCellValues():
     """
     Test Class for TableCellValues
     """
-
     def test_table_cell_values_serialization(self):
         """
         Test serialization/deserialization for TableCellValues
@@ -8275,7 +8781,7 @@ class TestModel_TableCellValues():
 
         # Construct dict forms of any model objects needed in order to build this model.
 
-        table_element_location_model = {} # TableElementLocation
+        table_element_location_model = {}  # TableElementLocation
         table_element_location_model['begin'] = 26
         table_element_location_model['end'] = 26
 
@@ -8286,12 +8792,15 @@ class TestModel_TableCellValues():
         table_cell_values_model_json['text'] = 'testString'
 
         # Construct a model instance of TableCellValues by calling from_dict on the json representation
-        table_cell_values_model = TableCellValues.from_dict(table_cell_values_model_json)
+        table_cell_values_model = TableCellValues.from_dict(
+            table_cell_values_model_json)
         assert table_cell_values_model != False
 
         # Construct a model instance of TableCellValues by calling from_dict on the json representation
-        table_cell_values_model_dict = TableCellValues.from_dict(table_cell_values_model_json).__dict__
-        table_cell_values_model2 = TableCellValues(**table_cell_values_model_dict)
+        table_cell_values_model_dict = TableCellValues.from_dict(
+            table_cell_values_model_json).__dict__
+        table_cell_values_model2 = TableCellValues(
+            **table_cell_values_model_dict)
 
         # Verify the model instances are equivalent
         assert table_cell_values_model == table_cell_values_model2
@@ -8300,11 +8809,11 @@ class TestModel_TableCellValues():
         table_cell_values_model_json2 = table_cell_values_model.to_dict()
         assert table_cell_values_model_json2 == table_cell_values_model_json
 
+
 class TestModel_TableColumnHeaderIds():
     """
     Test Class for TableColumnHeaderIds
     """
-
     def test_table_column_header_ids_serialization(self):
         """
         Test serialization/deserialization for TableColumnHeaderIds
@@ -8315,25 +8824,29 @@ class TestModel_TableColumnHeaderIds():
         table_column_header_ids_model_json['id'] = 'testString'
 
         # Construct a model instance of TableColumnHeaderIds by calling from_dict on the json representation
-        table_column_header_ids_model = TableColumnHeaderIds.from_dict(table_column_header_ids_model_json)
+        table_column_header_ids_model = TableColumnHeaderIds.from_dict(
+            table_column_header_ids_model_json)
         assert table_column_header_ids_model != False
 
         # Construct a model instance of TableColumnHeaderIds by calling from_dict on the json representation
-        table_column_header_ids_model_dict = TableColumnHeaderIds.from_dict(table_column_header_ids_model_json).__dict__
-        table_column_header_ids_model2 = TableColumnHeaderIds(**table_column_header_ids_model_dict)
+        table_column_header_ids_model_dict = TableColumnHeaderIds.from_dict(
+            table_column_header_ids_model_json).__dict__
+        table_column_header_ids_model2 = TableColumnHeaderIds(
+            **table_column_header_ids_model_dict)
 
         # Verify the model instances are equivalent
         assert table_column_header_ids_model == table_column_header_ids_model2
 
         # Convert model instance back to dict and verify no loss of data
-        table_column_header_ids_model_json2 = table_column_header_ids_model.to_dict()
+        table_column_header_ids_model_json2 = table_column_header_ids_model.to_dict(
+        )
         assert table_column_header_ids_model_json2 == table_column_header_ids_model_json
+
 
 class TestModel_TableColumnHeaderTexts():
     """
     Test Class for TableColumnHeaderTexts
     """
-
     def test_table_column_header_texts_serialization(self):
         """
         Test serialization/deserialization for TableColumnHeaderTexts
@@ -8344,25 +8857,29 @@ class TestModel_TableColumnHeaderTexts():
         table_column_header_texts_model_json['text'] = 'testString'
 
         # Construct a model instance of TableColumnHeaderTexts by calling from_dict on the json representation
-        table_column_header_texts_model = TableColumnHeaderTexts.from_dict(table_column_header_texts_model_json)
+        table_column_header_texts_model = TableColumnHeaderTexts.from_dict(
+            table_column_header_texts_model_json)
         assert table_column_header_texts_model != False
 
         # Construct a model instance of TableColumnHeaderTexts by calling from_dict on the json representation
-        table_column_header_texts_model_dict = TableColumnHeaderTexts.from_dict(table_column_header_texts_model_json).__dict__
-        table_column_header_texts_model2 = TableColumnHeaderTexts(**table_column_header_texts_model_dict)
+        table_column_header_texts_model_dict = TableColumnHeaderTexts.from_dict(
+            table_column_header_texts_model_json).__dict__
+        table_column_header_texts_model2 = TableColumnHeaderTexts(
+            **table_column_header_texts_model_dict)
 
         # Verify the model instances are equivalent
         assert table_column_header_texts_model == table_column_header_texts_model2
 
         # Convert model instance back to dict and verify no loss of data
-        table_column_header_texts_model_json2 = table_column_header_texts_model.to_dict()
+        table_column_header_texts_model_json2 = table_column_header_texts_model.to_dict(
+        )
         assert table_column_header_texts_model_json2 == table_column_header_texts_model_json
+
 
 class TestModel_TableColumnHeaderTextsNormalized():
     """
     Test Class for TableColumnHeaderTextsNormalized
     """
-
     def test_table_column_header_texts_normalized_serialization(self):
         """
         Test serialization/deserialization for TableColumnHeaderTextsNormalized
@@ -8370,28 +8887,33 @@ class TestModel_TableColumnHeaderTextsNormalized():
 
         # Construct a json representation of a TableColumnHeaderTextsNormalized model
         table_column_header_texts_normalized_model_json = {}
-        table_column_header_texts_normalized_model_json['text_normalized'] = 'testString'
+        table_column_header_texts_normalized_model_json[
+            'text_normalized'] = 'testString'
 
         # Construct a model instance of TableColumnHeaderTextsNormalized by calling from_dict on the json representation
-        table_column_header_texts_normalized_model = TableColumnHeaderTextsNormalized.from_dict(table_column_header_texts_normalized_model_json)
+        table_column_header_texts_normalized_model = TableColumnHeaderTextsNormalized.from_dict(
+            table_column_header_texts_normalized_model_json)
         assert table_column_header_texts_normalized_model != False
 
         # Construct a model instance of TableColumnHeaderTextsNormalized by calling from_dict on the json representation
-        table_column_header_texts_normalized_model_dict = TableColumnHeaderTextsNormalized.from_dict(table_column_header_texts_normalized_model_json).__dict__
-        table_column_header_texts_normalized_model2 = TableColumnHeaderTextsNormalized(**table_column_header_texts_normalized_model_dict)
+        table_column_header_texts_normalized_model_dict = TableColumnHeaderTextsNormalized.from_dict(
+            table_column_header_texts_normalized_model_json).__dict__
+        table_column_header_texts_normalized_model2 = TableColumnHeaderTextsNormalized(
+            **table_column_header_texts_normalized_model_dict)
 
         # Verify the model instances are equivalent
         assert table_column_header_texts_normalized_model == table_column_header_texts_normalized_model2
 
         # Convert model instance back to dict and verify no loss of data
-        table_column_header_texts_normalized_model_json2 = table_column_header_texts_normalized_model.to_dict()
+        table_column_header_texts_normalized_model_json2 = table_column_header_texts_normalized_model.to_dict(
+        )
         assert table_column_header_texts_normalized_model_json2 == table_column_header_texts_normalized_model_json
+
 
 class TestModel_TableColumnHeaders():
     """
     Test Class for TableColumnHeaders
     """
-
     def test_table_column_headers_serialization(self):
         """
         Test serialization/deserialization for TableColumnHeaders
@@ -8409,12 +8931,15 @@ class TestModel_TableColumnHeaders():
         table_column_headers_model_json['column_index_end'] = 26
 
         # Construct a model instance of TableColumnHeaders by calling from_dict on the json representation
-        table_column_headers_model = TableColumnHeaders.from_dict(table_column_headers_model_json)
+        table_column_headers_model = TableColumnHeaders.from_dict(
+            table_column_headers_model_json)
         assert table_column_headers_model != False
 
         # Construct a model instance of TableColumnHeaders by calling from_dict on the json representation
-        table_column_headers_model_dict = TableColumnHeaders.from_dict(table_column_headers_model_json).__dict__
-        table_column_headers_model2 = TableColumnHeaders(**table_column_headers_model_dict)
+        table_column_headers_model_dict = TableColumnHeaders.from_dict(
+            table_column_headers_model_json).__dict__
+        table_column_headers_model2 = TableColumnHeaders(
+            **table_column_headers_model_dict)
 
         # Verify the model instances are equivalent
         assert table_column_headers_model == table_column_headers_model2
@@ -8423,11 +8948,11 @@ class TestModel_TableColumnHeaders():
         table_column_headers_model_json2 = table_column_headers_model.to_dict()
         assert table_column_headers_model_json2 == table_column_headers_model_json
 
+
 class TestModel_TableElementLocation():
     """
     Test Class for TableElementLocation
     """
-
     def test_table_element_location_serialization(self):
         """
         Test serialization/deserialization for TableElementLocation
@@ -8439,25 +8964,29 @@ class TestModel_TableElementLocation():
         table_element_location_model_json['end'] = 26
 
         # Construct a model instance of TableElementLocation by calling from_dict on the json representation
-        table_element_location_model = TableElementLocation.from_dict(table_element_location_model_json)
+        table_element_location_model = TableElementLocation.from_dict(
+            table_element_location_model_json)
         assert table_element_location_model != False
 
         # Construct a model instance of TableElementLocation by calling from_dict on the json representation
-        table_element_location_model_dict = TableElementLocation.from_dict(table_element_location_model_json).__dict__
-        table_element_location_model2 = TableElementLocation(**table_element_location_model_dict)
+        table_element_location_model_dict = TableElementLocation.from_dict(
+            table_element_location_model_json).__dict__
+        table_element_location_model2 = TableElementLocation(
+            **table_element_location_model_dict)
 
         # Verify the model instances are equivalent
         assert table_element_location_model == table_element_location_model2
 
         # Convert model instance back to dict and verify no loss of data
-        table_element_location_model_json2 = table_element_location_model.to_dict()
+        table_element_location_model_json2 = table_element_location_model.to_dict(
+        )
         assert table_element_location_model_json2 == table_element_location_model_json
+
 
 class TestModel_TableHeaders():
     """
     Test Class for TableHeaders
     """
-
     def test_table_headers_serialization(self):
         """
         Test serialization/deserialization for TableHeaders
@@ -8478,7 +9007,8 @@ class TestModel_TableHeaders():
         assert table_headers_model != False
 
         # Construct a model instance of TableHeaders by calling from_dict on the json representation
-        table_headers_model_dict = TableHeaders.from_dict(table_headers_model_json).__dict__
+        table_headers_model_dict = TableHeaders.from_dict(
+            table_headers_model_json).__dict__
         table_headers_model2 = TableHeaders(**table_headers_model_dict)
 
         # Verify the model instances are equivalent
@@ -8488,11 +9018,11 @@ class TestModel_TableHeaders():
         table_headers_model_json2 = table_headers_model.to_dict()
         assert table_headers_model_json2 == table_headers_model_json
 
+
 class TestModel_TableKeyValuePairs():
     """
     Test Class for TableKeyValuePairs
     """
-
     def test_table_key_value_pairs_serialization(self):
         """
         Test serialization/deserialization for TableKeyValuePairs
@@ -8500,16 +9030,16 @@ class TestModel_TableKeyValuePairs():
 
         # Construct dict forms of any model objects needed in order to build this model.
 
-        table_element_location_model = {} # TableElementLocation
+        table_element_location_model = {}  # TableElementLocation
         table_element_location_model['begin'] = 26
         table_element_location_model['end'] = 26
 
-        table_cell_key_model = {} # TableCellKey
+        table_cell_key_model = {}  # TableCellKey
         table_cell_key_model['cell_id'] = 'testString'
         table_cell_key_model['location'] = table_element_location_model
         table_cell_key_model['text'] = 'testString'
 
-        table_cell_values_model = {} # TableCellValues
+        table_cell_values_model = {}  # TableCellValues
         table_cell_values_model['cell_id'] = 'testString'
         table_cell_values_model['location'] = table_element_location_model
         table_cell_values_model['text'] = 'testString'
@@ -8520,25 +9050,29 @@ class TestModel_TableKeyValuePairs():
         table_key_value_pairs_model_json['value'] = [table_cell_values_model]
 
         # Construct a model instance of TableKeyValuePairs by calling from_dict on the json representation
-        table_key_value_pairs_model = TableKeyValuePairs.from_dict(table_key_value_pairs_model_json)
+        table_key_value_pairs_model = TableKeyValuePairs.from_dict(
+            table_key_value_pairs_model_json)
         assert table_key_value_pairs_model != False
 
         # Construct a model instance of TableKeyValuePairs by calling from_dict on the json representation
-        table_key_value_pairs_model_dict = TableKeyValuePairs.from_dict(table_key_value_pairs_model_json).__dict__
-        table_key_value_pairs_model2 = TableKeyValuePairs(**table_key_value_pairs_model_dict)
+        table_key_value_pairs_model_dict = TableKeyValuePairs.from_dict(
+            table_key_value_pairs_model_json).__dict__
+        table_key_value_pairs_model2 = TableKeyValuePairs(
+            **table_key_value_pairs_model_dict)
 
         # Verify the model instances are equivalent
         assert table_key_value_pairs_model == table_key_value_pairs_model2
 
         # Convert model instance back to dict and verify no loss of data
-        table_key_value_pairs_model_json2 = table_key_value_pairs_model.to_dict()
+        table_key_value_pairs_model_json2 = table_key_value_pairs_model.to_dict(
+        )
         assert table_key_value_pairs_model_json2 == table_key_value_pairs_model_json
+
 
 class TestModel_TableResultTable():
     """
     Test Class for TableResultTable
     """
-
     def test_table_result_table_serialization(self):
         """
         Test serialization/deserialization for TableResultTable
@@ -8546,15 +9080,15 @@ class TestModel_TableResultTable():
 
         # Construct dict forms of any model objects needed in order to build this model.
 
-        table_element_location_model = {} # TableElementLocation
+        table_element_location_model = {}  # TableElementLocation
         table_element_location_model['begin'] = 26
         table_element_location_model['end'] = 26
 
-        table_text_location_model = {} # TableTextLocation
+        table_text_location_model = {}  # TableTextLocation
         table_text_location_model['text'] = 'testString'
         table_text_location_model['location'] = table_element_location_model
 
-        table_headers_model = {} # TableHeaders
+        table_headers_model = {}  # TableHeaders
         table_headers_model['cell_id'] = 'testString'
         table_headers_model['location'] = {'foo': 'bar'}
         table_headers_model['text'] = 'testString'
@@ -8563,7 +9097,7 @@ class TestModel_TableResultTable():
         table_headers_model['column_index_begin'] = 26
         table_headers_model['column_index_end'] = 26
 
-        table_row_headers_model = {} # TableRowHeaders
+        table_row_headers_model = {}  # TableRowHeaders
         table_row_headers_model['cell_id'] = 'testString'
         table_row_headers_model['location'] = table_element_location_model
         table_row_headers_model['text'] = 'testString'
@@ -8573,7 +9107,7 @@ class TestModel_TableResultTable():
         table_row_headers_model['column_index_begin'] = 26
         table_row_headers_model['column_index_end'] = 26
 
-        table_column_headers_model = {} # TableColumnHeaders
+        table_column_headers_model = {}  # TableColumnHeaders
         table_column_headers_model['cell_id'] = 'testString'
         table_column_headers_model['location'] = {'foo': 'bar'}
         table_column_headers_model['text'] = 'testString'
@@ -8583,44 +9117,48 @@ class TestModel_TableResultTable():
         table_column_headers_model['column_index_begin'] = 26
         table_column_headers_model['column_index_end'] = 26
 
-        table_cell_key_model = {} # TableCellKey
+        table_cell_key_model = {}  # TableCellKey
         table_cell_key_model['cell_id'] = 'testString'
         table_cell_key_model['location'] = table_element_location_model
         table_cell_key_model['text'] = 'testString'
 
-        table_cell_values_model = {} # TableCellValues
+        table_cell_values_model = {}  # TableCellValues
         table_cell_values_model['cell_id'] = 'testString'
         table_cell_values_model['location'] = table_element_location_model
         table_cell_values_model['text'] = 'testString'
 
-        table_key_value_pairs_model = {} # TableKeyValuePairs
+        table_key_value_pairs_model = {}  # TableKeyValuePairs
         table_key_value_pairs_model['key'] = table_cell_key_model
         table_key_value_pairs_model['value'] = [table_cell_values_model]
 
-        table_row_header_ids_model = {} # TableRowHeaderIds
+        table_row_header_ids_model = {}  # TableRowHeaderIds
         table_row_header_ids_model['id'] = 'testString'
 
-        table_row_header_texts_model = {} # TableRowHeaderTexts
+        table_row_header_texts_model = {}  # TableRowHeaderTexts
         table_row_header_texts_model['text'] = 'testString'
 
-        table_row_header_texts_normalized_model = {} # TableRowHeaderTextsNormalized
-        table_row_header_texts_normalized_model['text_normalized'] = 'testString'
+        table_row_header_texts_normalized_model = {
+        }  # TableRowHeaderTextsNormalized
+        table_row_header_texts_normalized_model[
+            'text_normalized'] = 'testString'
 
-        table_column_header_ids_model = {} # TableColumnHeaderIds
+        table_column_header_ids_model = {}  # TableColumnHeaderIds
         table_column_header_ids_model['id'] = 'testString'
 
-        table_column_header_texts_model = {} # TableColumnHeaderTexts
+        table_column_header_texts_model = {}  # TableColumnHeaderTexts
         table_column_header_texts_model['text'] = 'testString'
 
-        table_column_header_texts_normalized_model = {} # TableColumnHeaderTextsNormalized
-        table_column_header_texts_normalized_model['text_normalized'] = 'testString'
+        table_column_header_texts_normalized_model = {
+        }  # TableColumnHeaderTextsNormalized
+        table_column_header_texts_normalized_model[
+            'text_normalized'] = 'testString'
 
-        document_attribute_model = {} # DocumentAttribute
+        document_attribute_model = {}  # DocumentAttribute
         document_attribute_model['type'] = 'testString'
         document_attribute_model['text'] = 'testString'
         document_attribute_model['location'] = table_element_location_model
 
-        table_body_cells_model = {} # TableBodyCells
+        table_body_cells_model = {}  # TableBodyCells
         table_body_cells_model['cell_id'] = 'testString'
         table_body_cells_model['location'] = table_element_location_model
         table_body_cells_model['text'] = 'testString'
@@ -8629,33 +9167,54 @@ class TestModel_TableResultTable():
         table_body_cells_model['column_index_begin'] = 26
         table_body_cells_model['column_index_end'] = 26
         table_body_cells_model['row_header_ids'] = [table_row_header_ids_model]
-        table_body_cells_model['row_header_texts'] = [table_row_header_texts_model]
-        table_body_cells_model['row_header_texts_normalized'] = [table_row_header_texts_normalized_model]
-        table_body_cells_model['column_header_ids'] = [table_column_header_ids_model]
-        table_body_cells_model['column_header_texts'] = [table_column_header_texts_model]
-        table_body_cells_model['column_header_texts_normalized'] = [table_column_header_texts_normalized_model]
+        table_body_cells_model['row_header_texts'] = [
+            table_row_header_texts_model
+        ]
+        table_body_cells_model['row_header_texts_normalized'] = [
+            table_row_header_texts_normalized_model
+        ]
+        table_body_cells_model['column_header_ids'] = [
+            table_column_header_ids_model
+        ]
+        table_body_cells_model['column_header_texts'] = [
+            table_column_header_texts_model
+        ]
+        table_body_cells_model['column_header_texts_normalized'] = [
+            table_column_header_texts_normalized_model
+        ]
         table_body_cells_model['attributes'] = [document_attribute_model]
 
         # Construct a json representation of a TableResultTable model
         table_result_table_model_json = {}
-        table_result_table_model_json['location'] = table_element_location_model
+        table_result_table_model_json[
+            'location'] = table_element_location_model
         table_result_table_model_json['text'] = 'testString'
-        table_result_table_model_json['section_title'] = table_text_location_model
+        table_result_table_model_json[
+            'section_title'] = table_text_location_model
         table_result_table_model_json['title'] = table_text_location_model
         table_result_table_model_json['table_headers'] = [table_headers_model]
-        table_result_table_model_json['row_headers'] = [table_row_headers_model]
-        table_result_table_model_json['column_headers'] = [table_column_headers_model]
-        table_result_table_model_json['key_value_pairs'] = [table_key_value_pairs_model]
+        table_result_table_model_json['row_headers'] = [
+            table_row_headers_model
+        ]
+        table_result_table_model_json['column_headers'] = [
+            table_column_headers_model
+        ]
+        table_result_table_model_json['key_value_pairs'] = [
+            table_key_value_pairs_model
+        ]
         table_result_table_model_json['body_cells'] = [table_body_cells_model]
         table_result_table_model_json['contexts'] = [table_text_location_model]
 
         # Construct a model instance of TableResultTable by calling from_dict on the json representation
-        table_result_table_model = TableResultTable.from_dict(table_result_table_model_json)
+        table_result_table_model = TableResultTable.from_dict(
+            table_result_table_model_json)
         assert table_result_table_model != False
 
         # Construct a model instance of TableResultTable by calling from_dict on the json representation
-        table_result_table_model_dict = TableResultTable.from_dict(table_result_table_model_json).__dict__
-        table_result_table_model2 = TableResultTable(**table_result_table_model_dict)
+        table_result_table_model_dict = TableResultTable.from_dict(
+            table_result_table_model_json).__dict__
+        table_result_table_model2 = TableResultTable(
+            **table_result_table_model_dict)
 
         # Verify the model instances are equivalent
         assert table_result_table_model == table_result_table_model2
@@ -8664,11 +9223,11 @@ class TestModel_TableResultTable():
         table_result_table_model_json2 = table_result_table_model.to_dict()
         assert table_result_table_model_json2 == table_result_table_model_json
 
+
 class TestModel_TableRowHeaderIds():
     """
     Test Class for TableRowHeaderIds
     """
-
     def test_table_row_header_ids_serialization(self):
         """
         Test serialization/deserialization for TableRowHeaderIds
@@ -8679,12 +9238,15 @@ class TestModel_TableRowHeaderIds():
         table_row_header_ids_model_json['id'] = 'testString'
 
         # Construct a model instance of TableRowHeaderIds by calling from_dict on the json representation
-        table_row_header_ids_model = TableRowHeaderIds.from_dict(table_row_header_ids_model_json)
+        table_row_header_ids_model = TableRowHeaderIds.from_dict(
+            table_row_header_ids_model_json)
         assert table_row_header_ids_model != False
 
         # Construct a model instance of TableRowHeaderIds by calling from_dict on the json representation
-        table_row_header_ids_model_dict = TableRowHeaderIds.from_dict(table_row_header_ids_model_json).__dict__
-        table_row_header_ids_model2 = TableRowHeaderIds(**table_row_header_ids_model_dict)
+        table_row_header_ids_model_dict = TableRowHeaderIds.from_dict(
+            table_row_header_ids_model_json).__dict__
+        table_row_header_ids_model2 = TableRowHeaderIds(
+            **table_row_header_ids_model_dict)
 
         # Verify the model instances are equivalent
         assert table_row_header_ids_model == table_row_header_ids_model2
@@ -8693,11 +9255,11 @@ class TestModel_TableRowHeaderIds():
         table_row_header_ids_model_json2 = table_row_header_ids_model.to_dict()
         assert table_row_header_ids_model_json2 == table_row_header_ids_model_json
 
+
 class TestModel_TableRowHeaderTexts():
     """
     Test Class for TableRowHeaderTexts
     """
-
     def test_table_row_header_texts_serialization(self):
         """
         Test serialization/deserialization for TableRowHeaderTexts
@@ -8708,25 +9270,29 @@ class TestModel_TableRowHeaderTexts():
         table_row_header_texts_model_json['text'] = 'testString'
 
         # Construct a model instance of TableRowHeaderTexts by calling from_dict on the json representation
-        table_row_header_texts_model = TableRowHeaderTexts.from_dict(table_row_header_texts_model_json)
+        table_row_header_texts_model = TableRowHeaderTexts.from_dict(
+            table_row_header_texts_model_json)
         assert table_row_header_texts_model != False
 
         # Construct a model instance of TableRowHeaderTexts by calling from_dict on the json representation
-        table_row_header_texts_model_dict = TableRowHeaderTexts.from_dict(table_row_header_texts_model_json).__dict__
-        table_row_header_texts_model2 = TableRowHeaderTexts(**table_row_header_texts_model_dict)
+        table_row_header_texts_model_dict = TableRowHeaderTexts.from_dict(
+            table_row_header_texts_model_json).__dict__
+        table_row_header_texts_model2 = TableRowHeaderTexts(
+            **table_row_header_texts_model_dict)
 
         # Verify the model instances are equivalent
         assert table_row_header_texts_model == table_row_header_texts_model2
 
         # Convert model instance back to dict and verify no loss of data
-        table_row_header_texts_model_json2 = table_row_header_texts_model.to_dict()
+        table_row_header_texts_model_json2 = table_row_header_texts_model.to_dict(
+        )
         assert table_row_header_texts_model_json2 == table_row_header_texts_model_json
+
 
 class TestModel_TableRowHeaderTextsNormalized():
     """
     Test Class for TableRowHeaderTextsNormalized
     """
-
     def test_table_row_header_texts_normalized_serialization(self):
         """
         Test serialization/deserialization for TableRowHeaderTextsNormalized
@@ -8734,28 +9300,33 @@ class TestModel_TableRowHeaderTextsNormalized():
 
         # Construct a json representation of a TableRowHeaderTextsNormalized model
         table_row_header_texts_normalized_model_json = {}
-        table_row_header_texts_normalized_model_json['text_normalized'] = 'testString'
+        table_row_header_texts_normalized_model_json[
+            'text_normalized'] = 'testString'
 
         # Construct a model instance of TableRowHeaderTextsNormalized by calling from_dict on the json representation
-        table_row_header_texts_normalized_model = TableRowHeaderTextsNormalized.from_dict(table_row_header_texts_normalized_model_json)
+        table_row_header_texts_normalized_model = TableRowHeaderTextsNormalized.from_dict(
+            table_row_header_texts_normalized_model_json)
         assert table_row_header_texts_normalized_model != False
 
         # Construct a model instance of TableRowHeaderTextsNormalized by calling from_dict on the json representation
-        table_row_header_texts_normalized_model_dict = TableRowHeaderTextsNormalized.from_dict(table_row_header_texts_normalized_model_json).__dict__
-        table_row_header_texts_normalized_model2 = TableRowHeaderTextsNormalized(**table_row_header_texts_normalized_model_dict)
+        table_row_header_texts_normalized_model_dict = TableRowHeaderTextsNormalized.from_dict(
+            table_row_header_texts_normalized_model_json).__dict__
+        table_row_header_texts_normalized_model2 = TableRowHeaderTextsNormalized(
+            **table_row_header_texts_normalized_model_dict)
 
         # Verify the model instances are equivalent
         assert table_row_header_texts_normalized_model == table_row_header_texts_normalized_model2
 
         # Convert model instance back to dict and verify no loss of data
-        table_row_header_texts_normalized_model_json2 = table_row_header_texts_normalized_model.to_dict()
+        table_row_header_texts_normalized_model_json2 = table_row_header_texts_normalized_model.to_dict(
+        )
         assert table_row_header_texts_normalized_model_json2 == table_row_header_texts_normalized_model_json
+
 
 class TestModel_TableRowHeaders():
     """
     Test Class for TableRowHeaders
     """
-
     def test_table_row_headers_serialization(self):
         """
         Test serialization/deserialization for TableRowHeaders
@@ -8763,7 +9334,7 @@ class TestModel_TableRowHeaders():
 
         # Construct dict forms of any model objects needed in order to build this model.
 
-        table_element_location_model = {} # TableElementLocation
+        table_element_location_model = {}  # TableElementLocation
         table_element_location_model['begin'] = 26
         table_element_location_model['end'] = 26
 
@@ -8779,12 +9350,15 @@ class TestModel_TableRowHeaders():
         table_row_headers_model_json['column_index_end'] = 26
 
         # Construct a model instance of TableRowHeaders by calling from_dict on the json representation
-        table_row_headers_model = TableRowHeaders.from_dict(table_row_headers_model_json)
+        table_row_headers_model = TableRowHeaders.from_dict(
+            table_row_headers_model_json)
         assert table_row_headers_model != False
 
         # Construct a model instance of TableRowHeaders by calling from_dict on the json representation
-        table_row_headers_model_dict = TableRowHeaders.from_dict(table_row_headers_model_json).__dict__
-        table_row_headers_model2 = TableRowHeaders(**table_row_headers_model_dict)
+        table_row_headers_model_dict = TableRowHeaders.from_dict(
+            table_row_headers_model_json).__dict__
+        table_row_headers_model2 = TableRowHeaders(
+            **table_row_headers_model_dict)
 
         # Verify the model instances are equivalent
         assert table_row_headers_model == table_row_headers_model2
@@ -8793,11 +9367,11 @@ class TestModel_TableRowHeaders():
         table_row_headers_model_json2 = table_row_headers_model.to_dict()
         assert table_row_headers_model_json2 == table_row_headers_model_json
 
+
 class TestModel_TableTextLocation():
     """
     Test Class for TableTextLocation
     """
-
     def test_table_text_location_serialization(self):
         """
         Test serialization/deserialization for TableTextLocation
@@ -8805,22 +9379,26 @@ class TestModel_TableTextLocation():
 
         # Construct dict forms of any model objects needed in order to build this model.
 
-        table_element_location_model = {} # TableElementLocation
+        table_element_location_model = {}  # TableElementLocation
         table_element_location_model['begin'] = 26
         table_element_location_model['end'] = 26
 
         # Construct a json representation of a TableTextLocation model
         table_text_location_model_json = {}
         table_text_location_model_json['text'] = 'testString'
-        table_text_location_model_json['location'] = table_element_location_model
+        table_text_location_model_json[
+            'location'] = table_element_location_model
 
         # Construct a model instance of TableTextLocation by calling from_dict on the json representation
-        table_text_location_model = TableTextLocation.from_dict(table_text_location_model_json)
+        table_text_location_model = TableTextLocation.from_dict(
+            table_text_location_model_json)
         assert table_text_location_model != False
 
         # Construct a model instance of TableTextLocation by calling from_dict on the json representation
-        table_text_location_model_dict = TableTextLocation.from_dict(table_text_location_model_json).__dict__
-        table_text_location_model2 = TableTextLocation(**table_text_location_model_dict)
+        table_text_location_model_dict = TableTextLocation.from_dict(
+            table_text_location_model_json).__dict__
+        table_text_location_model2 = TableTextLocation(
+            **table_text_location_model_dict)
 
         # Verify the model instances are equivalent
         assert table_text_location_model == table_text_location_model2
@@ -8829,11 +9407,11 @@ class TestModel_TableTextLocation():
         table_text_location_model_json2 = table_text_location_model.to_dict()
         assert table_text_location_model_json2 == table_text_location_model_json
 
+
 class TestModel_TrainingExample():
     """
     Test Class for TrainingExample
     """
-
     def test_training_example_serialization(self):
         """
         Test serialization/deserialization for TrainingExample
@@ -8848,12 +9426,15 @@ class TestModel_TrainingExample():
         training_example_model_json['updated'] = '2019-01-01T12:00:00Z'
 
         # Construct a model instance of TrainingExample by calling from_dict on the json representation
-        training_example_model = TrainingExample.from_dict(training_example_model_json)
+        training_example_model = TrainingExample.from_dict(
+            training_example_model_json)
         assert training_example_model != False
 
         # Construct a model instance of TrainingExample by calling from_dict on the json representation
-        training_example_model_dict = TrainingExample.from_dict(training_example_model_json).__dict__
-        training_example_model2 = TrainingExample(**training_example_model_dict)
+        training_example_model_dict = TrainingExample.from_dict(
+            training_example_model_json).__dict__
+        training_example_model2 = TrainingExample(
+            **training_example_model_dict)
 
         # Verify the model instances are equivalent
         assert training_example_model == training_example_model2
@@ -8862,11 +9443,11 @@ class TestModel_TrainingExample():
         training_example_model_json2 = training_example_model.to_dict()
         assert training_example_model_json2 == training_example_model_json
 
+
 class TestModel_TrainingQuery():
     """
     Test Class for TrainingQuery
     """
-
     def test_training_query_serialization(self):
         """
         Test serialization/deserialization for TrainingQuery
@@ -8874,7 +9455,7 @@ class TestModel_TrainingQuery():
 
         # Construct dict forms of any model objects needed in order to build this model.
 
-        training_example_model = {} # TrainingExample
+        training_example_model = {}  # TrainingExample
         training_example_model['document_id'] = 'testString'
         training_example_model['collection_id'] = 'testString'
         training_example_model['relevance'] = 38
@@ -8891,11 +9472,13 @@ class TestModel_TrainingQuery():
         training_query_model_json['examples'] = [training_example_model]
 
         # Construct a model instance of TrainingQuery by calling from_dict on the json representation
-        training_query_model = TrainingQuery.from_dict(training_query_model_json)
+        training_query_model = TrainingQuery.from_dict(
+            training_query_model_json)
         assert training_query_model != False
 
         # Construct a model instance of TrainingQuery by calling from_dict on the json representation
-        training_query_model_dict = TrainingQuery.from_dict(training_query_model_json).__dict__
+        training_query_model_dict = TrainingQuery.from_dict(
+            training_query_model_json).__dict__
         training_query_model2 = TrainingQuery(**training_query_model_dict)
 
         # Verify the model instances are equivalent
@@ -8905,11 +9488,11 @@ class TestModel_TrainingQuery():
         training_query_model_json2 = training_query_model.to_dict()
         assert training_query_model_json2 == training_query_model_json
 
+
 class TestModel_TrainingQuerySet():
     """
     Test Class for TrainingQuerySet
     """
-
     def test_training_query_set_serialization(self):
         """
         Test serialization/deserialization for TrainingQuerySet
@@ -8917,14 +9500,14 @@ class TestModel_TrainingQuerySet():
 
         # Construct dict forms of any model objects needed in order to build this model.
 
-        training_example_model = {} # TrainingExample
+        training_example_model = {}  # TrainingExample
         training_example_model['document_id'] = 'testString'
         training_example_model['collection_id'] = 'testString'
         training_example_model['relevance'] = 38
         training_example_model['created'] = '2019-01-01T12:00:00Z'
         training_example_model['updated'] = '2019-01-01T12:00:00Z'
 
-        training_query_model = {} # TrainingQuery
+        training_query_model = {}  # TrainingQuery
         training_query_model['query_id'] = 'testString'
         training_query_model['natural_language_query'] = 'testString'
         training_query_model['filter'] = 'testString'
@@ -8937,12 +9520,15 @@ class TestModel_TrainingQuerySet():
         training_query_set_model_json['queries'] = [training_query_model]
 
         # Construct a model instance of TrainingQuerySet by calling from_dict on the json representation
-        training_query_set_model = TrainingQuerySet.from_dict(training_query_set_model_json)
+        training_query_set_model = TrainingQuerySet.from_dict(
+            training_query_set_model_json)
         assert training_query_set_model != False
 
         # Construct a model instance of TrainingQuerySet by calling from_dict on the json representation
-        training_query_set_model_dict = TrainingQuerySet.from_dict(training_query_set_model_json).__dict__
-        training_query_set_model2 = TrainingQuerySet(**training_query_set_model_dict)
+        training_query_set_model_dict = TrainingQuerySet.from_dict(
+            training_query_set_model_json).__dict__
+        training_query_set_model2 = TrainingQuerySet(
+            **training_query_set_model_dict)
 
         # Verify the model instances are equivalent
         assert training_query_set_model == training_query_set_model2
@@ -8951,11 +9537,11 @@ class TestModel_TrainingQuerySet():
         training_query_set_model_json2 = training_query_set_model.to_dict()
         assert training_query_set_model_json2 == training_query_set_model_json
 
+
 class TestModel_UpdateDocumentClassifier():
     """
     Test Class for UpdateDocumentClassifier
     """
-
     def test_update_document_classifier_serialization(self):
         """
         Test serialization/deserialization for UpdateDocumentClassifier
@@ -8967,25 +9553,29 @@ class TestModel_UpdateDocumentClassifier():
         update_document_classifier_model_json['description'] = 'testString'
 
         # Construct a model instance of UpdateDocumentClassifier by calling from_dict on the json representation
-        update_document_classifier_model = UpdateDocumentClassifier.from_dict(update_document_classifier_model_json)
+        update_document_classifier_model = UpdateDocumentClassifier.from_dict(
+            update_document_classifier_model_json)
         assert update_document_classifier_model != False
 
         # Construct a model instance of UpdateDocumentClassifier by calling from_dict on the json representation
-        update_document_classifier_model_dict = UpdateDocumentClassifier.from_dict(update_document_classifier_model_json).__dict__
-        update_document_classifier_model2 = UpdateDocumentClassifier(**update_document_classifier_model_dict)
+        update_document_classifier_model_dict = UpdateDocumentClassifier.from_dict(
+            update_document_classifier_model_json).__dict__
+        update_document_classifier_model2 = UpdateDocumentClassifier(
+            **update_document_classifier_model_dict)
 
         # Verify the model instances are equivalent
         assert update_document_classifier_model == update_document_classifier_model2
 
         # Convert model instance back to dict and verify no loss of data
-        update_document_classifier_model_json2 = update_document_classifier_model.to_dict()
+        update_document_classifier_model_json2 = update_document_classifier_model.to_dict(
+        )
         assert update_document_classifier_model_json2 == update_document_classifier_model_json
+
 
 class TestModel_QueryCalculationAggregation():
     """
     Test Class for QueryCalculationAggregation
     """
-
     def test_query_calculation_aggregation_serialization(self):
         """
         Test serialization/deserialization for QueryCalculationAggregation
@@ -8998,25 +9588,29 @@ class TestModel_QueryCalculationAggregation():
         query_calculation_aggregation_model_json['value'] = 72.5
 
         # Construct a model instance of QueryCalculationAggregation by calling from_dict on the json representation
-        query_calculation_aggregation_model = QueryCalculationAggregation.from_dict(query_calculation_aggregation_model_json)
+        query_calculation_aggregation_model = QueryCalculationAggregation.from_dict(
+            query_calculation_aggregation_model_json)
         assert query_calculation_aggregation_model != False
 
         # Construct a model instance of QueryCalculationAggregation by calling from_dict on the json representation
-        query_calculation_aggregation_model_dict = QueryCalculationAggregation.from_dict(query_calculation_aggregation_model_json).__dict__
-        query_calculation_aggregation_model2 = QueryCalculationAggregation(**query_calculation_aggregation_model_dict)
+        query_calculation_aggregation_model_dict = QueryCalculationAggregation.from_dict(
+            query_calculation_aggregation_model_json).__dict__
+        query_calculation_aggregation_model2 = QueryCalculationAggregation(
+            **query_calculation_aggregation_model_dict)
 
         # Verify the model instances are equivalent
         assert query_calculation_aggregation_model == query_calculation_aggregation_model2
 
         # Convert model instance back to dict and verify no loss of data
-        query_calculation_aggregation_model_json2 = query_calculation_aggregation_model.to_dict()
+        query_calculation_aggregation_model_json2 = query_calculation_aggregation_model.to_dict(
+        )
         assert query_calculation_aggregation_model_json2 == query_calculation_aggregation_model_json
+
 
 class TestModel_QueryFilterAggregation():
     """
     Test Class for QueryFilterAggregation
     """
-
     def test_query_filter_aggregation_serialization(self):
         """
         Test serialization/deserialization for QueryFilterAggregation
@@ -9029,25 +9623,29 @@ class TestModel_QueryFilterAggregation():
         query_filter_aggregation_model_json['matching_results'] = 26
 
         # Construct a model instance of QueryFilterAggregation by calling from_dict on the json representation
-        query_filter_aggregation_model = QueryFilterAggregation.from_dict(query_filter_aggregation_model_json)
+        query_filter_aggregation_model = QueryFilterAggregation.from_dict(
+            query_filter_aggregation_model_json)
         assert query_filter_aggregation_model != False
 
         # Construct a model instance of QueryFilterAggregation by calling from_dict on the json representation
-        query_filter_aggregation_model_dict = QueryFilterAggregation.from_dict(query_filter_aggregation_model_json).__dict__
-        query_filter_aggregation_model2 = QueryFilterAggregation(**query_filter_aggregation_model_dict)
+        query_filter_aggregation_model_dict = QueryFilterAggregation.from_dict(
+            query_filter_aggregation_model_json).__dict__
+        query_filter_aggregation_model2 = QueryFilterAggregation(
+            **query_filter_aggregation_model_dict)
 
         # Verify the model instances are equivalent
         assert query_filter_aggregation_model == query_filter_aggregation_model2
 
         # Convert model instance back to dict and verify no loss of data
-        query_filter_aggregation_model_json2 = query_filter_aggregation_model.to_dict()
+        query_filter_aggregation_model_json2 = query_filter_aggregation_model.to_dict(
+        )
         assert query_filter_aggregation_model_json2 == query_filter_aggregation_model_json
+
 
 class TestModel_QueryGroupByAggregation():
     """
     Test Class for QueryGroupByAggregation
     """
-
     def test_query_group_by_aggregation_serialization(self):
         """
         Test serialization/deserialization for QueryGroupByAggregation
@@ -9058,25 +9656,29 @@ class TestModel_QueryGroupByAggregation():
         query_group_by_aggregation_model_json['type'] = 'group_by'
 
         # Construct a model instance of QueryGroupByAggregation by calling from_dict on the json representation
-        query_group_by_aggregation_model = QueryGroupByAggregation.from_dict(query_group_by_aggregation_model_json)
+        query_group_by_aggregation_model = QueryGroupByAggregation.from_dict(
+            query_group_by_aggregation_model_json)
         assert query_group_by_aggregation_model != False
 
         # Construct a model instance of QueryGroupByAggregation by calling from_dict on the json representation
-        query_group_by_aggregation_model_dict = QueryGroupByAggregation.from_dict(query_group_by_aggregation_model_json).__dict__
-        query_group_by_aggregation_model2 = QueryGroupByAggregation(**query_group_by_aggregation_model_dict)
+        query_group_by_aggregation_model_dict = QueryGroupByAggregation.from_dict(
+            query_group_by_aggregation_model_json).__dict__
+        query_group_by_aggregation_model2 = QueryGroupByAggregation(
+            **query_group_by_aggregation_model_dict)
 
         # Verify the model instances are equivalent
         assert query_group_by_aggregation_model == query_group_by_aggregation_model2
 
         # Convert model instance back to dict and verify no loss of data
-        query_group_by_aggregation_model_json2 = query_group_by_aggregation_model.to_dict()
+        query_group_by_aggregation_model_json2 = query_group_by_aggregation_model.to_dict(
+        )
         assert query_group_by_aggregation_model_json2 == query_group_by_aggregation_model_json
+
 
 class TestModel_QueryHistogramAggregation():
     """
     Test Class for QueryHistogramAggregation
     """
-
     def test_query_histogram_aggregation_serialization(self):
         """
         Test serialization/deserialization for QueryHistogramAggregation
@@ -9090,25 +9692,29 @@ class TestModel_QueryHistogramAggregation():
         query_histogram_aggregation_model_json['name'] = 'testString'
 
         # Construct a model instance of QueryHistogramAggregation by calling from_dict on the json representation
-        query_histogram_aggregation_model = QueryHistogramAggregation.from_dict(query_histogram_aggregation_model_json)
+        query_histogram_aggregation_model = QueryHistogramAggregation.from_dict(
+            query_histogram_aggregation_model_json)
         assert query_histogram_aggregation_model != False
 
         # Construct a model instance of QueryHistogramAggregation by calling from_dict on the json representation
-        query_histogram_aggregation_model_dict = QueryHistogramAggregation.from_dict(query_histogram_aggregation_model_json).__dict__
-        query_histogram_aggregation_model2 = QueryHistogramAggregation(**query_histogram_aggregation_model_dict)
+        query_histogram_aggregation_model_dict = QueryHistogramAggregation.from_dict(
+            query_histogram_aggregation_model_json).__dict__
+        query_histogram_aggregation_model2 = QueryHistogramAggregation(
+            **query_histogram_aggregation_model_dict)
 
         # Verify the model instances are equivalent
         assert query_histogram_aggregation_model == query_histogram_aggregation_model2
 
         # Convert model instance back to dict and verify no loss of data
-        query_histogram_aggregation_model_json2 = query_histogram_aggregation_model.to_dict()
+        query_histogram_aggregation_model_json2 = query_histogram_aggregation_model.to_dict(
+        )
         assert query_histogram_aggregation_model_json2 == query_histogram_aggregation_model_json
+
 
 class TestModel_QueryNestedAggregation():
     """
     Test Class for QueryNestedAggregation
     """
-
     def test_query_nested_aggregation_serialization(self):
         """
         Test serialization/deserialization for QueryNestedAggregation
@@ -9121,25 +9727,29 @@ class TestModel_QueryNestedAggregation():
         query_nested_aggregation_model_json['matching_results'] = 26
 
         # Construct a model instance of QueryNestedAggregation by calling from_dict on the json representation
-        query_nested_aggregation_model = QueryNestedAggregation.from_dict(query_nested_aggregation_model_json)
+        query_nested_aggregation_model = QueryNestedAggregation.from_dict(
+            query_nested_aggregation_model_json)
         assert query_nested_aggregation_model != False
 
         # Construct a model instance of QueryNestedAggregation by calling from_dict on the json representation
-        query_nested_aggregation_model_dict = QueryNestedAggregation.from_dict(query_nested_aggregation_model_json).__dict__
-        query_nested_aggregation_model2 = QueryNestedAggregation(**query_nested_aggregation_model_dict)
+        query_nested_aggregation_model_dict = QueryNestedAggregation.from_dict(
+            query_nested_aggregation_model_json).__dict__
+        query_nested_aggregation_model2 = QueryNestedAggregation(
+            **query_nested_aggregation_model_dict)
 
         # Verify the model instances are equivalent
         assert query_nested_aggregation_model == query_nested_aggregation_model2
 
         # Convert model instance back to dict and verify no loss of data
-        query_nested_aggregation_model_json2 = query_nested_aggregation_model.to_dict()
+        query_nested_aggregation_model_json2 = query_nested_aggregation_model.to_dict(
+        )
         assert query_nested_aggregation_model_json2 == query_nested_aggregation_model_json
+
 
 class TestModel_QueryTermAggregation():
     """
     Test Class for QueryTermAggregation
     """
-
     def test_query_term_aggregation_serialization(self):
         """
         Test serialization/deserialization for QueryTermAggregation
@@ -9153,25 +9763,29 @@ class TestModel_QueryTermAggregation():
         query_term_aggregation_model_json['name'] = 'testString'
 
         # Construct a model instance of QueryTermAggregation by calling from_dict on the json representation
-        query_term_aggregation_model = QueryTermAggregation.from_dict(query_term_aggregation_model_json)
+        query_term_aggregation_model = QueryTermAggregation.from_dict(
+            query_term_aggregation_model_json)
         assert query_term_aggregation_model != False
 
         # Construct a model instance of QueryTermAggregation by calling from_dict on the json representation
-        query_term_aggregation_model_dict = QueryTermAggregation.from_dict(query_term_aggregation_model_json).__dict__
-        query_term_aggregation_model2 = QueryTermAggregation(**query_term_aggregation_model_dict)
+        query_term_aggregation_model_dict = QueryTermAggregation.from_dict(
+            query_term_aggregation_model_json).__dict__
+        query_term_aggregation_model2 = QueryTermAggregation(
+            **query_term_aggregation_model_dict)
 
         # Verify the model instances are equivalent
         assert query_term_aggregation_model == query_term_aggregation_model2
 
         # Convert model instance back to dict and verify no loss of data
-        query_term_aggregation_model_json2 = query_term_aggregation_model.to_dict()
+        query_term_aggregation_model_json2 = query_term_aggregation_model.to_dict(
+        )
         assert query_term_aggregation_model_json2 == query_term_aggregation_model_json
+
 
 class TestModel_QueryTimesliceAggregation():
     """
     Test Class for QueryTimesliceAggregation
     """
-
     def test_query_timeslice_aggregation_serialization(self):
         """
         Test serialization/deserialization for QueryTimesliceAggregation
@@ -9185,25 +9799,29 @@ class TestModel_QueryTimesliceAggregation():
         query_timeslice_aggregation_model_json['name'] = 'testString'
 
         # Construct a model instance of QueryTimesliceAggregation by calling from_dict on the json representation
-        query_timeslice_aggregation_model = QueryTimesliceAggregation.from_dict(query_timeslice_aggregation_model_json)
+        query_timeslice_aggregation_model = QueryTimesliceAggregation.from_dict(
+            query_timeslice_aggregation_model_json)
         assert query_timeslice_aggregation_model != False
 
         # Construct a model instance of QueryTimesliceAggregation by calling from_dict on the json representation
-        query_timeslice_aggregation_model_dict = QueryTimesliceAggregation.from_dict(query_timeslice_aggregation_model_json).__dict__
-        query_timeslice_aggregation_model2 = QueryTimesliceAggregation(**query_timeslice_aggregation_model_dict)
+        query_timeslice_aggregation_model_dict = QueryTimesliceAggregation.from_dict(
+            query_timeslice_aggregation_model_json).__dict__
+        query_timeslice_aggregation_model2 = QueryTimesliceAggregation(
+            **query_timeslice_aggregation_model_dict)
 
         # Verify the model instances are equivalent
         assert query_timeslice_aggregation_model == query_timeslice_aggregation_model2
 
         # Convert model instance back to dict and verify no loss of data
-        query_timeslice_aggregation_model_json2 = query_timeslice_aggregation_model.to_dict()
+        query_timeslice_aggregation_model_json2 = query_timeslice_aggregation_model.to_dict(
+        )
         assert query_timeslice_aggregation_model_json2 == query_timeslice_aggregation_model_json
+
 
 class TestModel_QueryTopHitsAggregation():
     """
     Test Class for QueryTopHitsAggregation
     """
-
     def test_query_top_hits_aggregation_serialization(self):
         """
         Test serialization/deserialization for QueryTopHitsAggregation
@@ -9211,30 +9829,38 @@ class TestModel_QueryTopHitsAggregation():
 
         # Construct dict forms of any model objects needed in order to build this model.
 
-        query_top_hits_aggregation_result_model = {} # QueryTopHitsAggregationResult
+        query_top_hits_aggregation_result_model = {
+        }  # QueryTopHitsAggregationResult
         query_top_hits_aggregation_result_model['matching_results'] = 38
-        query_top_hits_aggregation_result_model['hits'] = [{'key1': 'testString'}]
+        query_top_hits_aggregation_result_model['hits'] = [{
+            'key1': 'testString'
+        }]
 
         # Construct a json representation of a QueryTopHitsAggregation model
         query_top_hits_aggregation_model_json = {}
         query_top_hits_aggregation_model_json['type'] = 'top_hits'
         query_top_hits_aggregation_model_json['size'] = 38
         query_top_hits_aggregation_model_json['name'] = 'testString'
-        query_top_hits_aggregation_model_json['hits'] = query_top_hits_aggregation_result_model
+        query_top_hits_aggregation_model_json[
+            'hits'] = query_top_hits_aggregation_result_model
 
         # Construct a model instance of QueryTopHitsAggregation by calling from_dict on the json representation
-        query_top_hits_aggregation_model = QueryTopHitsAggregation.from_dict(query_top_hits_aggregation_model_json)
+        query_top_hits_aggregation_model = QueryTopHitsAggregation.from_dict(
+            query_top_hits_aggregation_model_json)
         assert query_top_hits_aggregation_model != False
 
         # Construct a model instance of QueryTopHitsAggregation by calling from_dict on the json representation
-        query_top_hits_aggregation_model_dict = QueryTopHitsAggregation.from_dict(query_top_hits_aggregation_model_json).__dict__
-        query_top_hits_aggregation_model2 = QueryTopHitsAggregation(**query_top_hits_aggregation_model_dict)
+        query_top_hits_aggregation_model_dict = QueryTopHitsAggregation.from_dict(
+            query_top_hits_aggregation_model_json).__dict__
+        query_top_hits_aggregation_model2 = QueryTopHitsAggregation(
+            **query_top_hits_aggregation_model_dict)
 
         # Verify the model instances are equivalent
         assert query_top_hits_aggregation_model == query_top_hits_aggregation_model2
 
         # Convert model instance back to dict and verify no loss of data
-        query_top_hits_aggregation_model_json2 = query_top_hits_aggregation_model.to_dict()
+        query_top_hits_aggregation_model_json2 = query_top_hits_aggregation_model.to_dict(
+        )
         assert query_top_hits_aggregation_model_json2 == query_top_hits_aggregation_model_json
 
 

--- a/test/unit/test_discovery_v2.py
+++ b/test/unit/test_discovery_v2.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# (C) Copyright IBM Corp. 2021.
+# (C) Copyright IBM Corp. 2022.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -36,2616 +36,37 @@ version = 'testString'
 _service = DiscoveryV2(
     authenticator=NoAuthAuthenticator(),
     version=version
-    )
+)
 
 _base_url = 'https://api.us-south.discovery.watson.cloud.ibm.com'
 _service.set_service_url(_base_url)
 
-##############################################################################
-# Start of Service: Collections
-##############################################################################
-# region
 
-class TestListCollections():
+def preprocess_url(operation_path: str):
     """
-    Test Class for list_collections
+    Returns the request url associated with the specified operation path.
+    This will be base_url concatenated with a quoted version of operation_path.
+    The returned request URL is used to register the mock response so it needs
+    to match the request URL that is formed by the requests library.
     """
+    # First, unquote the path since it might have some quoted/escaped characters in it
+    # due to how the generator inserts the operation paths into the unit test code.
+    operation_path = urllib.parse.unquote(operation_path)
+
+    # Next, quote the path using urllib so that we approximate what will
+    # happen during request processing.
+    operation_path = urllib.parse.quote(operation_path, safe='/')
+
+    # Finally, form the request URL from the base URL and operation path.
+    request_url = _base_url + operation_path
+
+    # If the request url does NOT end with a /, then just return it as-is.
+    # Otherwise, return a regular expression that matches one or more trailing /.
+    if re.fullmatch('.*/+', request_url) is None:
+        return request_url
+    else:
+        return re.compile(request_url.rstrip('/') + '/+')
 
-    def preprocess_url(self, request_url: str):
-        """
-        Preprocess the request URL to ensure the mock response will be found.
-        """
-        request_url = urllib.parse.unquote(request_url) # don't double-encode if already encoded
-        request_url = urllib.parse.quote(request_url, safe=':/')
-        if re.fullmatch('.*/+', request_url) is None:
-            return request_url
-        else:
-            return re.compile(request_url.rstrip('/') + '/+')
-
-    @responses.activate
-    def test_list_collections_all_params(self):
-        """
-        list_collections()
-        """
-        # Set up mock
-        url = self.preprocess_url(_base_url + '/v2/projects/testString/collections')
-        mock_response = '{"collections": [{"collection_id": "collection_id", "name": "name"}]}'
-        responses.add(responses.GET,
-                      url,
-                      body=mock_response,
-                      content_type='application/json',
-                      status=200)
-
-        # Set up parameter values
-        project_id = 'testString'
-
-        # Invoke method
-        response = _service.list_collections(
-            project_id,
-            headers={}
-        )
-
-        # Check for correct operation
-        assert len(responses.calls) == 1
-        assert response.status_code == 200
-
-
-    @responses.activate
-    def test_list_collections_value_error(self):
-        """
-        test_list_collections_value_error()
-        """
-        # Set up mock
-        url = self.preprocess_url(_base_url + '/v2/projects/testString/collections')
-        mock_response = '{"collections": [{"collection_id": "collection_id", "name": "name"}]}'
-        responses.add(responses.GET,
-                      url,
-                      body=mock_response,
-                      content_type='application/json',
-                      status=200)
-
-        # Set up parameter values
-        project_id = 'testString'
-
-        # Pass in all but one required param and check for a ValueError
-        req_param_dict = {
-            "project_id": project_id,
-        }
-        for param in req_param_dict.keys():
-            req_copy = {key:val if key is not param else None for (key,val) in req_param_dict.items()}
-            with pytest.raises(ValueError):
-                _service.list_collections(**req_copy)
-
-
-
-class TestCreateCollection():
-    """
-    Test Class for create_collection
-    """
-
-    def preprocess_url(self, request_url: str):
-        """
-        Preprocess the request URL to ensure the mock response will be found.
-        """
-        request_url = urllib.parse.unquote(request_url) # don't double-encode if already encoded
-        request_url = urllib.parse.quote(request_url, safe=':/')
-        if re.fullmatch('.*/+', request_url) is None:
-            return request_url
-        else:
-            return re.compile(request_url.rstrip('/') + '/+')
-
-    @responses.activate
-    def test_create_collection_all_params(self):
-        """
-        create_collection()
-        """
-        # Set up mock
-        url = self.preprocess_url(_base_url + '/v2/projects/testString/collections')
-        mock_response = '{"collection_id": "collection_id", "name": "name", "description": "description", "created": "2019-01-01T12:00:00.000Z", "language": "en", "enrichments": [{"enrichment_id": "enrichment_id", "fields": ["fields"]}]}'
-        responses.add(responses.POST,
-                      url,
-                      body=mock_response,
-                      content_type='application/json',
-                      status=200)
-
-        # Construct a dict representation of a CollectionEnrichment model
-        collection_enrichment_model = {}
-        collection_enrichment_model['enrichment_id'] = 'testString'
-        collection_enrichment_model['fields'] = ['testString']
-
-        # Set up parameter values
-        project_id = 'testString'
-        name = 'testString'
-        description = 'testString'
-        language = 'en'
-        enrichments = [collection_enrichment_model]
-
-        # Invoke method
-        response = _service.create_collection(
-            project_id,
-            name,
-            description=description,
-            language=language,
-            enrichments=enrichments,
-            headers={}
-        )
-
-        # Check for correct operation
-        assert len(responses.calls) == 1
-        assert response.status_code == 200
-        # Validate body params
-        req_body = json.loads(str(responses.calls[0].request.body, 'utf-8'))
-        assert req_body['name'] == 'testString'
-        assert req_body['description'] == 'testString'
-        assert req_body['language'] == 'en'
-        assert req_body['enrichments'] == [collection_enrichment_model]
-
-
-    @responses.activate
-    def test_create_collection_value_error(self):
-        """
-        test_create_collection_value_error()
-        """
-        # Set up mock
-        url = self.preprocess_url(_base_url + '/v2/projects/testString/collections')
-        mock_response = '{"collection_id": "collection_id", "name": "name", "description": "description", "created": "2019-01-01T12:00:00.000Z", "language": "en", "enrichments": [{"enrichment_id": "enrichment_id", "fields": ["fields"]}]}'
-        responses.add(responses.POST,
-                      url,
-                      body=mock_response,
-                      content_type='application/json',
-                      status=200)
-
-        # Construct a dict representation of a CollectionEnrichment model
-        collection_enrichment_model = {}
-        collection_enrichment_model['enrichment_id'] = 'testString'
-        collection_enrichment_model['fields'] = ['testString']
-
-        # Set up parameter values
-        project_id = 'testString'
-        name = 'testString'
-        description = 'testString'
-        language = 'en'
-        enrichments = [collection_enrichment_model]
-
-        # Pass in all but one required param and check for a ValueError
-        req_param_dict = {
-            "project_id": project_id,
-            "name": name,
-        }
-        for param in req_param_dict.keys():
-            req_copy = {key:val if key is not param else None for (key,val) in req_param_dict.items()}
-            with pytest.raises(ValueError):
-                _service.create_collection(**req_copy)
-
-
-
-class TestGetCollection():
-    """
-    Test Class for get_collection
-    """
-
-    def preprocess_url(self, request_url: str):
-        """
-        Preprocess the request URL to ensure the mock response will be found.
-        """
-        request_url = urllib.parse.unquote(request_url) # don't double-encode if already encoded
-        request_url = urllib.parse.quote(request_url, safe=':/')
-        if re.fullmatch('.*/+', request_url) is None:
-            return request_url
-        else:
-            return re.compile(request_url.rstrip('/') + '/+')
-
-    @responses.activate
-    def test_get_collection_all_params(self):
-        """
-        get_collection()
-        """
-        # Set up mock
-        url = self.preprocess_url(_base_url + '/v2/projects/testString/collections/testString')
-        mock_response = '{"collection_id": "collection_id", "name": "name", "description": "description", "created": "2019-01-01T12:00:00.000Z", "language": "en", "enrichments": [{"enrichment_id": "enrichment_id", "fields": ["fields"]}]}'
-        responses.add(responses.GET,
-                      url,
-                      body=mock_response,
-                      content_type='application/json',
-                      status=200)
-
-        # Set up parameter values
-        project_id = 'testString'
-        collection_id = 'testString'
-
-        # Invoke method
-        response = _service.get_collection(
-            project_id,
-            collection_id,
-            headers={}
-        )
-
-        # Check for correct operation
-        assert len(responses.calls) == 1
-        assert response.status_code == 200
-
-
-    @responses.activate
-    def test_get_collection_value_error(self):
-        """
-        test_get_collection_value_error()
-        """
-        # Set up mock
-        url = self.preprocess_url(_base_url + '/v2/projects/testString/collections/testString')
-        mock_response = '{"collection_id": "collection_id", "name": "name", "description": "description", "created": "2019-01-01T12:00:00.000Z", "language": "en", "enrichments": [{"enrichment_id": "enrichment_id", "fields": ["fields"]}]}'
-        responses.add(responses.GET,
-                      url,
-                      body=mock_response,
-                      content_type='application/json',
-                      status=200)
-
-        # Set up parameter values
-        project_id = 'testString'
-        collection_id = 'testString'
-
-        # Pass in all but one required param and check for a ValueError
-        req_param_dict = {
-            "project_id": project_id,
-            "collection_id": collection_id,
-        }
-        for param in req_param_dict.keys():
-            req_copy = {key:val if key is not param else None for (key,val) in req_param_dict.items()}
-            with pytest.raises(ValueError):
-                _service.get_collection(**req_copy)
-
-
-
-class TestUpdateCollection():
-    """
-    Test Class for update_collection
-    """
-
-    def preprocess_url(self, request_url: str):
-        """
-        Preprocess the request URL to ensure the mock response will be found.
-        """
-        request_url = urllib.parse.unquote(request_url) # don't double-encode if already encoded
-        request_url = urllib.parse.quote(request_url, safe=':/')
-        if re.fullmatch('.*/+', request_url) is None:
-            return request_url
-        else:
-            return re.compile(request_url.rstrip('/') + '/+')
-
-    @responses.activate
-    def test_update_collection_all_params(self):
-        """
-        update_collection()
-        """
-        # Set up mock
-        url = self.preprocess_url(_base_url + '/v2/projects/testString/collections/testString')
-        mock_response = '{"collection_id": "collection_id", "name": "name", "description": "description", "created": "2019-01-01T12:00:00.000Z", "language": "en", "enrichments": [{"enrichment_id": "enrichment_id", "fields": ["fields"]}]}'
-        responses.add(responses.POST,
-                      url,
-                      body=mock_response,
-                      content_type='application/json',
-                      status=200)
-
-        # Construct a dict representation of a CollectionEnrichment model
-        collection_enrichment_model = {}
-        collection_enrichment_model['enrichment_id'] = 'testString'
-        collection_enrichment_model['fields'] = ['testString']
-
-        # Set up parameter values
-        project_id = 'testString'
-        collection_id = 'testString'
-        name = 'testString'
-        description = 'testString'
-        enrichments = [collection_enrichment_model]
-
-        # Invoke method
-        response = _service.update_collection(
-            project_id,
-            collection_id,
-            name=name,
-            description=description,
-            enrichments=enrichments,
-            headers={}
-        )
-
-        # Check for correct operation
-        assert len(responses.calls) == 1
-        assert response.status_code == 200
-        # Validate body params
-        req_body = json.loads(str(responses.calls[0].request.body, 'utf-8'))
-        assert req_body['name'] == 'testString'
-        assert req_body['description'] == 'testString'
-        assert req_body['enrichments'] == [collection_enrichment_model]
-
-
-    @responses.activate
-    def test_update_collection_value_error(self):
-        """
-        test_update_collection_value_error()
-        """
-        # Set up mock
-        url = self.preprocess_url(_base_url + '/v2/projects/testString/collections/testString')
-        mock_response = '{"collection_id": "collection_id", "name": "name", "description": "description", "created": "2019-01-01T12:00:00.000Z", "language": "en", "enrichments": [{"enrichment_id": "enrichment_id", "fields": ["fields"]}]}'
-        responses.add(responses.POST,
-                      url,
-                      body=mock_response,
-                      content_type='application/json',
-                      status=200)
-
-        # Construct a dict representation of a CollectionEnrichment model
-        collection_enrichment_model = {}
-        collection_enrichment_model['enrichment_id'] = 'testString'
-        collection_enrichment_model['fields'] = ['testString']
-
-        # Set up parameter values
-        project_id = 'testString'
-        collection_id = 'testString'
-        name = 'testString'
-        description = 'testString'
-        enrichments = [collection_enrichment_model]
-
-        # Pass in all but one required param and check for a ValueError
-        req_param_dict = {
-            "project_id": project_id,
-            "collection_id": collection_id,
-        }
-        for param in req_param_dict.keys():
-            req_copy = {key:val if key is not param else None for (key,val) in req_param_dict.items()}
-            with pytest.raises(ValueError):
-                _service.update_collection(**req_copy)
-
-
-
-class TestDeleteCollection():
-    """
-    Test Class for delete_collection
-    """
-
-    def preprocess_url(self, request_url: str):
-        """
-        Preprocess the request URL to ensure the mock response will be found.
-        """
-        request_url = urllib.parse.unquote(request_url) # don't double-encode if already encoded
-        request_url = urllib.parse.quote(request_url, safe=':/')
-        if re.fullmatch('.*/+', request_url) is None:
-            return request_url
-        else:
-            return re.compile(request_url.rstrip('/') + '/+')
-
-    @responses.activate
-    def test_delete_collection_all_params(self):
-        """
-        delete_collection()
-        """
-        # Set up mock
-        url = self.preprocess_url(_base_url + '/v2/projects/testString/collections/testString')
-        responses.add(responses.DELETE,
-                      url,
-                      status=204)
-
-        # Set up parameter values
-        project_id = 'testString'
-        collection_id = 'testString'
-
-        # Invoke method
-        response = _service.delete_collection(
-            project_id,
-            collection_id,
-            headers={}
-        )
-
-        # Check for correct operation
-        assert len(responses.calls) == 1
-        assert response.status_code == 204
-
-
-    @responses.activate
-    def test_delete_collection_value_error(self):
-        """
-        test_delete_collection_value_error()
-        """
-        # Set up mock
-        url = self.preprocess_url(_base_url + '/v2/projects/testString/collections/testString')
-        responses.add(responses.DELETE,
-                      url,
-                      status=204)
-
-        # Set up parameter values
-        project_id = 'testString'
-        collection_id = 'testString'
-
-        # Pass in all but one required param and check for a ValueError
-        req_param_dict = {
-            "project_id": project_id,
-            "collection_id": collection_id,
-        }
-        for param in req_param_dict.keys():
-            req_copy = {key:val if key is not param else None for (key,val) in req_param_dict.items()}
-            with pytest.raises(ValueError):
-                _service.delete_collection(**req_copy)
-
-
-
-# endregion
-##############################################################################
-# End of Service: Collections
-##############################################################################
-
-##############################################################################
-# Start of Service: Queries
-##############################################################################
-# region
-
-class TestQuery():
-    """
-    Test Class for query
-    """
-
-    def preprocess_url(self, request_url: str):
-        """
-        Preprocess the request URL to ensure the mock response will be found.
-        """
-        request_url = urllib.parse.unquote(request_url) # don't double-encode if already encoded
-        request_url = urllib.parse.quote(request_url, safe=':/')
-        if re.fullmatch('.*/+', request_url) is None:
-            return request_url
-        else:
-            return re.compile(request_url.rstrip('/') + '/+')
-
-    @responses.activate
-    def test_query_all_params(self):
-        """
-        query()
-        """
-        # Set up mock
-        url = self.preprocess_url(_base_url + '/v2/projects/testString/query')
-        mock_response = '{"matching_results": 16, "results": [{"document_id": "document_id", "metadata": {"mapKey": "anyValue"}, "result_metadata": {"document_retrieval_source": "search", "collection_id": "collection_id", "confidence": 10}, "document_passages": [{"passage_text": "passage_text", "start_offset": 12, "end_offset": 10, "field": "field", "confidence": 0, "answers": [{"answer_text": "answer_text", "start_offset": 12, "end_offset": 10, "confidence": 0}]}]}], "aggregations": [{"type": "filter", "match": "match", "matching_results": 16}], "retrieval_details": {"document_retrieval_strategy": "untrained"}, "suggested_query": "suggested_query", "suggested_refinements": [{"text": "text"}], "table_results": [{"table_id": "table_id", "source_document_id": "source_document_id", "collection_id": "collection_id", "table_html": "table_html", "table_html_offset": 17, "table": {"location": {"begin": 5, "end": 3}, "text": "text", "section_title": {"text": "text", "location": {"begin": 5, "end": 3}}, "title": {"text": "text", "location": {"begin": 5, "end": 3}}, "table_headers": [{"cell_id": "cell_id", "location": {"anyKey": "anyValue"}, "text": "text", "row_index_begin": 15, "row_index_end": 13, "column_index_begin": 18, "column_index_end": 16}], "row_headers": [{"cell_id": "cell_id", "location": {"begin": 5, "end": 3}, "text": "text", "text_normalized": "text_normalized", "row_index_begin": 15, "row_index_end": 13, "column_index_begin": 18, "column_index_end": 16}], "column_headers": [{"cell_id": "cell_id", "location": {"anyKey": "anyValue"}, "text": "text", "text_normalized": "text_normalized", "row_index_begin": 15, "row_index_end": 13, "column_index_begin": 18, "column_index_end": 16}], "key_value_pairs": [{"key": {"cell_id": "cell_id", "location": {"begin": 5, "end": 3}, "text": "text"}, "value": [{"cell_id": "cell_id", "location": {"begin": 5, "end": 3}, "text": "text"}]}], "body_cells": [{"cell_id": "cell_id", "location": {"begin": 5, "end": 3}, "text": "text", "row_index_begin": 15, "row_index_end": 13, "column_index_begin": 18, "column_index_end": 16, "row_header_ids": [{"id": "id"}], "row_header_texts": [{"text": "text"}], "row_header_texts_normalized": [{"text_normalized": "text_normalized"}], "column_header_ids": [{"id": "id"}], "column_header_texts": [{"text": "text"}], "column_header_texts_normalized": [{"text_normalized": "text_normalized"}], "attributes": [{"type": "type", "text": "text", "location": {"begin": 5, "end": 3}}]}], "contexts": [{"text": "text", "location": {"begin": 5, "end": 3}}]}}], "passages": [{"passage_text": "passage_text", "passage_score": 13, "document_id": "document_id", "collection_id": "collection_id", "start_offset": 12, "end_offset": 10, "field": "field", "confidence": 0, "answers": [{"answer_text": "answer_text", "start_offset": 12, "end_offset": 10, "confidence": 0}]}]}'
-        responses.add(responses.POST,
-                      url,
-                      body=mock_response,
-                      content_type='application/json',
-                      status=200)
-
-        # Construct a dict representation of a QueryLargeTableResults model
-        query_large_table_results_model = {}
-        query_large_table_results_model['enabled'] = True
-        query_large_table_results_model['count'] = 38
-
-        # Construct a dict representation of a QueryLargeSuggestedRefinements model
-        query_large_suggested_refinements_model = {}
-        query_large_suggested_refinements_model['enabled'] = True
-        query_large_suggested_refinements_model['count'] = 1
-
-        # Construct a dict representation of a QueryLargePassages model
-        query_large_passages_model = {}
-        query_large_passages_model['enabled'] = True
-        query_large_passages_model['per_document'] = True
-        query_large_passages_model['max_per_document'] = 38
-        query_large_passages_model['fields'] = ['testString']
-        query_large_passages_model['count'] = 400
-        query_large_passages_model['characters'] = 50
-        query_large_passages_model['find_answers'] = False
-        query_large_passages_model['max_answers_per_passage'] = 38
-
-        # Set up parameter values
-        project_id = 'testString'
-        collection_ids = ['testString']
-        filter = 'testString'
-        query = 'testString'
-        natural_language_query = 'testString'
-        aggregation = 'testString'
-        count = 38
-        return_ = ['testString']
-        offset = 38
-        sort = 'testString'
-        highlight = True
-        spelling_suggestions = True
-        table_results = query_large_table_results_model
-        suggested_refinements = query_large_suggested_refinements_model
-        passages = query_large_passages_model
-
-        # Invoke method
-        response = _service.query(
-            project_id,
-            collection_ids=collection_ids,
-            filter=filter,
-            query=query,
-            natural_language_query=natural_language_query,
-            aggregation=aggregation,
-            count=count,
-            return_=return_,
-            offset=offset,
-            sort=sort,
-            highlight=highlight,
-            spelling_suggestions=spelling_suggestions,
-            table_results=table_results,
-            suggested_refinements=suggested_refinements,
-            passages=passages,
-            headers={}
-        )
-
-        # Check for correct operation
-        assert len(responses.calls) == 1
-        assert response.status_code == 200
-        # Validate body params
-        req_body = json.loads(str(responses.calls[0].request.body, 'utf-8'))
-        assert req_body['collection_ids'] == ['testString']
-        assert req_body['filter'] == 'testString'
-        assert req_body['query'] == 'testString'
-        assert req_body['natural_language_query'] == 'testString'
-        assert req_body['aggregation'] == 'testString'
-        assert req_body['count'] == 38
-        assert req_body['return'] == ['testString']
-        assert req_body['offset'] == 38
-        assert req_body['sort'] == 'testString'
-        assert req_body['highlight'] == True
-        assert req_body['spelling_suggestions'] == True
-        assert req_body['table_results'] == query_large_table_results_model
-        assert req_body['suggested_refinements'] == query_large_suggested_refinements_model
-        assert req_body['passages'] == query_large_passages_model
-
-
-    @responses.activate
-    def test_query_required_params(self):
-        """
-        test_query_required_params()
-        """
-        # Set up mock
-        url = self.preprocess_url(_base_url + '/v2/projects/testString/query')
-        mock_response = '{"matching_results": 16, "results": [{"document_id": "document_id", "metadata": {"mapKey": "anyValue"}, "result_metadata": {"document_retrieval_source": "search", "collection_id": "collection_id", "confidence": 10}, "document_passages": [{"passage_text": "passage_text", "start_offset": 12, "end_offset": 10, "field": "field", "confidence": 0, "answers": [{"answer_text": "answer_text", "start_offset": 12, "end_offset": 10, "confidence": 0}]}]}], "aggregations": [{"type": "filter", "match": "match", "matching_results": 16}], "retrieval_details": {"document_retrieval_strategy": "untrained"}, "suggested_query": "suggested_query", "suggested_refinements": [{"text": "text"}], "table_results": [{"table_id": "table_id", "source_document_id": "source_document_id", "collection_id": "collection_id", "table_html": "table_html", "table_html_offset": 17, "table": {"location": {"begin": 5, "end": 3}, "text": "text", "section_title": {"text": "text", "location": {"begin": 5, "end": 3}}, "title": {"text": "text", "location": {"begin": 5, "end": 3}}, "table_headers": [{"cell_id": "cell_id", "location": {"anyKey": "anyValue"}, "text": "text", "row_index_begin": 15, "row_index_end": 13, "column_index_begin": 18, "column_index_end": 16}], "row_headers": [{"cell_id": "cell_id", "location": {"begin": 5, "end": 3}, "text": "text", "text_normalized": "text_normalized", "row_index_begin": 15, "row_index_end": 13, "column_index_begin": 18, "column_index_end": 16}], "column_headers": [{"cell_id": "cell_id", "location": {"anyKey": "anyValue"}, "text": "text", "text_normalized": "text_normalized", "row_index_begin": 15, "row_index_end": 13, "column_index_begin": 18, "column_index_end": 16}], "key_value_pairs": [{"key": {"cell_id": "cell_id", "location": {"begin": 5, "end": 3}, "text": "text"}, "value": [{"cell_id": "cell_id", "location": {"begin": 5, "end": 3}, "text": "text"}]}], "body_cells": [{"cell_id": "cell_id", "location": {"begin": 5, "end": 3}, "text": "text", "row_index_begin": 15, "row_index_end": 13, "column_index_begin": 18, "column_index_end": 16, "row_header_ids": [{"id": "id"}], "row_header_texts": [{"text": "text"}], "row_header_texts_normalized": [{"text_normalized": "text_normalized"}], "column_header_ids": [{"id": "id"}], "column_header_texts": [{"text": "text"}], "column_header_texts_normalized": [{"text_normalized": "text_normalized"}], "attributes": [{"type": "type", "text": "text", "location": {"begin": 5, "end": 3}}]}], "contexts": [{"text": "text", "location": {"begin": 5, "end": 3}}]}}], "passages": [{"passage_text": "passage_text", "passage_score": 13, "document_id": "document_id", "collection_id": "collection_id", "start_offset": 12, "end_offset": 10, "field": "field", "confidence": 0, "answers": [{"answer_text": "answer_text", "start_offset": 12, "end_offset": 10, "confidence": 0}]}]}'
-        responses.add(responses.POST,
-                      url,
-                      body=mock_response,
-                      content_type='application/json',
-                      status=200)
-
-        # Set up parameter values
-        project_id = 'testString'
-
-        # Invoke method
-        response = _service.query(
-            project_id,
-            headers={}
-        )
-
-        # Check for correct operation
-        assert len(responses.calls) == 1
-        assert response.status_code == 200
-
-
-    @responses.activate
-    def test_query_value_error(self):
-        """
-        test_query_value_error()
-        """
-        # Set up mock
-        url = self.preprocess_url(_base_url + '/v2/projects/testString/query')
-        mock_response = '{"matching_results": 16, "results": [{"document_id": "document_id", "metadata": {"mapKey": "anyValue"}, "result_metadata": {"document_retrieval_source": "search", "collection_id": "collection_id", "confidence": 10}, "document_passages": [{"passage_text": "passage_text", "start_offset": 12, "end_offset": 10, "field": "field", "confidence": 0, "answers": [{"answer_text": "answer_text", "start_offset": 12, "end_offset": 10, "confidence": 0}]}]}], "aggregations": [{"type": "filter", "match": "match", "matching_results": 16}], "retrieval_details": {"document_retrieval_strategy": "untrained"}, "suggested_query": "suggested_query", "suggested_refinements": [{"text": "text"}], "table_results": [{"table_id": "table_id", "source_document_id": "source_document_id", "collection_id": "collection_id", "table_html": "table_html", "table_html_offset": 17, "table": {"location": {"begin": 5, "end": 3}, "text": "text", "section_title": {"text": "text", "location": {"begin": 5, "end": 3}}, "title": {"text": "text", "location": {"begin": 5, "end": 3}}, "table_headers": [{"cell_id": "cell_id", "location": {"anyKey": "anyValue"}, "text": "text", "row_index_begin": 15, "row_index_end": 13, "column_index_begin": 18, "column_index_end": 16}], "row_headers": [{"cell_id": "cell_id", "location": {"begin": 5, "end": 3}, "text": "text", "text_normalized": "text_normalized", "row_index_begin": 15, "row_index_end": 13, "column_index_begin": 18, "column_index_end": 16}], "column_headers": [{"cell_id": "cell_id", "location": {"anyKey": "anyValue"}, "text": "text", "text_normalized": "text_normalized", "row_index_begin": 15, "row_index_end": 13, "column_index_begin": 18, "column_index_end": 16}], "key_value_pairs": [{"key": {"cell_id": "cell_id", "location": {"begin": 5, "end": 3}, "text": "text"}, "value": [{"cell_id": "cell_id", "location": {"begin": 5, "end": 3}, "text": "text"}]}], "body_cells": [{"cell_id": "cell_id", "location": {"begin": 5, "end": 3}, "text": "text", "row_index_begin": 15, "row_index_end": 13, "column_index_begin": 18, "column_index_end": 16, "row_header_ids": [{"id": "id"}], "row_header_texts": [{"text": "text"}], "row_header_texts_normalized": [{"text_normalized": "text_normalized"}], "column_header_ids": [{"id": "id"}], "column_header_texts": [{"text": "text"}], "column_header_texts_normalized": [{"text_normalized": "text_normalized"}], "attributes": [{"type": "type", "text": "text", "location": {"begin": 5, "end": 3}}]}], "contexts": [{"text": "text", "location": {"begin": 5, "end": 3}}]}}], "passages": [{"passage_text": "passage_text", "passage_score": 13, "document_id": "document_id", "collection_id": "collection_id", "start_offset": 12, "end_offset": 10, "field": "field", "confidence": 0, "answers": [{"answer_text": "answer_text", "start_offset": 12, "end_offset": 10, "confidence": 0}]}]}'
-        responses.add(responses.POST,
-                      url,
-                      body=mock_response,
-                      content_type='application/json',
-                      status=200)
-
-        # Set up parameter values
-        project_id = 'testString'
-
-        # Pass in all but one required param and check for a ValueError
-        req_param_dict = {
-            "project_id": project_id,
-        }
-        for param in req_param_dict.keys():
-            req_copy = {key:val if key is not param else None for (key,val) in req_param_dict.items()}
-            with pytest.raises(ValueError):
-                _service.query(**req_copy)
-
-
-
-class TestGetAutocompletion():
-    """
-    Test Class for get_autocompletion
-    """
-
-    def preprocess_url(self, request_url: str):
-        """
-        Preprocess the request URL to ensure the mock response will be found.
-        """
-        request_url = urllib.parse.unquote(request_url) # don't double-encode if already encoded
-        request_url = urllib.parse.quote(request_url, safe=':/')
-        if re.fullmatch('.*/+', request_url) is None:
-            return request_url
-        else:
-            return re.compile(request_url.rstrip('/') + '/+')
-
-    @responses.activate
-    def test_get_autocompletion_all_params(self):
-        """
-        get_autocompletion()
-        """
-        # Set up mock
-        url = self.preprocess_url(_base_url + '/v2/projects/testString/autocompletion')
-        mock_response = '{"completions": ["completions"]}'
-        responses.add(responses.GET,
-                      url,
-                      body=mock_response,
-                      content_type='application/json',
-                      status=200)
-
-        # Set up parameter values
-        project_id = 'testString'
-        prefix = 'testString'
-        collection_ids = ['testString']
-        field = 'testString'
-        count = 38
-
-        # Invoke method
-        response = _service.get_autocompletion(
-            project_id,
-            prefix,
-            collection_ids=collection_ids,
-            field=field,
-            count=count,
-            headers={}
-        )
-
-        # Check for correct operation
-        assert len(responses.calls) == 1
-        assert response.status_code == 200
-        # Validate query params
-        query_string = responses.calls[0].request.url.split('?',1)[1]
-        query_string = urllib.parse.unquote_plus(query_string)
-        assert 'prefix={}'.format(prefix) in query_string
-        assert 'collection_ids={}'.format(','.join(collection_ids)) in query_string
-        assert 'field={}'.format(field) in query_string
-        assert 'count={}'.format(count) in query_string
-
-
-    @responses.activate
-    def test_get_autocompletion_required_params(self):
-        """
-        test_get_autocompletion_required_params()
-        """
-        # Set up mock
-        url = self.preprocess_url(_base_url + '/v2/projects/testString/autocompletion')
-        mock_response = '{"completions": ["completions"]}'
-        responses.add(responses.GET,
-                      url,
-                      body=mock_response,
-                      content_type='application/json',
-                      status=200)
-
-        # Set up parameter values
-        project_id = 'testString'
-        prefix = 'testString'
-
-        # Invoke method
-        response = _service.get_autocompletion(
-            project_id,
-            prefix,
-            headers={}
-        )
-
-        # Check for correct operation
-        assert len(responses.calls) == 1
-        assert response.status_code == 200
-        # Validate query params
-        query_string = responses.calls[0].request.url.split('?',1)[1]
-        query_string = urllib.parse.unquote_plus(query_string)
-        assert 'prefix={}'.format(prefix) in query_string
-
-
-    @responses.activate
-    def test_get_autocompletion_value_error(self):
-        """
-        test_get_autocompletion_value_error()
-        """
-        # Set up mock
-        url = self.preprocess_url(_base_url + '/v2/projects/testString/autocompletion')
-        mock_response = '{"completions": ["completions"]}'
-        responses.add(responses.GET,
-                      url,
-                      body=mock_response,
-                      content_type='application/json',
-                      status=200)
-
-        # Set up parameter values
-        project_id = 'testString'
-        prefix = 'testString'
-
-        # Pass in all but one required param and check for a ValueError
-        req_param_dict = {
-            "project_id": project_id,
-            "prefix": prefix,
-        }
-        for param in req_param_dict.keys():
-            req_copy = {key:val if key is not param else None for (key,val) in req_param_dict.items()}
-            with pytest.raises(ValueError):
-                _service.get_autocompletion(**req_copy)
-
-
-
-class TestQueryCollectionNotices():
-    """
-    Test Class for query_collection_notices
-    """
-
-    def preprocess_url(self, request_url: str):
-        """
-        Preprocess the request URL to ensure the mock response will be found.
-        """
-        request_url = urllib.parse.unquote(request_url) # don't double-encode if already encoded
-        request_url = urllib.parse.quote(request_url, safe=':/')
-        if re.fullmatch('.*/+', request_url) is None:
-            return request_url
-        else:
-            return re.compile(request_url.rstrip('/') + '/+')
-
-    @responses.activate
-    def test_query_collection_notices_all_params(self):
-        """
-        query_collection_notices()
-        """
-        # Set up mock
-        url = self.preprocess_url(_base_url + '/v2/projects/testString/collections/testString/notices')
-        mock_response = '{"matching_results": 16, "notices": [{"notice_id": "notice_id", "created": "2019-01-01T12:00:00.000Z", "document_id": "document_id", "collection_id": "collection_id", "query_id": "query_id", "severity": "warning", "step": "step", "description": "description"}]}'
-        responses.add(responses.GET,
-                      url,
-                      body=mock_response,
-                      content_type='application/json',
-                      status=200)
-
-        # Set up parameter values
-        project_id = 'testString'
-        collection_id = 'testString'
-        filter = 'testString'
-        query = 'testString'
-        natural_language_query = 'testString'
-        count = 38
-        offset = 38
-
-        # Invoke method
-        response = _service.query_collection_notices(
-            project_id,
-            collection_id,
-            filter=filter,
-            query=query,
-            natural_language_query=natural_language_query,
-            count=count,
-            offset=offset,
-            headers={}
-        )
-
-        # Check for correct operation
-        assert len(responses.calls) == 1
-        assert response.status_code == 200
-        # Validate query params
-        query_string = responses.calls[0].request.url.split('?',1)[1]
-        query_string = urllib.parse.unquote_plus(query_string)
-        assert 'filter={}'.format(filter) in query_string
-        assert 'query={}'.format(query) in query_string
-        assert 'natural_language_query={}'.format(natural_language_query) in query_string
-        assert 'count={}'.format(count) in query_string
-        assert 'offset={}'.format(offset) in query_string
-
-
-    @responses.activate
-    def test_query_collection_notices_required_params(self):
-        """
-        test_query_collection_notices_required_params()
-        """
-        # Set up mock
-        url = self.preprocess_url(_base_url + '/v2/projects/testString/collections/testString/notices')
-        mock_response = '{"matching_results": 16, "notices": [{"notice_id": "notice_id", "created": "2019-01-01T12:00:00.000Z", "document_id": "document_id", "collection_id": "collection_id", "query_id": "query_id", "severity": "warning", "step": "step", "description": "description"}]}'
-        responses.add(responses.GET,
-                      url,
-                      body=mock_response,
-                      content_type='application/json',
-                      status=200)
-
-        # Set up parameter values
-        project_id = 'testString'
-        collection_id = 'testString'
-
-        # Invoke method
-        response = _service.query_collection_notices(
-            project_id,
-            collection_id,
-            headers={}
-        )
-
-        # Check for correct operation
-        assert len(responses.calls) == 1
-        assert response.status_code == 200
-
-
-    @responses.activate
-    def test_query_collection_notices_value_error(self):
-        """
-        test_query_collection_notices_value_error()
-        """
-        # Set up mock
-        url = self.preprocess_url(_base_url + '/v2/projects/testString/collections/testString/notices')
-        mock_response = '{"matching_results": 16, "notices": [{"notice_id": "notice_id", "created": "2019-01-01T12:00:00.000Z", "document_id": "document_id", "collection_id": "collection_id", "query_id": "query_id", "severity": "warning", "step": "step", "description": "description"}]}'
-        responses.add(responses.GET,
-                      url,
-                      body=mock_response,
-                      content_type='application/json',
-                      status=200)
-
-        # Set up parameter values
-        project_id = 'testString'
-        collection_id = 'testString'
-
-        # Pass in all but one required param and check for a ValueError
-        req_param_dict = {
-            "project_id": project_id,
-            "collection_id": collection_id,
-        }
-        for param in req_param_dict.keys():
-            req_copy = {key:val if key is not param else None for (key,val) in req_param_dict.items()}
-            with pytest.raises(ValueError):
-                _service.query_collection_notices(**req_copy)
-
-
-
-class TestQueryNotices():
-    """
-    Test Class for query_notices
-    """
-
-    def preprocess_url(self, request_url: str):
-        """
-        Preprocess the request URL to ensure the mock response will be found.
-        """
-        request_url = urllib.parse.unquote(request_url) # don't double-encode if already encoded
-        request_url = urllib.parse.quote(request_url, safe=':/')
-        if re.fullmatch('.*/+', request_url) is None:
-            return request_url
-        else:
-            return re.compile(request_url.rstrip('/') + '/+')
-
-    @responses.activate
-    def test_query_notices_all_params(self):
-        """
-        query_notices()
-        """
-        # Set up mock
-        url = self.preprocess_url(_base_url + '/v2/projects/testString/notices')
-        mock_response = '{"matching_results": 16, "notices": [{"notice_id": "notice_id", "created": "2019-01-01T12:00:00.000Z", "document_id": "document_id", "collection_id": "collection_id", "query_id": "query_id", "severity": "warning", "step": "step", "description": "description"}]}'
-        responses.add(responses.GET,
-                      url,
-                      body=mock_response,
-                      content_type='application/json',
-                      status=200)
-
-        # Set up parameter values
-        project_id = 'testString'
-        filter = 'testString'
-        query = 'testString'
-        natural_language_query = 'testString'
-        count = 38
-        offset = 38
-
-        # Invoke method
-        response = _service.query_notices(
-            project_id,
-            filter=filter,
-            query=query,
-            natural_language_query=natural_language_query,
-            count=count,
-            offset=offset,
-            headers={}
-        )
-
-        # Check for correct operation
-        assert len(responses.calls) == 1
-        assert response.status_code == 200
-        # Validate query params
-        query_string = responses.calls[0].request.url.split('?',1)[1]
-        query_string = urllib.parse.unquote_plus(query_string)
-        assert 'filter={}'.format(filter) in query_string
-        assert 'query={}'.format(query) in query_string
-        assert 'natural_language_query={}'.format(natural_language_query) in query_string
-        assert 'count={}'.format(count) in query_string
-        assert 'offset={}'.format(offset) in query_string
-
-
-    @responses.activate
-    def test_query_notices_required_params(self):
-        """
-        test_query_notices_required_params()
-        """
-        # Set up mock
-        url = self.preprocess_url(_base_url + '/v2/projects/testString/notices')
-        mock_response = '{"matching_results": 16, "notices": [{"notice_id": "notice_id", "created": "2019-01-01T12:00:00.000Z", "document_id": "document_id", "collection_id": "collection_id", "query_id": "query_id", "severity": "warning", "step": "step", "description": "description"}]}'
-        responses.add(responses.GET,
-                      url,
-                      body=mock_response,
-                      content_type='application/json',
-                      status=200)
-
-        # Set up parameter values
-        project_id = 'testString'
-
-        # Invoke method
-        response = _service.query_notices(
-            project_id,
-            headers={}
-        )
-
-        # Check for correct operation
-        assert len(responses.calls) == 1
-        assert response.status_code == 200
-
-
-    @responses.activate
-    def test_query_notices_value_error(self):
-        """
-        test_query_notices_value_error()
-        """
-        # Set up mock
-        url = self.preprocess_url(_base_url + '/v2/projects/testString/notices')
-        mock_response = '{"matching_results": 16, "notices": [{"notice_id": "notice_id", "created": "2019-01-01T12:00:00.000Z", "document_id": "document_id", "collection_id": "collection_id", "query_id": "query_id", "severity": "warning", "step": "step", "description": "description"}]}'
-        responses.add(responses.GET,
-                      url,
-                      body=mock_response,
-                      content_type='application/json',
-                      status=200)
-
-        # Set up parameter values
-        project_id = 'testString'
-
-        # Pass in all but one required param and check for a ValueError
-        req_param_dict = {
-            "project_id": project_id,
-        }
-        for param in req_param_dict.keys():
-            req_copy = {key:val if key is not param else None for (key,val) in req_param_dict.items()}
-            with pytest.raises(ValueError):
-                _service.query_notices(**req_copy)
-
-
-
-class TestListFields():
-    """
-    Test Class for list_fields
-    """
-
-    def preprocess_url(self, request_url: str):
-        """
-        Preprocess the request URL to ensure the mock response will be found.
-        """
-        request_url = urllib.parse.unquote(request_url) # don't double-encode if already encoded
-        request_url = urllib.parse.quote(request_url, safe=':/')
-        if re.fullmatch('.*/+', request_url) is None:
-            return request_url
-        else:
-            return re.compile(request_url.rstrip('/') + '/+')
-
-    @responses.activate
-    def test_list_fields_all_params(self):
-        """
-        list_fields()
-        """
-        # Set up mock
-        url = self.preprocess_url(_base_url + '/v2/projects/testString/fields')
-        mock_response = '{"fields": [{"field": "field", "type": "nested", "collection_id": "collection_id"}]}'
-        responses.add(responses.GET,
-                      url,
-                      body=mock_response,
-                      content_type='application/json',
-                      status=200)
-
-        # Set up parameter values
-        project_id = 'testString'
-        collection_ids = ['testString']
-
-        # Invoke method
-        response = _service.list_fields(
-            project_id,
-            collection_ids=collection_ids,
-            headers={}
-        )
-
-        # Check for correct operation
-        assert len(responses.calls) == 1
-        assert response.status_code == 200
-        # Validate query params
-        query_string = responses.calls[0].request.url.split('?',1)[1]
-        query_string = urllib.parse.unquote_plus(query_string)
-        assert 'collection_ids={}'.format(','.join(collection_ids)) in query_string
-
-
-    @responses.activate
-    def test_list_fields_required_params(self):
-        """
-        test_list_fields_required_params()
-        """
-        # Set up mock
-        url = self.preprocess_url(_base_url + '/v2/projects/testString/fields')
-        mock_response = '{"fields": [{"field": "field", "type": "nested", "collection_id": "collection_id"}]}'
-        responses.add(responses.GET,
-                      url,
-                      body=mock_response,
-                      content_type='application/json',
-                      status=200)
-
-        # Set up parameter values
-        project_id = 'testString'
-
-        # Invoke method
-        response = _service.list_fields(
-            project_id,
-            headers={}
-        )
-
-        # Check for correct operation
-        assert len(responses.calls) == 1
-        assert response.status_code == 200
-
-
-    @responses.activate
-    def test_list_fields_value_error(self):
-        """
-        test_list_fields_value_error()
-        """
-        # Set up mock
-        url = self.preprocess_url(_base_url + '/v2/projects/testString/fields')
-        mock_response = '{"fields": [{"field": "field", "type": "nested", "collection_id": "collection_id"}]}'
-        responses.add(responses.GET,
-                      url,
-                      body=mock_response,
-                      content_type='application/json',
-                      status=200)
-
-        # Set up parameter values
-        project_id = 'testString'
-
-        # Pass in all but one required param and check for a ValueError
-        req_param_dict = {
-            "project_id": project_id,
-        }
-        for param in req_param_dict.keys():
-            req_copy = {key:val if key is not param else None for (key,val) in req_param_dict.items()}
-            with pytest.raises(ValueError):
-                _service.list_fields(**req_copy)
-
-
-
-# endregion
-##############################################################################
-# End of Service: Queries
-##############################################################################
-
-##############################################################################
-# Start of Service: ComponentSettings
-##############################################################################
-# region
-
-class TestGetComponentSettings():
-    """
-    Test Class for get_component_settings
-    """
-
-    def preprocess_url(self, request_url: str):
-        """
-        Preprocess the request URL to ensure the mock response will be found.
-        """
-        request_url = urllib.parse.unquote(request_url) # don't double-encode if already encoded
-        request_url = urllib.parse.quote(request_url, safe=':/')
-        if re.fullmatch('.*/+', request_url) is None:
-            return request_url
-        else:
-            return re.compile(request_url.rstrip('/') + '/+')
-
-    @responses.activate
-    def test_get_component_settings_all_params(self):
-        """
-        get_component_settings()
-        """
-        # Set up mock
-        url = self.preprocess_url(_base_url + '/v2/projects/testString/component_settings')
-        mock_response = '{"fields_shown": {"body": {"use_passage": false, "field": "field"}, "title": {"field": "field"}}, "autocomplete": true, "structured_search": false, "results_per_page": 16, "aggregations": [{"name": "name", "label": "label", "multiple_selections_allowed": false, "visualization_type": "auto"}]}'
-        responses.add(responses.GET,
-                      url,
-                      body=mock_response,
-                      content_type='application/json',
-                      status=200)
-
-        # Set up parameter values
-        project_id = 'testString'
-
-        # Invoke method
-        response = _service.get_component_settings(
-            project_id,
-            headers={}
-        )
-
-        # Check for correct operation
-        assert len(responses.calls) == 1
-        assert response.status_code == 200
-
-
-    @responses.activate
-    def test_get_component_settings_value_error(self):
-        """
-        test_get_component_settings_value_error()
-        """
-        # Set up mock
-        url = self.preprocess_url(_base_url + '/v2/projects/testString/component_settings')
-        mock_response = '{"fields_shown": {"body": {"use_passage": false, "field": "field"}, "title": {"field": "field"}}, "autocomplete": true, "structured_search": false, "results_per_page": 16, "aggregations": [{"name": "name", "label": "label", "multiple_selections_allowed": false, "visualization_type": "auto"}]}'
-        responses.add(responses.GET,
-                      url,
-                      body=mock_response,
-                      content_type='application/json',
-                      status=200)
-
-        # Set up parameter values
-        project_id = 'testString'
-
-        # Pass in all but one required param and check for a ValueError
-        req_param_dict = {
-            "project_id": project_id,
-        }
-        for param in req_param_dict.keys():
-            req_copy = {key:val if key is not param else None for (key,val) in req_param_dict.items()}
-            with pytest.raises(ValueError):
-                _service.get_component_settings(**req_copy)
-
-
-
-# endregion
-##############################################################################
-# End of Service: ComponentSettings
-##############################################################################
-
-##############################################################################
-# Start of Service: Documents
-##############################################################################
-# region
-
-class TestAddDocument():
-    """
-    Test Class for add_document
-    """
-
-    def preprocess_url(self, request_url: str):
-        """
-        Preprocess the request URL to ensure the mock response will be found.
-        """
-        request_url = urllib.parse.unquote(request_url) # don't double-encode if already encoded
-        request_url = urllib.parse.quote(request_url, safe=':/')
-        if re.fullmatch('.*/+', request_url) is None:
-            return request_url
-        else:
-            return re.compile(request_url.rstrip('/') + '/+')
-
-    @responses.activate
-    def test_add_document_all_params(self):
-        """
-        add_document()
-        """
-        # Set up mock
-        url = self.preprocess_url(_base_url + '/v2/projects/testString/collections/testString/documents')
-        mock_response = '{"document_id": "document_id", "status": "processing"}'
-        responses.add(responses.POST,
-                      url,
-                      body=mock_response,
-                      content_type='application/json',
-                      status=202)
-
-        # Set up parameter values
-        project_id = 'testString'
-        collection_id = 'testString'
-        file = io.BytesIO(b'This is a mock file.').getvalue()
-        filename = 'testString'
-        file_content_type = 'application/json'
-        metadata = 'testString'
-        x_watson_discovery_force = False
-
-        # Invoke method
-        response = _service.add_document(
-            project_id,
-            collection_id,
-            file=file,
-            filename=filename,
-            file_content_type=file_content_type,
-            metadata=metadata,
-            x_watson_discovery_force=x_watson_discovery_force,
-            headers={}
-        )
-
-        # Check for correct operation
-        assert len(responses.calls) == 1
-        assert response.status_code == 202
-
-
-    @responses.activate
-    def test_add_document_required_params(self):
-        """
-        test_add_document_required_params()
-        """
-        # Set up mock
-        url = self.preprocess_url(_base_url + '/v2/projects/testString/collections/testString/documents')
-        mock_response = '{"document_id": "document_id", "status": "processing"}'
-        responses.add(responses.POST,
-                      url,
-                      body=mock_response,
-                      content_type='application/json',
-                      status=202)
-
-        # Set up parameter values
-        project_id = 'testString'
-        collection_id = 'testString'
-
-        # Invoke method
-        response = _service.add_document(
-            project_id,
-            collection_id,
-            headers={}
-        )
-
-        # Check for correct operation
-        assert len(responses.calls) == 1
-        assert response.status_code == 202
-
-
-    @responses.activate
-    def test_add_document_value_error(self):
-        """
-        test_add_document_value_error()
-        """
-        # Set up mock
-        url = self.preprocess_url(_base_url + '/v2/projects/testString/collections/testString/documents')
-        mock_response = '{"document_id": "document_id", "status": "processing"}'
-        responses.add(responses.POST,
-                      url,
-                      body=mock_response,
-                      content_type='application/json',
-                      status=202)
-
-        # Set up parameter values
-        project_id = 'testString'
-        collection_id = 'testString'
-
-        # Pass in all but one required param and check for a ValueError
-        req_param_dict = {
-            "project_id": project_id,
-            "collection_id": collection_id,
-        }
-        for param in req_param_dict.keys():
-            req_copy = {key:val if key is not param else None for (key,val) in req_param_dict.items()}
-            with pytest.raises(ValueError):
-                _service.add_document(**req_copy)
-
-
-
-class TestUpdateDocument():
-    """
-    Test Class for update_document
-    """
-
-    def preprocess_url(self, request_url: str):
-        """
-        Preprocess the request URL to ensure the mock response will be found.
-        """
-        request_url = urllib.parse.unquote(request_url) # don't double-encode if already encoded
-        request_url = urllib.parse.quote(request_url, safe=':/')
-        if re.fullmatch('.*/+', request_url) is None:
-            return request_url
-        else:
-            return re.compile(request_url.rstrip('/') + '/+')
-
-    @responses.activate
-    def test_update_document_all_params(self):
-        """
-        update_document()
-        """
-        # Set up mock
-        url = self.preprocess_url(_base_url + '/v2/projects/testString/collections/testString/documents/testString')
-        mock_response = '{"document_id": "document_id", "status": "processing"}'
-        responses.add(responses.POST,
-                      url,
-                      body=mock_response,
-                      content_type='application/json',
-                      status=202)
-
-        # Set up parameter values
-        project_id = 'testString'
-        collection_id = 'testString'
-        document_id = 'testString'
-        file = io.BytesIO(b'This is a mock file.').getvalue()
-        filename = 'testString'
-        file_content_type = 'application/json'
-        metadata = 'testString'
-        x_watson_discovery_force = False
-
-        # Invoke method
-        response = _service.update_document(
-            project_id,
-            collection_id,
-            document_id,
-            file=file,
-            filename=filename,
-            file_content_type=file_content_type,
-            metadata=metadata,
-            x_watson_discovery_force=x_watson_discovery_force,
-            headers={}
-        )
-
-        # Check for correct operation
-        assert len(responses.calls) == 1
-        assert response.status_code == 202
-
-
-    @responses.activate
-    def test_update_document_required_params(self):
-        """
-        test_update_document_required_params()
-        """
-        # Set up mock
-        url = self.preprocess_url(_base_url + '/v2/projects/testString/collections/testString/documents/testString')
-        mock_response = '{"document_id": "document_id", "status": "processing"}'
-        responses.add(responses.POST,
-                      url,
-                      body=mock_response,
-                      content_type='application/json',
-                      status=202)
-
-        # Set up parameter values
-        project_id = 'testString'
-        collection_id = 'testString'
-        document_id = 'testString'
-
-        # Invoke method
-        response = _service.update_document(
-            project_id,
-            collection_id,
-            document_id,
-            headers={}
-        )
-
-        # Check for correct operation
-        assert len(responses.calls) == 1
-        assert response.status_code == 202
-
-
-    @responses.activate
-    def test_update_document_value_error(self):
-        """
-        test_update_document_value_error()
-        """
-        # Set up mock
-        url = self.preprocess_url(_base_url + '/v2/projects/testString/collections/testString/documents/testString')
-        mock_response = '{"document_id": "document_id", "status": "processing"}'
-        responses.add(responses.POST,
-                      url,
-                      body=mock_response,
-                      content_type='application/json',
-                      status=202)
-
-        # Set up parameter values
-        project_id = 'testString'
-        collection_id = 'testString'
-        document_id = 'testString'
-
-        # Pass in all but one required param and check for a ValueError
-        req_param_dict = {
-            "project_id": project_id,
-            "collection_id": collection_id,
-            "document_id": document_id,
-        }
-        for param in req_param_dict.keys():
-            req_copy = {key:val if key is not param else None for (key,val) in req_param_dict.items()}
-            with pytest.raises(ValueError):
-                _service.update_document(**req_copy)
-
-
-
-class TestDeleteDocument():
-    """
-    Test Class for delete_document
-    """
-
-    def preprocess_url(self, request_url: str):
-        """
-        Preprocess the request URL to ensure the mock response will be found.
-        """
-        request_url = urllib.parse.unquote(request_url) # don't double-encode if already encoded
-        request_url = urllib.parse.quote(request_url, safe=':/')
-        if re.fullmatch('.*/+', request_url) is None:
-            return request_url
-        else:
-            return re.compile(request_url.rstrip('/') + '/+')
-
-    @responses.activate
-    def test_delete_document_all_params(self):
-        """
-        delete_document()
-        """
-        # Set up mock
-        url = self.preprocess_url(_base_url + '/v2/projects/testString/collections/testString/documents/testString')
-        mock_response = '{"document_id": "document_id", "status": "deleted"}'
-        responses.add(responses.DELETE,
-                      url,
-                      body=mock_response,
-                      content_type='application/json',
-                      status=200)
-
-        # Set up parameter values
-        project_id = 'testString'
-        collection_id = 'testString'
-        document_id = 'testString'
-        x_watson_discovery_force = False
-
-        # Invoke method
-        response = _service.delete_document(
-            project_id,
-            collection_id,
-            document_id,
-            x_watson_discovery_force=x_watson_discovery_force,
-            headers={}
-        )
-
-        # Check for correct operation
-        assert len(responses.calls) == 1
-        assert response.status_code == 200
-
-
-    @responses.activate
-    def test_delete_document_required_params(self):
-        """
-        test_delete_document_required_params()
-        """
-        # Set up mock
-        url = self.preprocess_url(_base_url + '/v2/projects/testString/collections/testString/documents/testString')
-        mock_response = '{"document_id": "document_id", "status": "deleted"}'
-        responses.add(responses.DELETE,
-                      url,
-                      body=mock_response,
-                      content_type='application/json',
-                      status=200)
-
-        # Set up parameter values
-        project_id = 'testString'
-        collection_id = 'testString'
-        document_id = 'testString'
-
-        # Invoke method
-        response = _service.delete_document(
-            project_id,
-            collection_id,
-            document_id,
-            headers={}
-        )
-
-        # Check for correct operation
-        assert len(responses.calls) == 1
-        assert response.status_code == 200
-
-
-    @responses.activate
-    def test_delete_document_value_error(self):
-        """
-        test_delete_document_value_error()
-        """
-        # Set up mock
-        url = self.preprocess_url(_base_url + '/v2/projects/testString/collections/testString/documents/testString')
-        mock_response = '{"document_id": "document_id", "status": "deleted"}'
-        responses.add(responses.DELETE,
-                      url,
-                      body=mock_response,
-                      content_type='application/json',
-                      status=200)
-
-        # Set up parameter values
-        project_id = 'testString'
-        collection_id = 'testString'
-        document_id = 'testString'
-
-        # Pass in all but one required param and check for a ValueError
-        req_param_dict = {
-            "project_id": project_id,
-            "collection_id": collection_id,
-            "document_id": document_id,
-        }
-        for param in req_param_dict.keys():
-            req_copy = {key:val if key is not param else None for (key,val) in req_param_dict.items()}
-            with pytest.raises(ValueError):
-                _service.delete_document(**req_copy)
-
-
-
-# endregion
-##############################################################################
-# End of Service: Documents
-##############################################################################
-
-##############################################################################
-# Start of Service: TrainingData
-##############################################################################
-# region
-
-class TestListTrainingQueries():
-    """
-    Test Class for list_training_queries
-    """
-
-    def preprocess_url(self, request_url: str):
-        """
-        Preprocess the request URL to ensure the mock response will be found.
-        """
-        request_url = urllib.parse.unquote(request_url) # don't double-encode if already encoded
-        request_url = urllib.parse.quote(request_url, safe=':/')
-        if re.fullmatch('.*/+', request_url) is None:
-            return request_url
-        else:
-            return re.compile(request_url.rstrip('/') + '/+')
-
-    @responses.activate
-    def test_list_training_queries_all_params(self):
-        """
-        list_training_queries()
-        """
-        # Set up mock
-        url = self.preprocess_url(_base_url + '/v2/projects/testString/training_data/queries')
-        mock_response = '{"queries": [{"query_id": "query_id", "natural_language_query": "natural_language_query", "filter": "filter", "created": "2019-01-01T12:00:00.000Z", "updated": "2019-01-01T12:00:00.000Z", "examples": [{"document_id": "document_id", "collection_id": "collection_id", "relevance": 9, "created": "2019-01-01T12:00:00.000Z", "updated": "2019-01-01T12:00:00.000Z"}]}]}'
-        responses.add(responses.GET,
-                      url,
-                      body=mock_response,
-                      content_type='application/json',
-                      status=200)
-
-        # Set up parameter values
-        project_id = 'testString'
-
-        # Invoke method
-        response = _service.list_training_queries(
-            project_id,
-            headers={}
-        )
-
-        # Check for correct operation
-        assert len(responses.calls) == 1
-        assert response.status_code == 200
-
-
-    @responses.activate
-    def test_list_training_queries_value_error(self):
-        """
-        test_list_training_queries_value_error()
-        """
-        # Set up mock
-        url = self.preprocess_url(_base_url + '/v2/projects/testString/training_data/queries')
-        mock_response = '{"queries": [{"query_id": "query_id", "natural_language_query": "natural_language_query", "filter": "filter", "created": "2019-01-01T12:00:00.000Z", "updated": "2019-01-01T12:00:00.000Z", "examples": [{"document_id": "document_id", "collection_id": "collection_id", "relevance": 9, "created": "2019-01-01T12:00:00.000Z", "updated": "2019-01-01T12:00:00.000Z"}]}]}'
-        responses.add(responses.GET,
-                      url,
-                      body=mock_response,
-                      content_type='application/json',
-                      status=200)
-
-        # Set up parameter values
-        project_id = 'testString'
-
-        # Pass in all but one required param and check for a ValueError
-        req_param_dict = {
-            "project_id": project_id,
-        }
-        for param in req_param_dict.keys():
-            req_copy = {key:val if key is not param else None for (key,val) in req_param_dict.items()}
-            with pytest.raises(ValueError):
-                _service.list_training_queries(**req_copy)
-
-
-
-class TestDeleteTrainingQueries():
-    """
-    Test Class for delete_training_queries
-    """
-
-    def preprocess_url(self, request_url: str):
-        """
-        Preprocess the request URL to ensure the mock response will be found.
-        """
-        request_url = urllib.parse.unquote(request_url) # don't double-encode if already encoded
-        request_url = urllib.parse.quote(request_url, safe=':/')
-        if re.fullmatch('.*/+', request_url) is None:
-            return request_url
-        else:
-            return re.compile(request_url.rstrip('/') + '/+')
-
-    @responses.activate
-    def test_delete_training_queries_all_params(self):
-        """
-        delete_training_queries()
-        """
-        # Set up mock
-        url = self.preprocess_url(_base_url + '/v2/projects/testString/training_data/queries')
-        responses.add(responses.DELETE,
-                      url,
-                      status=204)
-
-        # Set up parameter values
-        project_id = 'testString'
-
-        # Invoke method
-        response = _service.delete_training_queries(
-            project_id,
-            headers={}
-        )
-
-        # Check for correct operation
-        assert len(responses.calls) == 1
-        assert response.status_code == 204
-
-
-    @responses.activate
-    def test_delete_training_queries_value_error(self):
-        """
-        test_delete_training_queries_value_error()
-        """
-        # Set up mock
-        url = self.preprocess_url(_base_url + '/v2/projects/testString/training_data/queries')
-        responses.add(responses.DELETE,
-                      url,
-                      status=204)
-
-        # Set up parameter values
-        project_id = 'testString'
-
-        # Pass in all but one required param and check for a ValueError
-        req_param_dict = {
-            "project_id": project_id,
-        }
-        for param in req_param_dict.keys():
-            req_copy = {key:val if key is not param else None for (key,val) in req_param_dict.items()}
-            with pytest.raises(ValueError):
-                _service.delete_training_queries(**req_copy)
-
-
-
-class TestCreateTrainingQuery():
-    """
-    Test Class for create_training_query
-    """
-
-    def preprocess_url(self, request_url: str):
-        """
-        Preprocess the request URL to ensure the mock response will be found.
-        """
-        request_url = urllib.parse.unquote(request_url) # don't double-encode if already encoded
-        request_url = urllib.parse.quote(request_url, safe=':/')
-        if re.fullmatch('.*/+', request_url) is None:
-            return request_url
-        else:
-            return re.compile(request_url.rstrip('/') + '/+')
-
-    @responses.activate
-    def test_create_training_query_all_params(self):
-        """
-        create_training_query()
-        """
-        # Set up mock
-        url = self.preprocess_url(_base_url + '/v2/projects/testString/training_data/queries')
-        mock_response = '{"query_id": "query_id", "natural_language_query": "natural_language_query", "filter": "filter", "created": "2019-01-01T12:00:00.000Z", "updated": "2019-01-01T12:00:00.000Z", "examples": [{"document_id": "document_id", "collection_id": "collection_id", "relevance": 9, "created": "2019-01-01T12:00:00.000Z", "updated": "2019-01-01T12:00:00.000Z"}]}'
-        responses.add(responses.POST,
-                      url,
-                      body=mock_response,
-                      content_type='application/json',
-                      status=201)
-
-        # Construct a dict representation of a TrainingExample model
-        training_example_model = {}
-        training_example_model['document_id'] = 'testString'
-        training_example_model['collection_id'] = 'testString'
-        training_example_model['relevance'] = 38
-
-        # Set up parameter values
-        project_id = 'testString'
-        natural_language_query = 'testString'
-        examples = [training_example_model]
-        filter = 'testString'
-
-        # Invoke method
-        response = _service.create_training_query(
-            project_id,
-            natural_language_query,
-            examples,
-            filter=filter,
-            headers={}
-        )
-
-        # Check for correct operation
-        assert len(responses.calls) == 1
-        assert response.status_code == 201
-        # Validate body params
-        req_body = json.loads(str(responses.calls[0].request.body, 'utf-8'))
-        assert req_body['natural_language_query'] == 'testString'
-        assert req_body['examples'] == [training_example_model]
-        assert req_body['filter'] == 'testString'
-
-
-    @responses.activate
-    def test_create_training_query_value_error(self):
-        """
-        test_create_training_query_value_error()
-        """
-        # Set up mock
-        url = self.preprocess_url(_base_url + '/v2/projects/testString/training_data/queries')
-        mock_response = '{"query_id": "query_id", "natural_language_query": "natural_language_query", "filter": "filter", "created": "2019-01-01T12:00:00.000Z", "updated": "2019-01-01T12:00:00.000Z", "examples": [{"document_id": "document_id", "collection_id": "collection_id", "relevance": 9, "created": "2019-01-01T12:00:00.000Z", "updated": "2019-01-01T12:00:00.000Z"}]}'
-        responses.add(responses.POST,
-                      url,
-                      body=mock_response,
-                      content_type='application/json',
-                      status=201)
-
-        # Construct a dict representation of a TrainingExample model
-        training_example_model = {}
-        training_example_model['document_id'] = 'testString'
-        training_example_model['collection_id'] = 'testString'
-        training_example_model['relevance'] = 38
-
-        # Set up parameter values
-        project_id = 'testString'
-        natural_language_query = 'testString'
-        examples = [training_example_model]
-        filter = 'testString'
-
-        # Pass in all but one required param and check for a ValueError
-        req_param_dict = {
-            "project_id": project_id,
-            "natural_language_query": natural_language_query,
-            "examples": examples,
-        }
-        for param in req_param_dict.keys():
-            req_copy = {key:val if key is not param else None for (key,val) in req_param_dict.items()}
-            with pytest.raises(ValueError):
-                _service.create_training_query(**req_copy)
-
-
-
-class TestGetTrainingQuery():
-    """
-    Test Class for get_training_query
-    """
-
-    def preprocess_url(self, request_url: str):
-        """
-        Preprocess the request URL to ensure the mock response will be found.
-        """
-        request_url = urllib.parse.unquote(request_url) # don't double-encode if already encoded
-        request_url = urllib.parse.quote(request_url, safe=':/')
-        if re.fullmatch('.*/+', request_url) is None:
-            return request_url
-        else:
-            return re.compile(request_url.rstrip('/') + '/+')
-
-    @responses.activate
-    def test_get_training_query_all_params(self):
-        """
-        get_training_query()
-        """
-        # Set up mock
-        url = self.preprocess_url(_base_url + '/v2/projects/testString/training_data/queries/testString')
-        mock_response = '{"query_id": "query_id", "natural_language_query": "natural_language_query", "filter": "filter", "created": "2019-01-01T12:00:00.000Z", "updated": "2019-01-01T12:00:00.000Z", "examples": [{"document_id": "document_id", "collection_id": "collection_id", "relevance": 9, "created": "2019-01-01T12:00:00.000Z", "updated": "2019-01-01T12:00:00.000Z"}]}'
-        responses.add(responses.GET,
-                      url,
-                      body=mock_response,
-                      content_type='application/json',
-                      status=200)
-
-        # Set up parameter values
-        project_id = 'testString'
-        query_id = 'testString'
-
-        # Invoke method
-        response = _service.get_training_query(
-            project_id,
-            query_id,
-            headers={}
-        )
-
-        # Check for correct operation
-        assert len(responses.calls) == 1
-        assert response.status_code == 200
-
-
-    @responses.activate
-    def test_get_training_query_value_error(self):
-        """
-        test_get_training_query_value_error()
-        """
-        # Set up mock
-        url = self.preprocess_url(_base_url + '/v2/projects/testString/training_data/queries/testString')
-        mock_response = '{"query_id": "query_id", "natural_language_query": "natural_language_query", "filter": "filter", "created": "2019-01-01T12:00:00.000Z", "updated": "2019-01-01T12:00:00.000Z", "examples": [{"document_id": "document_id", "collection_id": "collection_id", "relevance": 9, "created": "2019-01-01T12:00:00.000Z", "updated": "2019-01-01T12:00:00.000Z"}]}'
-        responses.add(responses.GET,
-                      url,
-                      body=mock_response,
-                      content_type='application/json',
-                      status=200)
-
-        # Set up parameter values
-        project_id = 'testString'
-        query_id = 'testString'
-
-        # Pass in all but one required param and check for a ValueError
-        req_param_dict = {
-            "project_id": project_id,
-            "query_id": query_id,
-        }
-        for param in req_param_dict.keys():
-            req_copy = {key:val if key is not param else None for (key,val) in req_param_dict.items()}
-            with pytest.raises(ValueError):
-                _service.get_training_query(**req_copy)
-
-
-
-class TestUpdateTrainingQuery():
-    """
-    Test Class for update_training_query
-    """
-
-    def preprocess_url(self, request_url: str):
-        """
-        Preprocess the request URL to ensure the mock response will be found.
-        """
-        request_url = urllib.parse.unquote(request_url) # don't double-encode if already encoded
-        request_url = urllib.parse.quote(request_url, safe=':/')
-        if re.fullmatch('.*/+', request_url) is None:
-            return request_url
-        else:
-            return re.compile(request_url.rstrip('/') + '/+')
-
-    @responses.activate
-    def test_update_training_query_all_params(self):
-        """
-        update_training_query()
-        """
-        # Set up mock
-        url = self.preprocess_url(_base_url + '/v2/projects/testString/training_data/queries/testString')
-        mock_response = '{"query_id": "query_id", "natural_language_query": "natural_language_query", "filter": "filter", "created": "2019-01-01T12:00:00.000Z", "updated": "2019-01-01T12:00:00.000Z", "examples": [{"document_id": "document_id", "collection_id": "collection_id", "relevance": 9, "created": "2019-01-01T12:00:00.000Z", "updated": "2019-01-01T12:00:00.000Z"}]}'
-        responses.add(responses.POST,
-                      url,
-                      body=mock_response,
-                      content_type='application/json',
-                      status=201)
-
-        # Construct a dict representation of a TrainingExample model
-        training_example_model = {}
-        training_example_model['document_id'] = 'testString'
-        training_example_model['collection_id'] = 'testString'
-        training_example_model['relevance'] = 38
-
-        # Set up parameter values
-        project_id = 'testString'
-        query_id = 'testString'
-        natural_language_query = 'testString'
-        examples = [training_example_model]
-        filter = 'testString'
-
-        # Invoke method
-        response = _service.update_training_query(
-            project_id,
-            query_id,
-            natural_language_query,
-            examples,
-            filter=filter,
-            headers={}
-        )
-
-        # Check for correct operation
-        assert len(responses.calls) == 1
-        assert response.status_code == 201
-        # Validate body params
-        req_body = json.loads(str(responses.calls[0].request.body, 'utf-8'))
-        assert req_body['natural_language_query'] == 'testString'
-        assert req_body['examples'] == [training_example_model]
-        assert req_body['filter'] == 'testString'
-
-
-    @responses.activate
-    def test_update_training_query_value_error(self):
-        """
-        test_update_training_query_value_error()
-        """
-        # Set up mock
-        url = self.preprocess_url(_base_url + '/v2/projects/testString/training_data/queries/testString')
-        mock_response = '{"query_id": "query_id", "natural_language_query": "natural_language_query", "filter": "filter", "created": "2019-01-01T12:00:00.000Z", "updated": "2019-01-01T12:00:00.000Z", "examples": [{"document_id": "document_id", "collection_id": "collection_id", "relevance": 9, "created": "2019-01-01T12:00:00.000Z", "updated": "2019-01-01T12:00:00.000Z"}]}'
-        responses.add(responses.POST,
-                      url,
-                      body=mock_response,
-                      content_type='application/json',
-                      status=201)
-
-        # Construct a dict representation of a TrainingExample model
-        training_example_model = {}
-        training_example_model['document_id'] = 'testString'
-        training_example_model['collection_id'] = 'testString'
-        training_example_model['relevance'] = 38
-
-        # Set up parameter values
-        project_id = 'testString'
-        query_id = 'testString'
-        natural_language_query = 'testString'
-        examples = [training_example_model]
-        filter = 'testString'
-
-        # Pass in all but one required param and check for a ValueError
-        req_param_dict = {
-            "project_id": project_id,
-            "query_id": query_id,
-            "natural_language_query": natural_language_query,
-            "examples": examples,
-        }
-        for param in req_param_dict.keys():
-            req_copy = {key:val if key is not param else None for (key,val) in req_param_dict.items()}
-            with pytest.raises(ValueError):
-                _service.update_training_query(**req_copy)
-
-
-
-class TestDeleteTrainingQuery():
-    """
-    Test Class for delete_training_query
-    """
-
-    def preprocess_url(self, request_url: str):
-        """
-        Preprocess the request URL to ensure the mock response will be found.
-        """
-        request_url = urllib.parse.unquote(request_url) # don't double-encode if already encoded
-        request_url = urllib.parse.quote(request_url, safe=':/')
-        if re.fullmatch('.*/+', request_url) is None:
-            return request_url
-        else:
-            return re.compile(request_url.rstrip('/') + '/+')
-
-    @responses.activate
-    def test_delete_training_query_all_params(self):
-        """
-        delete_training_query()
-        """
-        # Set up mock
-        url = self.preprocess_url(_base_url + '/v2/projects/testString/training_data/queries/testString')
-        responses.add(responses.DELETE,
-                      url,
-                      status=204)
-
-        # Set up parameter values
-        project_id = 'testString'
-        query_id = 'testString'
-
-        # Invoke method
-        response = _service.delete_training_query(
-            project_id,
-            query_id,
-            headers={}
-        )
-
-        # Check for correct operation
-        assert len(responses.calls) == 1
-        assert response.status_code == 204
-
-
-    @responses.activate
-    def test_delete_training_query_value_error(self):
-        """
-        test_delete_training_query_value_error()
-        """
-        # Set up mock
-        url = self.preprocess_url(_base_url + '/v2/projects/testString/training_data/queries/testString')
-        responses.add(responses.DELETE,
-                      url,
-                      status=204)
-
-        # Set up parameter values
-        project_id = 'testString'
-        query_id = 'testString'
-
-        # Pass in all but one required param and check for a ValueError
-        req_param_dict = {
-            "project_id": project_id,
-            "query_id": query_id,
-        }
-        for param in req_param_dict.keys():
-            req_copy = {key:val if key is not param else None for (key,val) in req_param_dict.items()}
-            with pytest.raises(ValueError):
-                _service.delete_training_query(**req_copy)
-
-
-
-# endregion
-##############################################################################
-# End of Service: TrainingData
-##############################################################################
-
-##############################################################################
-# Start of Service: Analyze
-##############################################################################
-# region
-
-class TestAnalyzeDocument():
-    """
-    Test Class for analyze_document
-    """
-
-    def preprocess_url(self, request_url: str):
-        """
-        Preprocess the request URL to ensure the mock response will be found.
-        """
-        request_url = urllib.parse.unquote(request_url) # don't double-encode if already encoded
-        request_url = urllib.parse.quote(request_url, safe=':/')
-        if re.fullmatch('.*/+', request_url) is None:
-            return request_url
-        else:
-            return re.compile(request_url.rstrip('/') + '/+')
-
-    @responses.activate
-    def test_analyze_document_all_params(self):
-        """
-        analyze_document()
-        """
-        # Set up mock
-        url = self.preprocess_url(_base_url + '/v2/projects/testString/collections/testString/analyze')
-        mock_response = '{"notices": [{"notice_id": "notice_id", "created": "2019-01-01T12:00:00.000Z", "document_id": "document_id", "collection_id": "collection_id", "query_id": "query_id", "severity": "warning", "step": "step", "description": "description"}], "result": {"metadata": {"mapKey": "anyValue"}}}'
-        responses.add(responses.POST,
-                      url,
-                      body=mock_response,
-                      content_type='application/json',
-                      status=200)
-
-        # Set up parameter values
-        project_id = 'testString'
-        collection_id = 'testString'
-        file = io.BytesIO(b'This is a mock file.').getvalue()
-        filename = 'testString'
-        file_content_type = 'application/json'
-        metadata = 'testString'
-
-        # Invoke method
-        response = _service.analyze_document(
-            project_id,
-            collection_id,
-            file=file,
-            filename=filename,
-            file_content_type=file_content_type,
-            metadata=metadata,
-            headers={}
-        )
-
-        # Check for correct operation
-        assert len(responses.calls) == 1
-        assert response.status_code == 200
-
-
-    @responses.activate
-    def test_analyze_document_required_params(self):
-        """
-        test_analyze_document_required_params()
-        """
-        # Set up mock
-        url = self.preprocess_url(_base_url + '/v2/projects/testString/collections/testString/analyze')
-        mock_response = '{"notices": [{"notice_id": "notice_id", "created": "2019-01-01T12:00:00.000Z", "document_id": "document_id", "collection_id": "collection_id", "query_id": "query_id", "severity": "warning", "step": "step", "description": "description"}], "result": {"metadata": {"mapKey": "anyValue"}}}'
-        responses.add(responses.POST,
-                      url,
-                      body=mock_response,
-                      content_type='application/json',
-                      status=200)
-
-        # Set up parameter values
-        project_id = 'testString'
-        collection_id = 'testString'
-
-        # Invoke method
-        response = _service.analyze_document(
-            project_id,
-            collection_id,
-            headers={}
-        )
-
-        # Check for correct operation
-        assert len(responses.calls) == 1
-        assert response.status_code == 200
-
-
-    @responses.activate
-    def test_analyze_document_value_error(self):
-        """
-        test_analyze_document_value_error()
-        """
-        # Set up mock
-        url = self.preprocess_url(_base_url + '/v2/projects/testString/collections/testString/analyze')
-        mock_response = '{"notices": [{"notice_id": "notice_id", "created": "2019-01-01T12:00:00.000Z", "document_id": "document_id", "collection_id": "collection_id", "query_id": "query_id", "severity": "warning", "step": "step", "description": "description"}], "result": {"metadata": {"mapKey": "anyValue"}}}'
-        responses.add(responses.POST,
-                      url,
-                      body=mock_response,
-                      content_type='application/json',
-                      status=200)
-
-        # Set up parameter values
-        project_id = 'testString'
-        collection_id = 'testString'
-
-        # Pass in all but one required param and check for a ValueError
-        req_param_dict = {
-            "project_id": project_id,
-            "collection_id": collection_id,
-        }
-        for param in req_param_dict.keys():
-            req_copy = {key:val if key is not param else None for (key,val) in req_param_dict.items()}
-            with pytest.raises(ValueError):
-                _service.analyze_document(**req_copy)
-
-
-
-# endregion
-##############################################################################
-# End of Service: Analyze
-##############################################################################
-
-##############################################################################
-# Start of Service: Enrichments
-##############################################################################
-# region
-
-class TestListEnrichments():
-    """
-    Test Class for list_enrichments
-    """
-
-    def preprocess_url(self, request_url: str):
-        """
-        Preprocess the request URL to ensure the mock response will be found.
-        """
-        request_url = urllib.parse.unquote(request_url) # don't double-encode if already encoded
-        request_url = urllib.parse.quote(request_url, safe=':/')
-        if re.fullmatch('.*/+', request_url) is None:
-            return request_url
-        else:
-            return re.compile(request_url.rstrip('/') + '/+')
-
-    @responses.activate
-    def test_list_enrichments_all_params(self):
-        """
-        list_enrichments()
-        """
-        # Set up mock
-        url = self.preprocess_url(_base_url + '/v2/projects/testString/enrichments')
-        mock_response = '{"enrichments": [{"enrichment_id": "enrichment_id", "name": "name", "description": "description", "type": "part_of_speech", "options": {"languages": ["languages"], "entity_type": "entity_type", "regular_expression": "regular_expression", "result_field": "result_field"}}]}'
-        responses.add(responses.GET,
-                      url,
-                      body=mock_response,
-                      content_type='application/json',
-                      status=200)
-
-        # Set up parameter values
-        project_id = 'testString'
-
-        # Invoke method
-        response = _service.list_enrichments(
-            project_id,
-            headers={}
-        )
-
-        # Check for correct operation
-        assert len(responses.calls) == 1
-        assert response.status_code == 200
-
-
-    @responses.activate
-    def test_list_enrichments_value_error(self):
-        """
-        test_list_enrichments_value_error()
-        """
-        # Set up mock
-        url = self.preprocess_url(_base_url + '/v2/projects/testString/enrichments')
-        mock_response = '{"enrichments": [{"enrichment_id": "enrichment_id", "name": "name", "description": "description", "type": "part_of_speech", "options": {"languages": ["languages"], "entity_type": "entity_type", "regular_expression": "regular_expression", "result_field": "result_field"}}]}'
-        responses.add(responses.GET,
-                      url,
-                      body=mock_response,
-                      content_type='application/json',
-                      status=200)
-
-        # Set up parameter values
-        project_id = 'testString'
-
-        # Pass in all but one required param and check for a ValueError
-        req_param_dict = {
-            "project_id": project_id,
-        }
-        for param in req_param_dict.keys():
-            req_copy = {key:val if key is not param else None for (key,val) in req_param_dict.items()}
-            with pytest.raises(ValueError):
-                _service.list_enrichments(**req_copy)
-
-
-
-class TestCreateEnrichment():
-    """
-    Test Class for create_enrichment
-    """
-
-    def preprocess_url(self, request_url: str):
-        """
-        Preprocess the request URL to ensure the mock response will be found.
-        """
-        request_url = urllib.parse.unquote(request_url) # don't double-encode if already encoded
-        request_url = urllib.parse.quote(request_url, safe=':/')
-        if re.fullmatch('.*/+', request_url) is None:
-            return request_url
-        else:
-            return re.compile(request_url.rstrip('/') + '/+')
-
-    @responses.activate
-    def test_create_enrichment_all_params(self):
-        """
-        create_enrichment()
-        """
-        # Set up mock
-        url = self.preprocess_url(_base_url + '/v2/projects/testString/enrichments')
-        mock_response = '{"enrichment_id": "enrichment_id", "name": "name", "description": "description", "type": "part_of_speech", "options": {"languages": ["languages"], "entity_type": "entity_type", "regular_expression": "regular_expression", "result_field": "result_field"}}'
-        responses.add(responses.POST,
-                      url,
-                      body=mock_response,
-                      content_type='application/json',
-                      status=201)
-
-        # Construct a dict representation of a EnrichmentOptions model
-        enrichment_options_model = {}
-        enrichment_options_model['languages'] = ['testString']
-        enrichment_options_model['entity_type'] = 'testString'
-        enrichment_options_model['regular_expression'] = 'testString'
-        enrichment_options_model['result_field'] = 'testString'
-
-        # Construct a dict representation of a CreateEnrichment model
-        create_enrichment_model = {}
-        create_enrichment_model['name'] = 'testString'
-        create_enrichment_model['description'] = 'testString'
-        create_enrichment_model['type'] = 'dictionary'
-        create_enrichment_model['options'] = enrichment_options_model
-
-        # Set up parameter values
-        project_id = 'testString'
-        enrichment = create_enrichment_model
-        file = io.BytesIO(b'This is a mock file.').getvalue()
-
-        # Invoke method
-        response = _service.create_enrichment(
-            project_id,
-            enrichment,
-            file=file,
-            headers={}
-        )
-
-        # Check for correct operation
-        assert len(responses.calls) == 1
-        assert response.status_code == 201
-
-
-    @responses.activate
-    def test_create_enrichment_required_params(self):
-        """
-        test_create_enrichment_required_params()
-        """
-        # Set up mock
-        url = self.preprocess_url(_base_url + '/v2/projects/testString/enrichments')
-        mock_response = '{"enrichment_id": "enrichment_id", "name": "name", "description": "description", "type": "part_of_speech", "options": {"languages": ["languages"], "entity_type": "entity_type", "regular_expression": "regular_expression", "result_field": "result_field"}}'
-        responses.add(responses.POST,
-                      url,
-                      body=mock_response,
-                      content_type='application/json',
-                      status=201)
-
-        # Construct a dict representation of a EnrichmentOptions model
-        enrichment_options_model = {}
-        enrichment_options_model['languages'] = ['testString']
-        enrichment_options_model['entity_type'] = 'testString'
-        enrichment_options_model['regular_expression'] = 'testString'
-        enrichment_options_model['result_field'] = 'testString'
-
-        # Construct a dict representation of a CreateEnrichment model
-        create_enrichment_model = {}
-        create_enrichment_model['name'] = 'testString'
-        create_enrichment_model['description'] = 'testString'
-        create_enrichment_model['type'] = 'dictionary'
-        create_enrichment_model['options'] = enrichment_options_model
-
-        # Set up parameter values
-        project_id = 'testString'
-        enrichment = create_enrichment_model
-
-        # Invoke method
-        response = _service.create_enrichment(
-            project_id,
-            enrichment,
-            headers={}
-        )
-
-        # Check for correct operation
-        assert len(responses.calls) == 1
-        assert response.status_code == 201
-
-
-    @responses.activate
-    def test_create_enrichment_value_error(self):
-        """
-        test_create_enrichment_value_error()
-        """
-        # Set up mock
-        url = self.preprocess_url(_base_url + '/v2/projects/testString/enrichments')
-        mock_response = '{"enrichment_id": "enrichment_id", "name": "name", "description": "description", "type": "part_of_speech", "options": {"languages": ["languages"], "entity_type": "entity_type", "regular_expression": "regular_expression", "result_field": "result_field"}}'
-        responses.add(responses.POST,
-                      url,
-                      body=mock_response,
-                      content_type='application/json',
-                      status=201)
-
-        # Construct a dict representation of a EnrichmentOptions model
-        enrichment_options_model = {}
-        enrichment_options_model['languages'] = ['testString']
-        enrichment_options_model['entity_type'] = 'testString'
-        enrichment_options_model['regular_expression'] = 'testString'
-        enrichment_options_model['result_field'] = 'testString'
-
-        # Construct a dict representation of a CreateEnrichment model
-        create_enrichment_model = {}
-        create_enrichment_model['name'] = 'testString'
-        create_enrichment_model['description'] = 'testString'
-        create_enrichment_model['type'] = 'dictionary'
-        create_enrichment_model['options'] = enrichment_options_model
-
-        # Set up parameter values
-        project_id = 'testString'
-        enrichment = create_enrichment_model
-
-        # Pass in all but one required param and check for a ValueError
-        req_param_dict = {
-            "project_id": project_id,
-            "enrichment": enrichment,
-        }
-        for param in req_param_dict.keys():
-            req_copy = {key:val if key is not param else None for (key,val) in req_param_dict.items()}
-            with pytest.raises(ValueError):
-                _service.create_enrichment(**req_copy)
-
-
-
-class TestGetEnrichment():
-    """
-    Test Class for get_enrichment
-    """
-
-    def preprocess_url(self, request_url: str):
-        """
-        Preprocess the request URL to ensure the mock response will be found.
-        """
-        request_url = urllib.parse.unquote(request_url) # don't double-encode if already encoded
-        request_url = urllib.parse.quote(request_url, safe=':/')
-        if re.fullmatch('.*/+', request_url) is None:
-            return request_url
-        else:
-            return re.compile(request_url.rstrip('/') + '/+')
-
-    @responses.activate
-    def test_get_enrichment_all_params(self):
-        """
-        get_enrichment()
-        """
-        # Set up mock
-        url = self.preprocess_url(_base_url + '/v2/projects/testString/enrichments/testString')
-        mock_response = '{"enrichment_id": "enrichment_id", "name": "name", "description": "description", "type": "part_of_speech", "options": {"languages": ["languages"], "entity_type": "entity_type", "regular_expression": "regular_expression", "result_field": "result_field"}}'
-        responses.add(responses.GET,
-                      url,
-                      body=mock_response,
-                      content_type='application/json',
-                      status=200)
-
-        # Set up parameter values
-        project_id = 'testString'
-        enrichment_id = 'testString'
-
-        # Invoke method
-        response = _service.get_enrichment(
-            project_id,
-            enrichment_id,
-            headers={}
-        )
-
-        # Check for correct operation
-        assert len(responses.calls) == 1
-        assert response.status_code == 200
-
-
-    @responses.activate
-    def test_get_enrichment_value_error(self):
-        """
-        test_get_enrichment_value_error()
-        """
-        # Set up mock
-        url = self.preprocess_url(_base_url + '/v2/projects/testString/enrichments/testString')
-        mock_response = '{"enrichment_id": "enrichment_id", "name": "name", "description": "description", "type": "part_of_speech", "options": {"languages": ["languages"], "entity_type": "entity_type", "regular_expression": "regular_expression", "result_field": "result_field"}}'
-        responses.add(responses.GET,
-                      url,
-                      body=mock_response,
-                      content_type='application/json',
-                      status=200)
-
-        # Set up parameter values
-        project_id = 'testString'
-        enrichment_id = 'testString'
-
-        # Pass in all but one required param and check for a ValueError
-        req_param_dict = {
-            "project_id": project_id,
-            "enrichment_id": enrichment_id,
-        }
-        for param in req_param_dict.keys():
-            req_copy = {key:val if key is not param else None for (key,val) in req_param_dict.items()}
-            with pytest.raises(ValueError):
-                _service.get_enrichment(**req_copy)
-
-
-
-class TestUpdateEnrichment():
-    """
-    Test Class for update_enrichment
-    """
-
-    def preprocess_url(self, request_url: str):
-        """
-        Preprocess the request URL to ensure the mock response will be found.
-        """
-        request_url = urllib.parse.unquote(request_url) # don't double-encode if already encoded
-        request_url = urllib.parse.quote(request_url, safe=':/')
-        if re.fullmatch('.*/+', request_url) is None:
-            return request_url
-        else:
-            return re.compile(request_url.rstrip('/') + '/+')
-
-    @responses.activate
-    def test_update_enrichment_all_params(self):
-        """
-        update_enrichment()
-        """
-        # Set up mock
-        url = self.preprocess_url(_base_url + '/v2/projects/testString/enrichments/testString')
-        mock_response = '{"enrichment_id": "enrichment_id", "name": "name", "description": "description", "type": "part_of_speech", "options": {"languages": ["languages"], "entity_type": "entity_type", "regular_expression": "regular_expression", "result_field": "result_field"}}'
-        responses.add(responses.POST,
-                      url,
-                      body=mock_response,
-                      content_type='application/json',
-                      status=200)
-
-        # Set up parameter values
-        project_id = 'testString'
-        enrichment_id = 'testString'
-        name = 'testString'
-        description = 'testString'
-
-        # Invoke method
-        response = _service.update_enrichment(
-            project_id,
-            enrichment_id,
-            name,
-            description=description,
-            headers={}
-        )
-
-        # Check for correct operation
-        assert len(responses.calls) == 1
-        assert response.status_code == 200
-        # Validate body params
-        req_body = json.loads(str(responses.calls[0].request.body, 'utf-8'))
-        assert req_body['name'] == 'testString'
-        assert req_body['description'] == 'testString'
-
-
-    @responses.activate
-    def test_update_enrichment_value_error(self):
-        """
-        test_update_enrichment_value_error()
-        """
-        # Set up mock
-        url = self.preprocess_url(_base_url + '/v2/projects/testString/enrichments/testString')
-        mock_response = '{"enrichment_id": "enrichment_id", "name": "name", "description": "description", "type": "part_of_speech", "options": {"languages": ["languages"], "entity_type": "entity_type", "regular_expression": "regular_expression", "result_field": "result_field"}}'
-        responses.add(responses.POST,
-                      url,
-                      body=mock_response,
-                      content_type='application/json',
-                      status=200)
-
-        # Set up parameter values
-        project_id = 'testString'
-        enrichment_id = 'testString'
-        name = 'testString'
-        description = 'testString'
-
-        # Pass in all but one required param and check for a ValueError
-        req_param_dict = {
-            "project_id": project_id,
-            "enrichment_id": enrichment_id,
-            "name": name,
-        }
-        for param in req_param_dict.keys():
-            req_copy = {key:val if key is not param else None for (key,val) in req_param_dict.items()}
-            with pytest.raises(ValueError):
-                _service.update_enrichment(**req_copy)
-
-
-
-class TestDeleteEnrichment():
-    """
-    Test Class for delete_enrichment
-    """
-
-    def preprocess_url(self, request_url: str):
-        """
-        Preprocess the request URL to ensure the mock response will be found.
-        """
-        request_url = urllib.parse.unquote(request_url) # don't double-encode if already encoded
-        request_url = urllib.parse.quote(request_url, safe=':/')
-        if re.fullmatch('.*/+', request_url) is None:
-            return request_url
-        else:
-            return re.compile(request_url.rstrip('/') + '/+')
-
-    @responses.activate
-    def test_delete_enrichment_all_params(self):
-        """
-        delete_enrichment()
-        """
-        # Set up mock
-        url = self.preprocess_url(_base_url + '/v2/projects/testString/enrichments/testString')
-        responses.add(responses.DELETE,
-                      url,
-                      status=204)
-
-        # Set up parameter values
-        project_id = 'testString'
-        enrichment_id = 'testString'
-
-        # Invoke method
-        response = _service.delete_enrichment(
-            project_id,
-            enrichment_id,
-            headers={}
-        )
-
-        # Check for correct operation
-        assert len(responses.calls) == 1
-        assert response.status_code == 204
-
-
-    @responses.activate
-    def test_delete_enrichment_value_error(self):
-        """
-        test_delete_enrichment_value_error()
-        """
-        # Set up mock
-        url = self.preprocess_url(_base_url + '/v2/projects/testString/enrichments/testString')
-        responses.add(responses.DELETE,
-                      url,
-                      status=204)
-
-        # Set up parameter values
-        project_id = 'testString'
-        enrichment_id = 'testString'
-
-        # Pass in all but one required param and check for a ValueError
-        req_param_dict = {
-            "project_id": project_id,
-            "enrichment_id": enrichment_id,
-        }
-        for param in req_param_dict.keys():
-            req_copy = {key:val if key is not param else None for (key,val) in req_param_dict.items()}
-            with pytest.raises(ValueError):
-                _service.delete_enrichment(**req_copy)
-
-
-
-# endregion
-##############################################################################
-# End of Service: Enrichments
-##############################################################################
 
 ##############################################################################
 # Start of Service: Projects
@@ -2657,24 +78,13 @@ class TestListProjects():
     Test Class for list_projects
     """
 
-    def preprocess_url(self, request_url: str):
-        """
-        Preprocess the request URL to ensure the mock response will be found.
-        """
-        request_url = urllib.parse.unquote(request_url) # don't double-encode if already encoded
-        request_url = urllib.parse.quote(request_url, safe=':/')
-        if re.fullmatch('.*/+', request_url) is None:
-            return request_url
-        else:
-            return re.compile(request_url.rstrip('/') + '/+')
-
     @responses.activate
     def test_list_projects_all_params(self):
         """
         list_projects()
         """
         # Set up mock
-        url = self.preprocess_url(_base_url + '/v2/projects')
+        url = preprocess_url('/v2/projects')
         mock_response = '{"projects": [{"project_id": "project_id", "name": "name", "type": "document_retrieval", "relevancy_training_status": {"data_updated": "data_updated", "total_examples": 14, "sufficient_label_diversity": true, "processing": true, "minimum_examples_added": true, "successfully_trained": "successfully_trained", "available": false, "notices": 7, "minimum_queries_added": false}, "collection_count": 16}]}'
         responses.add(responses.GET,
                       url,
@@ -2690,6 +100,14 @@ class TestListProjects():
         assert len(responses.calls) == 1
         assert response.status_code == 200
 
+    def test_list_projects_all_params_with_retries(self):
+        # Enable retries and run test_list_projects_all_params.
+        _service.enable_retries()
+        self.test_list_projects_all_params()
+
+        # Disable retries and run test_list_projects_all_params.
+        _service.disable_retries()
+        self.test_list_projects_all_params()
 
     @responses.activate
     def test_list_projects_value_error(self):
@@ -2697,7 +115,7 @@ class TestListProjects():
         test_list_projects_value_error()
         """
         # Set up mock
-        url = self.preprocess_url(_base_url + '/v2/projects')
+        url = preprocess_url('/v2/projects')
         mock_response = '{"projects": [{"project_id": "project_id", "name": "name", "type": "document_retrieval", "relevancy_training_status": {"data_updated": "data_updated", "total_examples": 14, "sufficient_label_diversity": true, "processing": true, "minimum_examples_added": true, "successfully_trained": "successfully_trained", "available": false, "notices": 7, "minimum_queries_added": false}, "collection_count": 16}]}'
         responses.add(responses.GET,
                       url,
@@ -2713,23 +131,19 @@ class TestListProjects():
             with pytest.raises(ValueError):
                 _service.list_projects(**req_copy)
 
+    def test_list_projects_value_error_with_retries(self):
+        # Enable retries and run test_list_projects_value_error.
+        _service.enable_retries()
+        self.test_list_projects_value_error()
 
+        # Disable retries and run test_list_projects_value_error.
+        _service.disable_retries()
+        self.test_list_projects_value_error()
 
 class TestCreateProject():
     """
     Test Class for create_project
     """
-
-    def preprocess_url(self, request_url: str):
-        """
-        Preprocess the request URL to ensure the mock response will be found.
-        """
-        request_url = urllib.parse.unquote(request_url) # don't double-encode if already encoded
-        request_url = urllib.parse.quote(request_url, safe=':/')
-        if re.fullmatch('.*/+', request_url) is None:
-            return request_url
-        else:
-            return re.compile(request_url.rstrip('/') + '/+')
 
     @responses.activate
     def test_create_project_all_params(self):
@@ -2737,13 +151,13 @@ class TestCreateProject():
         create_project()
         """
         # Set up mock
-        url = self.preprocess_url(_base_url + '/v2/projects')
+        url = preprocess_url('/v2/projects')
         mock_response = '{"project_id": "project_id", "name": "name", "type": "document_retrieval", "relevancy_training_status": {"data_updated": "data_updated", "total_examples": 14, "sufficient_label_diversity": true, "processing": true, "minimum_examples_added": true, "successfully_trained": "successfully_trained", "available": false, "notices": 7, "minimum_queries_added": false}, "collection_count": 16, "default_query_parameters": {"collection_ids": ["collection_ids"], "passages": {"enabled": false, "count": 5, "fields": ["fields"], "characters": 10, "per_document": true, "max_per_document": 16}, "table_results": {"enabled": false, "count": 5, "per_document": 12}, "aggregation": "aggregation", "suggested_refinements": {"enabled": false, "count": 5}, "spelling_suggestions": true, "highlight": false, "count": 5, "sort": "sort", "return": ["return_"]}}'
         responses.add(responses.POST,
                       url,
                       body=mock_response,
                       content_type='application/json',
-                      status=200)
+                      status=201)
 
         # Construct a dict representation of a DefaultQueryParamsPassages model
         default_query_params_passages_model = {}
@@ -2793,13 +207,21 @@ class TestCreateProject():
 
         # Check for correct operation
         assert len(responses.calls) == 1
-        assert response.status_code == 200
+        assert response.status_code == 201
         # Validate body params
         req_body = json.loads(str(responses.calls[0].request.body, 'utf-8'))
         assert req_body['name'] == 'testString'
         assert req_body['type'] == 'document_retrieval'
         assert req_body['default_query_parameters'] == default_query_params_model
 
+    def test_create_project_all_params_with_retries(self):
+        # Enable retries and run test_create_project_all_params.
+        _service.enable_retries()
+        self.test_create_project_all_params()
+
+        # Disable retries and run test_create_project_all_params.
+        _service.disable_retries()
+        self.test_create_project_all_params()
 
     @responses.activate
     def test_create_project_value_error(self):
@@ -2807,13 +229,13 @@ class TestCreateProject():
         test_create_project_value_error()
         """
         # Set up mock
-        url = self.preprocess_url(_base_url + '/v2/projects')
+        url = preprocess_url('/v2/projects')
         mock_response = '{"project_id": "project_id", "name": "name", "type": "document_retrieval", "relevancy_training_status": {"data_updated": "data_updated", "total_examples": 14, "sufficient_label_diversity": true, "processing": true, "minimum_examples_added": true, "successfully_trained": "successfully_trained", "available": false, "notices": 7, "minimum_queries_added": false}, "collection_count": 16, "default_query_parameters": {"collection_ids": ["collection_ids"], "passages": {"enabled": false, "count": 5, "fields": ["fields"], "characters": 10, "per_document": true, "max_per_document": 16}, "table_results": {"enabled": false, "count": 5, "per_document": 12}, "aggregation": "aggregation", "suggested_refinements": {"enabled": false, "count": 5}, "spelling_suggestions": true, "highlight": false, "count": 5, "sort": "sort", "return": ["return_"]}}'
         responses.add(responses.POST,
                       url,
                       body=mock_response,
                       content_type='application/json',
-                      status=200)
+                      status=201)
 
         # Construct a dict representation of a DefaultQueryParamsPassages model
         default_query_params_passages_model = {}
@@ -2863,23 +285,19 @@ class TestCreateProject():
             with pytest.raises(ValueError):
                 _service.create_project(**req_copy)
 
+    def test_create_project_value_error_with_retries(self):
+        # Enable retries and run test_create_project_value_error.
+        _service.enable_retries()
+        self.test_create_project_value_error()
 
+        # Disable retries and run test_create_project_value_error.
+        _service.disable_retries()
+        self.test_create_project_value_error()
 
 class TestGetProject():
     """
     Test Class for get_project
     """
-
-    def preprocess_url(self, request_url: str):
-        """
-        Preprocess the request URL to ensure the mock response will be found.
-        """
-        request_url = urllib.parse.unquote(request_url) # don't double-encode if already encoded
-        request_url = urllib.parse.quote(request_url, safe=':/')
-        if re.fullmatch('.*/+', request_url) is None:
-            return request_url
-        else:
-            return re.compile(request_url.rstrip('/') + '/+')
 
     @responses.activate
     def test_get_project_all_params(self):
@@ -2887,7 +305,7 @@ class TestGetProject():
         get_project()
         """
         # Set up mock
-        url = self.preprocess_url(_base_url + '/v2/projects/testString')
+        url = preprocess_url('/v2/projects/testString')
         mock_response = '{"project_id": "project_id", "name": "name", "type": "document_retrieval", "relevancy_training_status": {"data_updated": "data_updated", "total_examples": 14, "sufficient_label_diversity": true, "processing": true, "minimum_examples_added": true, "successfully_trained": "successfully_trained", "available": false, "notices": 7, "minimum_queries_added": false}, "collection_count": 16, "default_query_parameters": {"collection_ids": ["collection_ids"], "passages": {"enabled": false, "count": 5, "fields": ["fields"], "characters": 10, "per_document": true, "max_per_document": 16}, "table_results": {"enabled": false, "count": 5, "per_document": 12}, "aggregation": "aggregation", "suggested_refinements": {"enabled": false, "count": 5}, "spelling_suggestions": true, "highlight": false, "count": 5, "sort": "sort", "return": ["return_"]}}'
         responses.add(responses.GET,
                       url,
@@ -2908,6 +326,14 @@ class TestGetProject():
         assert len(responses.calls) == 1
         assert response.status_code == 200
 
+    def test_get_project_all_params_with_retries(self):
+        # Enable retries and run test_get_project_all_params.
+        _service.enable_retries()
+        self.test_get_project_all_params()
+
+        # Disable retries and run test_get_project_all_params.
+        _service.disable_retries()
+        self.test_get_project_all_params()
 
     @responses.activate
     def test_get_project_value_error(self):
@@ -2915,7 +341,7 @@ class TestGetProject():
         test_get_project_value_error()
         """
         # Set up mock
-        url = self.preprocess_url(_base_url + '/v2/projects/testString')
+        url = preprocess_url('/v2/projects/testString')
         mock_response = '{"project_id": "project_id", "name": "name", "type": "document_retrieval", "relevancy_training_status": {"data_updated": "data_updated", "total_examples": 14, "sufficient_label_diversity": true, "processing": true, "minimum_examples_added": true, "successfully_trained": "successfully_trained", "available": false, "notices": 7, "minimum_queries_added": false}, "collection_count": 16, "default_query_parameters": {"collection_ids": ["collection_ids"], "passages": {"enabled": false, "count": 5, "fields": ["fields"], "characters": 10, "per_document": true, "max_per_document": 16}, "table_results": {"enabled": false, "count": 5, "per_document": 12}, "aggregation": "aggregation", "suggested_refinements": {"enabled": false, "count": 5}, "spelling_suggestions": true, "highlight": false, "count": 5, "sort": "sort", "return": ["return_"]}}'
         responses.add(responses.GET,
                       url,
@@ -2935,23 +361,19 @@ class TestGetProject():
             with pytest.raises(ValueError):
                 _service.get_project(**req_copy)
 
+    def test_get_project_value_error_with_retries(self):
+        # Enable retries and run test_get_project_value_error.
+        _service.enable_retries()
+        self.test_get_project_value_error()
 
+        # Disable retries and run test_get_project_value_error.
+        _service.disable_retries()
+        self.test_get_project_value_error()
 
 class TestUpdateProject():
     """
     Test Class for update_project
     """
-
-    def preprocess_url(self, request_url: str):
-        """
-        Preprocess the request URL to ensure the mock response will be found.
-        """
-        request_url = urllib.parse.unquote(request_url) # don't double-encode if already encoded
-        request_url = urllib.parse.quote(request_url, safe=':/')
-        if re.fullmatch('.*/+', request_url) is None:
-            return request_url
-        else:
-            return re.compile(request_url.rstrip('/') + '/+')
 
     @responses.activate
     def test_update_project_all_params(self):
@@ -2959,7 +381,7 @@ class TestUpdateProject():
         update_project()
         """
         # Set up mock
-        url = self.preprocess_url(_base_url + '/v2/projects/testString')
+        url = preprocess_url('/v2/projects/testString')
         mock_response = '{"project_id": "project_id", "name": "name", "type": "document_retrieval", "relevancy_training_status": {"data_updated": "data_updated", "total_examples": 14, "sufficient_label_diversity": true, "processing": true, "minimum_examples_added": true, "successfully_trained": "successfully_trained", "available": false, "notices": 7, "minimum_queries_added": false}, "collection_count": 16, "default_query_parameters": {"collection_ids": ["collection_ids"], "passages": {"enabled": false, "count": 5, "fields": ["fields"], "characters": 10, "per_document": true, "max_per_document": 16}, "table_results": {"enabled": false, "count": 5, "per_document": 12}, "aggregation": "aggregation", "suggested_refinements": {"enabled": false, "count": 5}, "spelling_suggestions": true, "highlight": false, "count": 5, "sort": "sort", "return": ["return_"]}}'
         responses.add(responses.POST,
                       url,
@@ -2985,6 +407,14 @@ class TestUpdateProject():
         req_body = json.loads(str(responses.calls[0].request.body, 'utf-8'))
         assert req_body['name'] == 'testString'
 
+    def test_update_project_all_params_with_retries(self):
+        # Enable retries and run test_update_project_all_params.
+        _service.enable_retries()
+        self.test_update_project_all_params()
+
+        # Disable retries and run test_update_project_all_params.
+        _service.disable_retries()
+        self.test_update_project_all_params()
 
     @responses.activate
     def test_update_project_required_params(self):
@@ -2992,7 +422,7 @@ class TestUpdateProject():
         test_update_project_required_params()
         """
         # Set up mock
-        url = self.preprocess_url(_base_url + '/v2/projects/testString')
+        url = preprocess_url('/v2/projects/testString')
         mock_response = '{"project_id": "project_id", "name": "name", "type": "document_retrieval", "relevancy_training_status": {"data_updated": "data_updated", "total_examples": 14, "sufficient_label_diversity": true, "processing": true, "minimum_examples_added": true, "successfully_trained": "successfully_trained", "available": false, "notices": 7, "minimum_queries_added": false}, "collection_count": 16, "default_query_parameters": {"collection_ids": ["collection_ids"], "passages": {"enabled": false, "count": 5, "fields": ["fields"], "characters": 10, "per_document": true, "max_per_document": 16}, "table_results": {"enabled": false, "count": 5, "per_document": 12}, "aggregation": "aggregation", "suggested_refinements": {"enabled": false, "count": 5}, "spelling_suggestions": true, "highlight": false, "count": 5, "sort": "sort", "return": ["return_"]}}'
         responses.add(responses.POST,
                       url,
@@ -3013,6 +443,14 @@ class TestUpdateProject():
         assert len(responses.calls) == 1
         assert response.status_code == 200
 
+    def test_update_project_required_params_with_retries(self):
+        # Enable retries and run test_update_project_required_params.
+        _service.enable_retries()
+        self.test_update_project_required_params()
+
+        # Disable retries and run test_update_project_required_params.
+        _service.disable_retries()
+        self.test_update_project_required_params()
 
     @responses.activate
     def test_update_project_value_error(self):
@@ -3020,7 +458,7 @@ class TestUpdateProject():
         test_update_project_value_error()
         """
         # Set up mock
-        url = self.preprocess_url(_base_url + '/v2/projects/testString')
+        url = preprocess_url('/v2/projects/testString')
         mock_response = '{"project_id": "project_id", "name": "name", "type": "document_retrieval", "relevancy_training_status": {"data_updated": "data_updated", "total_examples": 14, "sufficient_label_diversity": true, "processing": true, "minimum_examples_added": true, "successfully_trained": "successfully_trained", "available": false, "notices": 7, "minimum_queries_added": false}, "collection_count": 16, "default_query_parameters": {"collection_ids": ["collection_ids"], "passages": {"enabled": false, "count": 5, "fields": ["fields"], "characters": 10, "per_document": true, "max_per_document": 16}, "table_results": {"enabled": false, "count": 5, "per_document": 12}, "aggregation": "aggregation", "suggested_refinements": {"enabled": false, "count": 5}, "spelling_suggestions": true, "highlight": false, "count": 5, "sort": "sort", "return": ["return_"]}}'
         responses.add(responses.POST,
                       url,
@@ -3040,23 +478,19 @@ class TestUpdateProject():
             with pytest.raises(ValueError):
                 _service.update_project(**req_copy)
 
+    def test_update_project_value_error_with_retries(self):
+        # Enable retries and run test_update_project_value_error.
+        _service.enable_retries()
+        self.test_update_project_value_error()
 
+        # Disable retries and run test_update_project_value_error.
+        _service.disable_retries()
+        self.test_update_project_value_error()
 
 class TestDeleteProject():
     """
     Test Class for delete_project
     """
-
-    def preprocess_url(self, request_url: str):
-        """
-        Preprocess the request URL to ensure the mock response will be found.
-        """
-        request_url = urllib.parse.unquote(request_url) # don't double-encode if already encoded
-        request_url = urllib.parse.quote(request_url, safe=':/')
-        if re.fullmatch('.*/+', request_url) is None:
-            return request_url
-        else:
-            return re.compile(request_url.rstrip('/') + '/+')
 
     @responses.activate
     def test_delete_project_all_params(self):
@@ -3064,7 +498,7 @@ class TestDeleteProject():
         delete_project()
         """
         # Set up mock
-        url = self.preprocess_url(_base_url + '/v2/projects/testString')
+        url = preprocess_url('/v2/projects/testString')
         responses.add(responses.DELETE,
                       url,
                       status=204)
@@ -3082,6 +516,14 @@ class TestDeleteProject():
         assert len(responses.calls) == 1
         assert response.status_code == 204
 
+    def test_delete_project_all_params_with_retries(self):
+        # Enable retries and run test_delete_project_all_params.
+        _service.enable_retries()
+        self.test_delete_project_all_params()
+
+        # Disable retries and run test_delete_project_all_params.
+        _service.disable_retries()
+        self.test_delete_project_all_params()
 
     @responses.activate
     def test_delete_project_value_error(self):
@@ -3089,7 +531,7 @@ class TestDeleteProject():
         test_delete_project_value_error()
         """
         # Set up mock
-        url = self.preprocess_url(_base_url + '/v2/projects/testString')
+        url = preprocess_url('/v2/projects/testString')
         responses.add(responses.DELETE,
                       url,
                       status=204)
@@ -3106,11 +548,4624 @@ class TestDeleteProject():
             with pytest.raises(ValueError):
                 _service.delete_project(**req_copy)
 
+    def test_delete_project_value_error_with_retries(self):
+        # Enable retries and run test_delete_project_value_error.
+        _service.enable_retries()
+        self.test_delete_project_value_error()
 
+        # Disable retries and run test_delete_project_value_error.
+        _service.disable_retries()
+        self.test_delete_project_value_error()
+
+class TestListFields():
+    """
+    Test Class for list_fields
+    """
+
+    @responses.activate
+    def test_list_fields_all_params(self):
+        """
+        list_fields()
+        """
+        # Set up mock
+        url = preprocess_url('/v2/projects/testString/fields')
+        mock_response = '{"fields": [{"field": "field", "type": "nested", "collection_id": "collection_id"}]}'
+        responses.add(responses.GET,
+                      url,
+                      body=mock_response,
+                      content_type='application/json',
+                      status=200)
+
+        # Set up parameter values
+        project_id = 'testString'
+        collection_ids = ['testString']
+
+        # Invoke method
+        response = _service.list_fields(
+            project_id,
+            collection_ids=collection_ids,
+            headers={}
+        )
+
+        # Check for correct operation
+        assert len(responses.calls) == 1
+        assert response.status_code == 200
+        # Validate query params
+        query_string = responses.calls[0].request.url.split('?',1)[1]
+        query_string = urllib.parse.unquote_plus(query_string)
+        assert 'collection_ids={}'.format(','.join(collection_ids)) in query_string
+
+    def test_list_fields_all_params_with_retries(self):
+        # Enable retries and run test_list_fields_all_params.
+        _service.enable_retries()
+        self.test_list_fields_all_params()
+
+        # Disable retries and run test_list_fields_all_params.
+        _service.disable_retries()
+        self.test_list_fields_all_params()
+
+    @responses.activate
+    def test_list_fields_required_params(self):
+        """
+        test_list_fields_required_params()
+        """
+        # Set up mock
+        url = preprocess_url('/v2/projects/testString/fields')
+        mock_response = '{"fields": [{"field": "field", "type": "nested", "collection_id": "collection_id"}]}'
+        responses.add(responses.GET,
+                      url,
+                      body=mock_response,
+                      content_type='application/json',
+                      status=200)
+
+        # Set up parameter values
+        project_id = 'testString'
+
+        # Invoke method
+        response = _service.list_fields(
+            project_id,
+            headers={}
+        )
+
+        # Check for correct operation
+        assert len(responses.calls) == 1
+        assert response.status_code == 200
+
+    def test_list_fields_required_params_with_retries(self):
+        # Enable retries and run test_list_fields_required_params.
+        _service.enable_retries()
+        self.test_list_fields_required_params()
+
+        # Disable retries and run test_list_fields_required_params.
+        _service.disable_retries()
+        self.test_list_fields_required_params()
+
+    @responses.activate
+    def test_list_fields_value_error(self):
+        """
+        test_list_fields_value_error()
+        """
+        # Set up mock
+        url = preprocess_url('/v2/projects/testString/fields')
+        mock_response = '{"fields": [{"field": "field", "type": "nested", "collection_id": "collection_id"}]}'
+        responses.add(responses.GET,
+                      url,
+                      body=mock_response,
+                      content_type='application/json',
+                      status=200)
+
+        # Set up parameter values
+        project_id = 'testString'
+
+        # Pass in all but one required param and check for a ValueError
+        req_param_dict = {
+            "project_id": project_id,
+        }
+        for param in req_param_dict.keys():
+            req_copy = {key:val if key is not param else None for (key,val) in req_param_dict.items()}
+            with pytest.raises(ValueError):
+                _service.list_fields(**req_copy)
+
+    def test_list_fields_value_error_with_retries(self):
+        # Enable retries and run test_list_fields_value_error.
+        _service.enable_retries()
+        self.test_list_fields_value_error()
+
+        # Disable retries and run test_list_fields_value_error.
+        _service.disable_retries()
+        self.test_list_fields_value_error()
 
 # endregion
 ##############################################################################
 # End of Service: Projects
+##############################################################################
+
+##############################################################################
+# Start of Service: Collections
+##############################################################################
+# region
+
+class TestListCollections():
+    """
+    Test Class for list_collections
+    """
+
+    @responses.activate
+    def test_list_collections_all_params(self):
+        """
+        list_collections()
+        """
+        # Set up mock
+        url = preprocess_url('/v2/projects/testString/collections')
+        mock_response = '{"collections": [{"collection_id": "collection_id", "name": "name"}]}'
+        responses.add(responses.GET,
+                      url,
+                      body=mock_response,
+                      content_type='application/json',
+                      status=200)
+
+        # Set up parameter values
+        project_id = 'testString'
+
+        # Invoke method
+        response = _service.list_collections(
+            project_id,
+            headers={}
+        )
+
+        # Check for correct operation
+        assert len(responses.calls) == 1
+        assert response.status_code == 200
+
+    def test_list_collections_all_params_with_retries(self):
+        # Enable retries and run test_list_collections_all_params.
+        _service.enable_retries()
+        self.test_list_collections_all_params()
+
+        # Disable retries and run test_list_collections_all_params.
+        _service.disable_retries()
+        self.test_list_collections_all_params()
+
+    @responses.activate
+    def test_list_collections_value_error(self):
+        """
+        test_list_collections_value_error()
+        """
+        # Set up mock
+        url = preprocess_url('/v2/projects/testString/collections')
+        mock_response = '{"collections": [{"collection_id": "collection_id", "name": "name"}]}'
+        responses.add(responses.GET,
+                      url,
+                      body=mock_response,
+                      content_type='application/json',
+                      status=200)
+
+        # Set up parameter values
+        project_id = 'testString'
+
+        # Pass in all but one required param and check for a ValueError
+        req_param_dict = {
+            "project_id": project_id,
+        }
+        for param in req_param_dict.keys():
+            req_copy = {key:val if key is not param else None for (key,val) in req_param_dict.items()}
+            with pytest.raises(ValueError):
+                _service.list_collections(**req_copy)
+
+    def test_list_collections_value_error_with_retries(self):
+        # Enable retries and run test_list_collections_value_error.
+        _service.enable_retries()
+        self.test_list_collections_value_error()
+
+        # Disable retries and run test_list_collections_value_error.
+        _service.disable_retries()
+        self.test_list_collections_value_error()
+
+class TestCreateCollection():
+    """
+    Test Class for create_collection
+    """
+
+    @responses.activate
+    def test_create_collection_all_params(self):
+        """
+        create_collection()
+        """
+        # Set up mock
+        url = preprocess_url('/v2/projects/testString/collections')
+        mock_response = '{"collection_id": "collection_id", "name": "name", "description": "description", "created": "2019-01-01T12:00:00.000Z", "language": "en", "enrichments": [{"enrichment_id": "enrichment_id", "fields": ["fields"]}], "smart_document_understanding": {"enabled": false, "model": "custom"}}'
+        responses.add(responses.POST,
+                      url,
+                      body=mock_response,
+                      content_type='application/json',
+                      status=201)
+
+        # Construct a dict representation of a CollectionEnrichment model
+        collection_enrichment_model = {}
+        collection_enrichment_model['enrichment_id'] = 'testString'
+        collection_enrichment_model['fields'] = ['testString']
+
+        # Construct a dict representation of a CollectionDetailsSmartDocumentUnderstanding model
+        collection_details_smart_document_understanding_model = {}
+        collection_details_smart_document_understanding_model['enabled'] = True
+        collection_details_smart_document_understanding_model['model'] = 'custom'
+
+        # Set up parameter values
+        project_id = 'testString'
+        name = 'testString'
+        description = 'testString'
+        language = 'en'
+        enrichments = [collection_enrichment_model]
+        smart_document_understanding = collection_details_smart_document_understanding_model
+
+        # Invoke method
+        response = _service.create_collection(
+            project_id,
+            name,
+            description=description,
+            language=language,
+            enrichments=enrichments,
+            smart_document_understanding=smart_document_understanding,
+            headers={}
+        )
+
+        # Check for correct operation
+        assert len(responses.calls) == 1
+        assert response.status_code == 201
+        # Validate body params
+        req_body = json.loads(str(responses.calls[0].request.body, 'utf-8'))
+        assert req_body['name'] == 'testString'
+        assert req_body['description'] == 'testString'
+        assert req_body['language'] == 'en'
+        assert req_body['enrichments'] == [collection_enrichment_model]
+        assert req_body['smart_document_understanding'] == collection_details_smart_document_understanding_model
+
+    def test_create_collection_all_params_with_retries(self):
+        # Enable retries and run test_create_collection_all_params.
+        _service.enable_retries()
+        self.test_create_collection_all_params()
+
+        # Disable retries and run test_create_collection_all_params.
+        _service.disable_retries()
+        self.test_create_collection_all_params()
+
+    @responses.activate
+    def test_create_collection_value_error(self):
+        """
+        test_create_collection_value_error()
+        """
+        # Set up mock
+        url = preprocess_url('/v2/projects/testString/collections')
+        mock_response = '{"collection_id": "collection_id", "name": "name", "description": "description", "created": "2019-01-01T12:00:00.000Z", "language": "en", "enrichments": [{"enrichment_id": "enrichment_id", "fields": ["fields"]}], "smart_document_understanding": {"enabled": false, "model": "custom"}}'
+        responses.add(responses.POST,
+                      url,
+                      body=mock_response,
+                      content_type='application/json',
+                      status=201)
+
+        # Construct a dict representation of a CollectionEnrichment model
+        collection_enrichment_model = {}
+        collection_enrichment_model['enrichment_id'] = 'testString'
+        collection_enrichment_model['fields'] = ['testString']
+
+        # Construct a dict representation of a CollectionDetailsSmartDocumentUnderstanding model
+        collection_details_smart_document_understanding_model = {}
+        collection_details_smart_document_understanding_model['enabled'] = True
+        collection_details_smart_document_understanding_model['model'] = 'custom'
+
+        # Set up parameter values
+        project_id = 'testString'
+        name = 'testString'
+        description = 'testString'
+        language = 'en'
+        enrichments = [collection_enrichment_model]
+        smart_document_understanding = collection_details_smart_document_understanding_model
+
+        # Pass in all but one required param and check for a ValueError
+        req_param_dict = {
+            "project_id": project_id,
+            "name": name,
+        }
+        for param in req_param_dict.keys():
+            req_copy = {key:val if key is not param else None for (key,val) in req_param_dict.items()}
+            with pytest.raises(ValueError):
+                _service.create_collection(**req_copy)
+
+    def test_create_collection_value_error_with_retries(self):
+        # Enable retries and run test_create_collection_value_error.
+        _service.enable_retries()
+        self.test_create_collection_value_error()
+
+        # Disable retries and run test_create_collection_value_error.
+        _service.disable_retries()
+        self.test_create_collection_value_error()
+
+class TestGetCollection():
+    """
+    Test Class for get_collection
+    """
+
+    @responses.activate
+    def test_get_collection_all_params(self):
+        """
+        get_collection()
+        """
+        # Set up mock
+        url = preprocess_url('/v2/projects/testString/collections/testString')
+        mock_response = '{"collection_id": "collection_id", "name": "name", "description": "description", "created": "2019-01-01T12:00:00.000Z", "language": "en", "enrichments": [{"enrichment_id": "enrichment_id", "fields": ["fields"]}], "smart_document_understanding": {"enabled": false, "model": "custom"}}'
+        responses.add(responses.GET,
+                      url,
+                      body=mock_response,
+                      content_type='application/json',
+                      status=200)
+
+        # Set up parameter values
+        project_id = 'testString'
+        collection_id = 'testString'
+
+        # Invoke method
+        response = _service.get_collection(
+            project_id,
+            collection_id,
+            headers={}
+        )
+
+        # Check for correct operation
+        assert len(responses.calls) == 1
+        assert response.status_code == 200
+
+    def test_get_collection_all_params_with_retries(self):
+        # Enable retries and run test_get_collection_all_params.
+        _service.enable_retries()
+        self.test_get_collection_all_params()
+
+        # Disable retries and run test_get_collection_all_params.
+        _service.disable_retries()
+        self.test_get_collection_all_params()
+
+    @responses.activate
+    def test_get_collection_value_error(self):
+        """
+        test_get_collection_value_error()
+        """
+        # Set up mock
+        url = preprocess_url('/v2/projects/testString/collections/testString')
+        mock_response = '{"collection_id": "collection_id", "name": "name", "description": "description", "created": "2019-01-01T12:00:00.000Z", "language": "en", "enrichments": [{"enrichment_id": "enrichment_id", "fields": ["fields"]}], "smart_document_understanding": {"enabled": false, "model": "custom"}}'
+        responses.add(responses.GET,
+                      url,
+                      body=mock_response,
+                      content_type='application/json',
+                      status=200)
+
+        # Set up parameter values
+        project_id = 'testString'
+        collection_id = 'testString'
+
+        # Pass in all but one required param and check for a ValueError
+        req_param_dict = {
+            "project_id": project_id,
+            "collection_id": collection_id,
+        }
+        for param in req_param_dict.keys():
+            req_copy = {key:val if key is not param else None for (key,val) in req_param_dict.items()}
+            with pytest.raises(ValueError):
+                _service.get_collection(**req_copy)
+
+    def test_get_collection_value_error_with_retries(self):
+        # Enable retries and run test_get_collection_value_error.
+        _service.enable_retries()
+        self.test_get_collection_value_error()
+
+        # Disable retries and run test_get_collection_value_error.
+        _service.disable_retries()
+        self.test_get_collection_value_error()
+
+class TestUpdateCollection():
+    """
+    Test Class for update_collection
+    """
+
+    @responses.activate
+    def test_update_collection_all_params(self):
+        """
+        update_collection()
+        """
+        # Set up mock
+        url = preprocess_url('/v2/projects/testString/collections/testString')
+        mock_response = '{"collection_id": "collection_id", "name": "name", "description": "description", "created": "2019-01-01T12:00:00.000Z", "language": "en", "enrichments": [{"enrichment_id": "enrichment_id", "fields": ["fields"]}], "smart_document_understanding": {"enabled": false, "model": "custom"}}'
+        responses.add(responses.POST,
+                      url,
+                      body=mock_response,
+                      content_type='application/json',
+                      status=200)
+
+        # Construct a dict representation of a CollectionEnrichment model
+        collection_enrichment_model = {}
+        collection_enrichment_model['enrichment_id'] = 'testString'
+        collection_enrichment_model['fields'] = ['testString']
+
+        # Set up parameter values
+        project_id = 'testString'
+        collection_id = 'testString'
+        name = 'testString'
+        description = 'testString'
+        enrichments = [collection_enrichment_model]
+
+        # Invoke method
+        response = _service.update_collection(
+            project_id,
+            collection_id,
+            name=name,
+            description=description,
+            enrichments=enrichments,
+            headers={}
+        )
+
+        # Check for correct operation
+        assert len(responses.calls) == 1
+        assert response.status_code == 200
+        # Validate body params
+        req_body = json.loads(str(responses.calls[0].request.body, 'utf-8'))
+        assert req_body['name'] == 'testString'
+        assert req_body['description'] == 'testString'
+        assert req_body['enrichments'] == [collection_enrichment_model]
+
+    def test_update_collection_all_params_with_retries(self):
+        # Enable retries and run test_update_collection_all_params.
+        _service.enable_retries()
+        self.test_update_collection_all_params()
+
+        # Disable retries and run test_update_collection_all_params.
+        _service.disable_retries()
+        self.test_update_collection_all_params()
+
+    @responses.activate
+    def test_update_collection_value_error(self):
+        """
+        test_update_collection_value_error()
+        """
+        # Set up mock
+        url = preprocess_url('/v2/projects/testString/collections/testString')
+        mock_response = '{"collection_id": "collection_id", "name": "name", "description": "description", "created": "2019-01-01T12:00:00.000Z", "language": "en", "enrichments": [{"enrichment_id": "enrichment_id", "fields": ["fields"]}], "smart_document_understanding": {"enabled": false, "model": "custom"}}'
+        responses.add(responses.POST,
+                      url,
+                      body=mock_response,
+                      content_type='application/json',
+                      status=200)
+
+        # Construct a dict representation of a CollectionEnrichment model
+        collection_enrichment_model = {}
+        collection_enrichment_model['enrichment_id'] = 'testString'
+        collection_enrichment_model['fields'] = ['testString']
+
+        # Set up parameter values
+        project_id = 'testString'
+        collection_id = 'testString'
+        name = 'testString'
+        description = 'testString'
+        enrichments = [collection_enrichment_model]
+
+        # Pass in all but one required param and check for a ValueError
+        req_param_dict = {
+            "project_id": project_id,
+            "collection_id": collection_id,
+        }
+        for param in req_param_dict.keys():
+            req_copy = {key:val if key is not param else None for (key,val) in req_param_dict.items()}
+            with pytest.raises(ValueError):
+                _service.update_collection(**req_copy)
+
+    def test_update_collection_value_error_with_retries(self):
+        # Enable retries and run test_update_collection_value_error.
+        _service.enable_retries()
+        self.test_update_collection_value_error()
+
+        # Disable retries and run test_update_collection_value_error.
+        _service.disable_retries()
+        self.test_update_collection_value_error()
+
+class TestDeleteCollection():
+    """
+    Test Class for delete_collection
+    """
+
+    @responses.activate
+    def test_delete_collection_all_params(self):
+        """
+        delete_collection()
+        """
+        # Set up mock
+        url = preprocess_url('/v2/projects/testString/collections/testString')
+        responses.add(responses.DELETE,
+                      url,
+                      status=204)
+
+        # Set up parameter values
+        project_id = 'testString'
+        collection_id = 'testString'
+
+        # Invoke method
+        response = _service.delete_collection(
+            project_id,
+            collection_id,
+            headers={}
+        )
+
+        # Check for correct operation
+        assert len(responses.calls) == 1
+        assert response.status_code == 204
+
+    def test_delete_collection_all_params_with_retries(self):
+        # Enable retries and run test_delete_collection_all_params.
+        _service.enable_retries()
+        self.test_delete_collection_all_params()
+
+        # Disable retries and run test_delete_collection_all_params.
+        _service.disable_retries()
+        self.test_delete_collection_all_params()
+
+    @responses.activate
+    def test_delete_collection_value_error(self):
+        """
+        test_delete_collection_value_error()
+        """
+        # Set up mock
+        url = preprocess_url('/v2/projects/testString/collections/testString')
+        responses.add(responses.DELETE,
+                      url,
+                      status=204)
+
+        # Set up parameter values
+        project_id = 'testString'
+        collection_id = 'testString'
+
+        # Pass in all but one required param and check for a ValueError
+        req_param_dict = {
+            "project_id": project_id,
+            "collection_id": collection_id,
+        }
+        for param in req_param_dict.keys():
+            req_copy = {key:val if key is not param else None for (key,val) in req_param_dict.items()}
+            with pytest.raises(ValueError):
+                _service.delete_collection(**req_copy)
+
+    def test_delete_collection_value_error_with_retries(self):
+        # Enable retries and run test_delete_collection_value_error.
+        _service.enable_retries()
+        self.test_delete_collection_value_error()
+
+        # Disable retries and run test_delete_collection_value_error.
+        _service.disable_retries()
+        self.test_delete_collection_value_error()
+
+# endregion
+##############################################################################
+# End of Service: Collections
+##############################################################################
+
+##############################################################################
+# Start of Service: Documents
+##############################################################################
+# region
+
+class TestListDocuments():
+    """
+    Test Class for list_documents
+    """
+
+    @responses.activate
+    def test_list_documents_all_params(self):
+        """
+        list_documents()
+        """
+        # Set up mock
+        url = preprocess_url('/v2/projects/testString/collections/testString/documents')
+        mock_response = '{"matching_results": 16, "documents": [{"document_id": "document_id", "created": "2019-01-01T12:00:00.000Z", "updated": "2019-01-01T12:00:00.000Z", "status": "available", "notices": [{"notice_id": "notice_id", "created": "2019-01-01T12:00:00.000Z", "document_id": "document_id", "collection_id": "collection_id", "query_id": "query_id", "severity": "warning", "step": "step", "description": "description"}], "children": {"have_notices": true, "count": 5}, "filename": "filename", "file_type": "file_type", "sha256": "sha256"}]}'
+        responses.add(responses.GET,
+                      url,
+                      body=mock_response,
+                      content_type='application/json',
+                      status=200)
+
+        # Set up parameter values
+        project_id = 'testString'
+        collection_id = 'testString'
+        count = 38
+        status = 'testString'
+        has_notices = True
+        is_parent = True
+        parent_document_id = 'testString'
+        sha256 = 'testString'
+
+        # Invoke method
+        response = _service.list_documents(
+            project_id,
+            collection_id,
+            count=count,
+            status=status,
+            has_notices=has_notices,
+            is_parent=is_parent,
+            parent_document_id=parent_document_id,
+            sha256=sha256,
+            headers={}
+        )
+
+        # Check for correct operation
+        assert len(responses.calls) == 1
+        assert response.status_code == 200
+        # Validate query params
+        query_string = responses.calls[0].request.url.split('?',1)[1]
+        query_string = urllib.parse.unquote_plus(query_string)
+        assert 'count={}'.format(count) in query_string
+        assert 'status={}'.format(status) in query_string
+        assert 'has_notices={}'.format('true' if has_notices else 'false') in query_string
+        assert 'is_parent={}'.format('true' if is_parent else 'false') in query_string
+        assert 'parent_document_id={}'.format(parent_document_id) in query_string
+        assert 'sha256={}'.format(sha256) in query_string
+
+    def test_list_documents_all_params_with_retries(self):
+        # Enable retries and run test_list_documents_all_params.
+        _service.enable_retries()
+        self.test_list_documents_all_params()
+
+        # Disable retries and run test_list_documents_all_params.
+        _service.disable_retries()
+        self.test_list_documents_all_params()
+
+    @responses.activate
+    def test_list_documents_required_params(self):
+        """
+        test_list_documents_required_params()
+        """
+        # Set up mock
+        url = preprocess_url('/v2/projects/testString/collections/testString/documents')
+        mock_response = '{"matching_results": 16, "documents": [{"document_id": "document_id", "created": "2019-01-01T12:00:00.000Z", "updated": "2019-01-01T12:00:00.000Z", "status": "available", "notices": [{"notice_id": "notice_id", "created": "2019-01-01T12:00:00.000Z", "document_id": "document_id", "collection_id": "collection_id", "query_id": "query_id", "severity": "warning", "step": "step", "description": "description"}], "children": {"have_notices": true, "count": 5}, "filename": "filename", "file_type": "file_type", "sha256": "sha256"}]}'
+        responses.add(responses.GET,
+                      url,
+                      body=mock_response,
+                      content_type='application/json',
+                      status=200)
+
+        # Set up parameter values
+        project_id = 'testString'
+        collection_id = 'testString'
+
+        # Invoke method
+        response = _service.list_documents(
+            project_id,
+            collection_id,
+            headers={}
+        )
+
+        # Check for correct operation
+        assert len(responses.calls) == 1
+        assert response.status_code == 200
+
+    def test_list_documents_required_params_with_retries(self):
+        # Enable retries and run test_list_documents_required_params.
+        _service.enable_retries()
+        self.test_list_documents_required_params()
+
+        # Disable retries and run test_list_documents_required_params.
+        _service.disable_retries()
+        self.test_list_documents_required_params()
+
+    @responses.activate
+    def test_list_documents_value_error(self):
+        """
+        test_list_documents_value_error()
+        """
+        # Set up mock
+        url = preprocess_url('/v2/projects/testString/collections/testString/documents')
+        mock_response = '{"matching_results": 16, "documents": [{"document_id": "document_id", "created": "2019-01-01T12:00:00.000Z", "updated": "2019-01-01T12:00:00.000Z", "status": "available", "notices": [{"notice_id": "notice_id", "created": "2019-01-01T12:00:00.000Z", "document_id": "document_id", "collection_id": "collection_id", "query_id": "query_id", "severity": "warning", "step": "step", "description": "description"}], "children": {"have_notices": true, "count": 5}, "filename": "filename", "file_type": "file_type", "sha256": "sha256"}]}'
+        responses.add(responses.GET,
+                      url,
+                      body=mock_response,
+                      content_type='application/json',
+                      status=200)
+
+        # Set up parameter values
+        project_id = 'testString'
+        collection_id = 'testString'
+
+        # Pass in all but one required param and check for a ValueError
+        req_param_dict = {
+            "project_id": project_id,
+            "collection_id": collection_id,
+        }
+        for param in req_param_dict.keys():
+            req_copy = {key:val if key is not param else None for (key,val) in req_param_dict.items()}
+            with pytest.raises(ValueError):
+                _service.list_documents(**req_copy)
+
+    def test_list_documents_value_error_with_retries(self):
+        # Enable retries and run test_list_documents_value_error.
+        _service.enable_retries()
+        self.test_list_documents_value_error()
+
+        # Disable retries and run test_list_documents_value_error.
+        _service.disable_retries()
+        self.test_list_documents_value_error()
+
+class TestAddDocument():
+    """
+    Test Class for add_document
+    """
+
+    @responses.activate
+    def test_add_document_all_params(self):
+        """
+        add_document()
+        """
+        # Set up mock
+        url = preprocess_url('/v2/projects/testString/collections/testString/documents')
+        mock_response = '{"document_id": "document_id", "status": "processing"}'
+        responses.add(responses.POST,
+                      url,
+                      body=mock_response,
+                      content_type='application/json',
+                      status=202)
+
+        # Set up parameter values
+        project_id = 'testString'
+        collection_id = 'testString'
+        file = io.BytesIO(b'This is a mock file.').getvalue()
+        filename = 'testString'
+        file_content_type = 'application/json'
+        metadata = 'testString'
+        x_watson_discovery_force = False
+
+        # Invoke method
+        response = _service.add_document(
+            project_id,
+            collection_id,
+            file=file,
+            filename=filename,
+            file_content_type=file_content_type,
+            metadata=metadata,
+            x_watson_discovery_force=x_watson_discovery_force,
+            headers={}
+        )
+
+        # Check for correct operation
+        assert len(responses.calls) == 1
+        assert response.status_code == 202
+
+    def test_add_document_all_params_with_retries(self):
+        # Enable retries and run test_add_document_all_params.
+        _service.enable_retries()
+        self.test_add_document_all_params()
+
+        # Disable retries and run test_add_document_all_params.
+        _service.disable_retries()
+        self.test_add_document_all_params()
+
+    @responses.activate
+    def test_add_document_required_params(self):
+        """
+        test_add_document_required_params()
+        """
+        # Set up mock
+        url = preprocess_url('/v2/projects/testString/collections/testString/documents')
+        mock_response = '{"document_id": "document_id", "status": "processing"}'
+        responses.add(responses.POST,
+                      url,
+                      body=mock_response,
+                      content_type='application/json',
+                      status=202)
+
+        # Set up parameter values
+        project_id = 'testString'
+        collection_id = 'testString'
+
+        # Invoke method
+        response = _service.add_document(
+            project_id,
+            collection_id,
+            headers={}
+        )
+
+        # Check for correct operation
+        assert len(responses.calls) == 1
+        assert response.status_code == 202
+
+    def test_add_document_required_params_with_retries(self):
+        # Enable retries and run test_add_document_required_params.
+        _service.enable_retries()
+        self.test_add_document_required_params()
+
+        # Disable retries and run test_add_document_required_params.
+        _service.disable_retries()
+        self.test_add_document_required_params()
+
+    @responses.activate
+    def test_add_document_value_error(self):
+        """
+        test_add_document_value_error()
+        """
+        # Set up mock
+        url = preprocess_url('/v2/projects/testString/collections/testString/documents')
+        mock_response = '{"document_id": "document_id", "status": "processing"}'
+        responses.add(responses.POST,
+                      url,
+                      body=mock_response,
+                      content_type='application/json',
+                      status=202)
+
+        # Set up parameter values
+        project_id = 'testString'
+        collection_id = 'testString'
+
+        # Pass in all but one required param and check for a ValueError
+        req_param_dict = {
+            "project_id": project_id,
+            "collection_id": collection_id,
+        }
+        for param in req_param_dict.keys():
+            req_copy = {key:val if key is not param else None for (key,val) in req_param_dict.items()}
+            with pytest.raises(ValueError):
+                _service.add_document(**req_copy)
+
+    def test_add_document_value_error_with_retries(self):
+        # Enable retries and run test_add_document_value_error.
+        _service.enable_retries()
+        self.test_add_document_value_error()
+
+        # Disable retries and run test_add_document_value_error.
+        _service.disable_retries()
+        self.test_add_document_value_error()
+
+class TestGetDocument():
+    """
+    Test Class for get_document
+    """
+
+    @responses.activate
+    def test_get_document_all_params(self):
+        """
+        get_document()
+        """
+        # Set up mock
+        url = preprocess_url('/v2/projects/testString/collections/testString/documents/testString')
+        mock_response = '{"document_id": "document_id", "created": "2019-01-01T12:00:00.000Z", "updated": "2019-01-01T12:00:00.000Z", "status": "available", "notices": [{"notice_id": "notice_id", "created": "2019-01-01T12:00:00.000Z", "document_id": "document_id", "collection_id": "collection_id", "query_id": "query_id", "severity": "warning", "step": "step", "description": "description"}], "children": {"have_notices": true, "count": 5}, "filename": "filename", "file_type": "file_type", "sha256": "sha256"}'
+        responses.add(responses.GET,
+                      url,
+                      body=mock_response,
+                      content_type='application/json',
+                      status=200)
+
+        # Set up parameter values
+        project_id = 'testString'
+        collection_id = 'testString'
+        document_id = 'testString'
+
+        # Invoke method
+        response = _service.get_document(
+            project_id,
+            collection_id,
+            document_id,
+            headers={}
+        )
+
+        # Check for correct operation
+        assert len(responses.calls) == 1
+        assert response.status_code == 200
+
+    def test_get_document_all_params_with_retries(self):
+        # Enable retries and run test_get_document_all_params.
+        _service.enable_retries()
+        self.test_get_document_all_params()
+
+        # Disable retries and run test_get_document_all_params.
+        _service.disable_retries()
+        self.test_get_document_all_params()
+
+    @responses.activate
+    def test_get_document_value_error(self):
+        """
+        test_get_document_value_error()
+        """
+        # Set up mock
+        url = preprocess_url('/v2/projects/testString/collections/testString/documents/testString')
+        mock_response = '{"document_id": "document_id", "created": "2019-01-01T12:00:00.000Z", "updated": "2019-01-01T12:00:00.000Z", "status": "available", "notices": [{"notice_id": "notice_id", "created": "2019-01-01T12:00:00.000Z", "document_id": "document_id", "collection_id": "collection_id", "query_id": "query_id", "severity": "warning", "step": "step", "description": "description"}], "children": {"have_notices": true, "count": 5}, "filename": "filename", "file_type": "file_type", "sha256": "sha256"}'
+        responses.add(responses.GET,
+                      url,
+                      body=mock_response,
+                      content_type='application/json',
+                      status=200)
+
+        # Set up parameter values
+        project_id = 'testString'
+        collection_id = 'testString'
+        document_id = 'testString'
+
+        # Pass in all but one required param and check for a ValueError
+        req_param_dict = {
+            "project_id": project_id,
+            "collection_id": collection_id,
+            "document_id": document_id,
+        }
+        for param in req_param_dict.keys():
+            req_copy = {key:val if key is not param else None for (key,val) in req_param_dict.items()}
+            with pytest.raises(ValueError):
+                _service.get_document(**req_copy)
+
+    def test_get_document_value_error_with_retries(self):
+        # Enable retries and run test_get_document_value_error.
+        _service.enable_retries()
+        self.test_get_document_value_error()
+
+        # Disable retries and run test_get_document_value_error.
+        _service.disable_retries()
+        self.test_get_document_value_error()
+
+class TestUpdateDocument():
+    """
+    Test Class for update_document
+    """
+
+    @responses.activate
+    def test_update_document_all_params(self):
+        """
+        update_document()
+        """
+        # Set up mock
+        url = preprocess_url('/v2/projects/testString/collections/testString/documents/testString')
+        mock_response = '{"document_id": "document_id", "status": "processing"}'
+        responses.add(responses.POST,
+                      url,
+                      body=mock_response,
+                      content_type='application/json',
+                      status=202)
+
+        # Set up parameter values
+        project_id = 'testString'
+        collection_id = 'testString'
+        document_id = 'testString'
+        file = io.BytesIO(b'This is a mock file.').getvalue()
+        filename = 'testString'
+        file_content_type = 'application/json'
+        metadata = 'testString'
+        x_watson_discovery_force = False
+
+        # Invoke method
+        response = _service.update_document(
+            project_id,
+            collection_id,
+            document_id,
+            file=file,
+            filename=filename,
+            file_content_type=file_content_type,
+            metadata=metadata,
+            x_watson_discovery_force=x_watson_discovery_force,
+            headers={}
+        )
+
+        # Check for correct operation
+        assert len(responses.calls) == 1
+        assert response.status_code == 202
+
+    def test_update_document_all_params_with_retries(self):
+        # Enable retries and run test_update_document_all_params.
+        _service.enable_retries()
+        self.test_update_document_all_params()
+
+        # Disable retries and run test_update_document_all_params.
+        _service.disable_retries()
+        self.test_update_document_all_params()
+
+    @responses.activate
+    def test_update_document_required_params(self):
+        """
+        test_update_document_required_params()
+        """
+        # Set up mock
+        url = preprocess_url('/v2/projects/testString/collections/testString/documents/testString')
+        mock_response = '{"document_id": "document_id", "status": "processing"}'
+        responses.add(responses.POST,
+                      url,
+                      body=mock_response,
+                      content_type='application/json',
+                      status=202)
+
+        # Set up parameter values
+        project_id = 'testString'
+        collection_id = 'testString'
+        document_id = 'testString'
+
+        # Invoke method
+        response = _service.update_document(
+            project_id,
+            collection_id,
+            document_id,
+            headers={}
+        )
+
+        # Check for correct operation
+        assert len(responses.calls) == 1
+        assert response.status_code == 202
+
+    def test_update_document_required_params_with_retries(self):
+        # Enable retries and run test_update_document_required_params.
+        _service.enable_retries()
+        self.test_update_document_required_params()
+
+        # Disable retries and run test_update_document_required_params.
+        _service.disable_retries()
+        self.test_update_document_required_params()
+
+    @responses.activate
+    def test_update_document_value_error(self):
+        """
+        test_update_document_value_error()
+        """
+        # Set up mock
+        url = preprocess_url('/v2/projects/testString/collections/testString/documents/testString')
+        mock_response = '{"document_id": "document_id", "status": "processing"}'
+        responses.add(responses.POST,
+                      url,
+                      body=mock_response,
+                      content_type='application/json',
+                      status=202)
+
+        # Set up parameter values
+        project_id = 'testString'
+        collection_id = 'testString'
+        document_id = 'testString'
+
+        # Pass in all but one required param and check for a ValueError
+        req_param_dict = {
+            "project_id": project_id,
+            "collection_id": collection_id,
+            "document_id": document_id,
+        }
+        for param in req_param_dict.keys():
+            req_copy = {key:val if key is not param else None for (key,val) in req_param_dict.items()}
+            with pytest.raises(ValueError):
+                _service.update_document(**req_copy)
+
+    def test_update_document_value_error_with_retries(self):
+        # Enable retries and run test_update_document_value_error.
+        _service.enable_retries()
+        self.test_update_document_value_error()
+
+        # Disable retries and run test_update_document_value_error.
+        _service.disable_retries()
+        self.test_update_document_value_error()
+
+class TestDeleteDocument():
+    """
+    Test Class for delete_document
+    """
+
+    @responses.activate
+    def test_delete_document_all_params(self):
+        """
+        delete_document()
+        """
+        # Set up mock
+        url = preprocess_url('/v2/projects/testString/collections/testString/documents/testString')
+        mock_response = '{"document_id": "document_id", "status": "deleted"}'
+        responses.add(responses.DELETE,
+                      url,
+                      body=mock_response,
+                      content_type='application/json',
+                      status=200)
+
+        # Set up parameter values
+        project_id = 'testString'
+        collection_id = 'testString'
+        document_id = 'testString'
+        x_watson_discovery_force = False
+
+        # Invoke method
+        response = _service.delete_document(
+            project_id,
+            collection_id,
+            document_id,
+            x_watson_discovery_force=x_watson_discovery_force,
+            headers={}
+        )
+
+        # Check for correct operation
+        assert len(responses.calls) == 1
+        assert response.status_code == 200
+
+    def test_delete_document_all_params_with_retries(self):
+        # Enable retries and run test_delete_document_all_params.
+        _service.enable_retries()
+        self.test_delete_document_all_params()
+
+        # Disable retries and run test_delete_document_all_params.
+        _service.disable_retries()
+        self.test_delete_document_all_params()
+
+    @responses.activate
+    def test_delete_document_required_params(self):
+        """
+        test_delete_document_required_params()
+        """
+        # Set up mock
+        url = preprocess_url('/v2/projects/testString/collections/testString/documents/testString')
+        mock_response = '{"document_id": "document_id", "status": "deleted"}'
+        responses.add(responses.DELETE,
+                      url,
+                      body=mock_response,
+                      content_type='application/json',
+                      status=200)
+
+        # Set up parameter values
+        project_id = 'testString'
+        collection_id = 'testString'
+        document_id = 'testString'
+
+        # Invoke method
+        response = _service.delete_document(
+            project_id,
+            collection_id,
+            document_id,
+            headers={}
+        )
+
+        # Check for correct operation
+        assert len(responses.calls) == 1
+        assert response.status_code == 200
+
+    def test_delete_document_required_params_with_retries(self):
+        # Enable retries and run test_delete_document_required_params.
+        _service.enable_retries()
+        self.test_delete_document_required_params()
+
+        # Disable retries and run test_delete_document_required_params.
+        _service.disable_retries()
+        self.test_delete_document_required_params()
+
+    @responses.activate
+    def test_delete_document_value_error(self):
+        """
+        test_delete_document_value_error()
+        """
+        # Set up mock
+        url = preprocess_url('/v2/projects/testString/collections/testString/documents/testString')
+        mock_response = '{"document_id": "document_id", "status": "deleted"}'
+        responses.add(responses.DELETE,
+                      url,
+                      body=mock_response,
+                      content_type='application/json',
+                      status=200)
+
+        # Set up parameter values
+        project_id = 'testString'
+        collection_id = 'testString'
+        document_id = 'testString'
+
+        # Pass in all but one required param and check for a ValueError
+        req_param_dict = {
+            "project_id": project_id,
+            "collection_id": collection_id,
+            "document_id": document_id,
+        }
+        for param in req_param_dict.keys():
+            req_copy = {key:val if key is not param else None for (key,val) in req_param_dict.items()}
+            with pytest.raises(ValueError):
+                _service.delete_document(**req_copy)
+
+    def test_delete_document_value_error_with_retries(self):
+        # Enable retries and run test_delete_document_value_error.
+        _service.enable_retries()
+        self.test_delete_document_value_error()
+
+        # Disable retries and run test_delete_document_value_error.
+        _service.disable_retries()
+        self.test_delete_document_value_error()
+
+# endregion
+##############################################################################
+# End of Service: Documents
+##############################################################################
+
+##############################################################################
+# Start of Service: Queries
+##############################################################################
+# region
+
+class TestQuery():
+    """
+    Test Class for query
+    """
+
+    @responses.activate
+    def test_query_all_params(self):
+        """
+        query()
+        """
+        # Set up mock
+        url = preprocess_url('/v2/projects/testString/query')
+        mock_response = '{"matching_results": 16, "results": [{"document_id": "document_id", "metadata": {"mapKey": "anyValue"}, "result_metadata": {"document_retrieval_source": "search", "collection_id": "collection_id", "confidence": 10}, "document_passages": [{"passage_text": "passage_text", "start_offset": 12, "end_offset": 10, "field": "field", "confidence": 0, "answers": [{"answer_text": "answer_text", "start_offset": 12, "end_offset": 10, "confidence": 0}]}]}], "aggregations": [{"type": "filter", "match": "match", "matching_results": 16}], "retrieval_details": {"document_retrieval_strategy": "untrained"}, "suggested_query": "suggested_query", "suggested_refinements": [{"text": "text"}], "table_results": [{"table_id": "table_id", "source_document_id": "source_document_id", "collection_id": "collection_id", "table_html": "table_html", "table_html_offset": 17, "table": {"location": {"begin": 5, "end": 3}, "text": "text", "section_title": {"text": "text", "location": {"begin": 5, "end": 3}}, "title": {"text": "text", "location": {"begin": 5, "end": 3}}, "table_headers": [{"cell_id": "cell_id", "location": {"anyKey": "anyValue"}, "text": "text", "row_index_begin": 15, "row_index_end": 13, "column_index_begin": 18, "column_index_end": 16}], "row_headers": [{"cell_id": "cell_id", "location": {"begin": 5, "end": 3}, "text": "text", "text_normalized": "text_normalized", "row_index_begin": 15, "row_index_end": 13, "column_index_begin": 18, "column_index_end": 16}], "column_headers": [{"cell_id": "cell_id", "location": {"anyKey": "anyValue"}, "text": "text", "text_normalized": "text_normalized", "row_index_begin": 15, "row_index_end": 13, "column_index_begin": 18, "column_index_end": 16}], "key_value_pairs": [{"key": {"cell_id": "cell_id", "location": {"begin": 5, "end": 3}, "text": "text"}, "value": [{"cell_id": "cell_id", "location": {"begin": 5, "end": 3}, "text": "text"}]}], "body_cells": [{"cell_id": "cell_id", "location": {"begin": 5, "end": 3}, "text": "text", "row_index_begin": 15, "row_index_end": 13, "column_index_begin": 18, "column_index_end": 16, "row_header_ids": [{"id": "id"}], "row_header_texts": [{"text": "text"}], "row_header_texts_normalized": [{"text_normalized": "text_normalized"}], "column_header_ids": [{"id": "id"}], "column_header_texts": [{"text": "text"}], "column_header_texts_normalized": [{"text_normalized": "text_normalized"}], "attributes": [{"type": "type", "text": "text", "location": {"begin": 5, "end": 3}}]}], "contexts": [{"text": "text", "location": {"begin": 5, "end": 3}}]}}], "passages": [{"passage_text": "passage_text", "passage_score": 13, "document_id": "document_id", "collection_id": "collection_id", "start_offset": 12, "end_offset": 10, "field": "field", "confidence": 0, "answers": [{"answer_text": "answer_text", "start_offset": 12, "end_offset": 10, "confidence": 0}]}]}'
+        responses.add(responses.POST,
+                      url,
+                      body=mock_response,
+                      content_type='application/json',
+                      status=200)
+
+        # Construct a dict representation of a QueryLargeTableResults model
+        query_large_table_results_model = {}
+        query_large_table_results_model['enabled'] = True
+        query_large_table_results_model['count'] = 38
+
+        # Construct a dict representation of a QueryLargeSuggestedRefinements model
+        query_large_suggested_refinements_model = {}
+        query_large_suggested_refinements_model['enabled'] = True
+        query_large_suggested_refinements_model['count'] = 1
+
+        # Construct a dict representation of a QueryLargePassages model
+        query_large_passages_model = {}
+        query_large_passages_model['enabled'] = True
+        query_large_passages_model['per_document'] = True
+        query_large_passages_model['max_per_document'] = 38
+        query_large_passages_model['fields'] = ['testString']
+        query_large_passages_model['count'] = 400
+        query_large_passages_model['characters'] = 50
+        query_large_passages_model['find_answers'] = False
+        query_large_passages_model['max_answers_per_passage'] = 38
+
+        # Construct a dict representation of a QueryLargeSimilar model
+        query_large_similar_model = {}
+        query_large_similar_model['enabled'] = False
+        query_large_similar_model['document_ids'] = ['testString']
+        query_large_similar_model['fields'] = ['testString']
+
+        # Set up parameter values
+        project_id = 'testString'
+        collection_ids = ['testString']
+        filter = 'testString'
+        query = 'testString'
+        natural_language_query = 'testString'
+        aggregation = 'testString'
+        count = 38
+        return_ = ['testString']
+        offset = 38
+        sort = 'testString'
+        highlight = True
+        spelling_suggestions = True
+        table_results = query_large_table_results_model
+        suggested_refinements = query_large_suggested_refinements_model
+        passages = query_large_passages_model
+        similar = query_large_similar_model
+
+        # Invoke method
+        response = _service.query(
+            project_id,
+            collection_ids=collection_ids,
+            filter=filter,
+            query=query,
+            natural_language_query=natural_language_query,
+            aggregation=aggregation,
+            count=count,
+            return_=return_,
+            offset=offset,
+            sort=sort,
+            highlight=highlight,
+            spelling_suggestions=spelling_suggestions,
+            table_results=table_results,
+            suggested_refinements=suggested_refinements,
+            passages=passages,
+            similar=similar,
+            headers={}
+        )
+
+        # Check for correct operation
+        assert len(responses.calls) == 1
+        assert response.status_code == 200
+        # Validate body params
+        req_body = json.loads(str(responses.calls[0].request.body, 'utf-8'))
+        assert req_body['collection_ids'] == ['testString']
+        assert req_body['filter'] == 'testString'
+        assert req_body['query'] == 'testString'
+        assert req_body['natural_language_query'] == 'testString'
+        assert req_body['aggregation'] == 'testString'
+        assert req_body['count'] == 38
+        assert req_body['return'] == ['testString']
+        assert req_body['offset'] == 38
+        assert req_body['sort'] == 'testString'
+        assert req_body['highlight'] == True
+        assert req_body['spelling_suggestions'] == True
+        assert req_body['table_results'] == query_large_table_results_model
+        assert req_body['suggested_refinements'] == query_large_suggested_refinements_model
+        assert req_body['passages'] == query_large_passages_model
+        assert req_body['similar'] == query_large_similar_model
+
+    def test_query_all_params_with_retries(self):
+        # Enable retries and run test_query_all_params.
+        _service.enable_retries()
+        self.test_query_all_params()
+
+        # Disable retries and run test_query_all_params.
+        _service.disable_retries()
+        self.test_query_all_params()
+
+    @responses.activate
+    def test_query_required_params(self):
+        """
+        test_query_required_params()
+        """
+        # Set up mock
+        url = preprocess_url('/v2/projects/testString/query')
+        mock_response = '{"matching_results": 16, "results": [{"document_id": "document_id", "metadata": {"mapKey": "anyValue"}, "result_metadata": {"document_retrieval_source": "search", "collection_id": "collection_id", "confidence": 10}, "document_passages": [{"passage_text": "passage_text", "start_offset": 12, "end_offset": 10, "field": "field", "confidence": 0, "answers": [{"answer_text": "answer_text", "start_offset": 12, "end_offset": 10, "confidence": 0}]}]}], "aggregations": [{"type": "filter", "match": "match", "matching_results": 16}], "retrieval_details": {"document_retrieval_strategy": "untrained"}, "suggested_query": "suggested_query", "suggested_refinements": [{"text": "text"}], "table_results": [{"table_id": "table_id", "source_document_id": "source_document_id", "collection_id": "collection_id", "table_html": "table_html", "table_html_offset": 17, "table": {"location": {"begin": 5, "end": 3}, "text": "text", "section_title": {"text": "text", "location": {"begin": 5, "end": 3}}, "title": {"text": "text", "location": {"begin": 5, "end": 3}}, "table_headers": [{"cell_id": "cell_id", "location": {"anyKey": "anyValue"}, "text": "text", "row_index_begin": 15, "row_index_end": 13, "column_index_begin": 18, "column_index_end": 16}], "row_headers": [{"cell_id": "cell_id", "location": {"begin": 5, "end": 3}, "text": "text", "text_normalized": "text_normalized", "row_index_begin": 15, "row_index_end": 13, "column_index_begin": 18, "column_index_end": 16}], "column_headers": [{"cell_id": "cell_id", "location": {"anyKey": "anyValue"}, "text": "text", "text_normalized": "text_normalized", "row_index_begin": 15, "row_index_end": 13, "column_index_begin": 18, "column_index_end": 16}], "key_value_pairs": [{"key": {"cell_id": "cell_id", "location": {"begin": 5, "end": 3}, "text": "text"}, "value": [{"cell_id": "cell_id", "location": {"begin": 5, "end": 3}, "text": "text"}]}], "body_cells": [{"cell_id": "cell_id", "location": {"begin": 5, "end": 3}, "text": "text", "row_index_begin": 15, "row_index_end": 13, "column_index_begin": 18, "column_index_end": 16, "row_header_ids": [{"id": "id"}], "row_header_texts": [{"text": "text"}], "row_header_texts_normalized": [{"text_normalized": "text_normalized"}], "column_header_ids": [{"id": "id"}], "column_header_texts": [{"text": "text"}], "column_header_texts_normalized": [{"text_normalized": "text_normalized"}], "attributes": [{"type": "type", "text": "text", "location": {"begin": 5, "end": 3}}]}], "contexts": [{"text": "text", "location": {"begin": 5, "end": 3}}]}}], "passages": [{"passage_text": "passage_text", "passage_score": 13, "document_id": "document_id", "collection_id": "collection_id", "start_offset": 12, "end_offset": 10, "field": "field", "confidence": 0, "answers": [{"answer_text": "answer_text", "start_offset": 12, "end_offset": 10, "confidence": 0}]}]}'
+        responses.add(responses.POST,
+                      url,
+                      body=mock_response,
+                      content_type='application/json',
+                      status=200)
+
+        # Set up parameter values
+        project_id = 'testString'
+
+        # Invoke method
+        response = _service.query(
+            project_id,
+            headers={}
+        )
+
+        # Check for correct operation
+        assert len(responses.calls) == 1
+        assert response.status_code == 200
+
+    def test_query_required_params_with_retries(self):
+        # Enable retries and run test_query_required_params.
+        _service.enable_retries()
+        self.test_query_required_params()
+
+        # Disable retries and run test_query_required_params.
+        _service.disable_retries()
+        self.test_query_required_params()
+
+    @responses.activate
+    def test_query_value_error(self):
+        """
+        test_query_value_error()
+        """
+        # Set up mock
+        url = preprocess_url('/v2/projects/testString/query')
+        mock_response = '{"matching_results": 16, "results": [{"document_id": "document_id", "metadata": {"mapKey": "anyValue"}, "result_metadata": {"document_retrieval_source": "search", "collection_id": "collection_id", "confidence": 10}, "document_passages": [{"passage_text": "passage_text", "start_offset": 12, "end_offset": 10, "field": "field", "confidence": 0, "answers": [{"answer_text": "answer_text", "start_offset": 12, "end_offset": 10, "confidence": 0}]}]}], "aggregations": [{"type": "filter", "match": "match", "matching_results": 16}], "retrieval_details": {"document_retrieval_strategy": "untrained"}, "suggested_query": "suggested_query", "suggested_refinements": [{"text": "text"}], "table_results": [{"table_id": "table_id", "source_document_id": "source_document_id", "collection_id": "collection_id", "table_html": "table_html", "table_html_offset": 17, "table": {"location": {"begin": 5, "end": 3}, "text": "text", "section_title": {"text": "text", "location": {"begin": 5, "end": 3}}, "title": {"text": "text", "location": {"begin": 5, "end": 3}}, "table_headers": [{"cell_id": "cell_id", "location": {"anyKey": "anyValue"}, "text": "text", "row_index_begin": 15, "row_index_end": 13, "column_index_begin": 18, "column_index_end": 16}], "row_headers": [{"cell_id": "cell_id", "location": {"begin": 5, "end": 3}, "text": "text", "text_normalized": "text_normalized", "row_index_begin": 15, "row_index_end": 13, "column_index_begin": 18, "column_index_end": 16}], "column_headers": [{"cell_id": "cell_id", "location": {"anyKey": "anyValue"}, "text": "text", "text_normalized": "text_normalized", "row_index_begin": 15, "row_index_end": 13, "column_index_begin": 18, "column_index_end": 16}], "key_value_pairs": [{"key": {"cell_id": "cell_id", "location": {"begin": 5, "end": 3}, "text": "text"}, "value": [{"cell_id": "cell_id", "location": {"begin": 5, "end": 3}, "text": "text"}]}], "body_cells": [{"cell_id": "cell_id", "location": {"begin": 5, "end": 3}, "text": "text", "row_index_begin": 15, "row_index_end": 13, "column_index_begin": 18, "column_index_end": 16, "row_header_ids": [{"id": "id"}], "row_header_texts": [{"text": "text"}], "row_header_texts_normalized": [{"text_normalized": "text_normalized"}], "column_header_ids": [{"id": "id"}], "column_header_texts": [{"text": "text"}], "column_header_texts_normalized": [{"text_normalized": "text_normalized"}], "attributes": [{"type": "type", "text": "text", "location": {"begin": 5, "end": 3}}]}], "contexts": [{"text": "text", "location": {"begin": 5, "end": 3}}]}}], "passages": [{"passage_text": "passage_text", "passage_score": 13, "document_id": "document_id", "collection_id": "collection_id", "start_offset": 12, "end_offset": 10, "field": "field", "confidence": 0, "answers": [{"answer_text": "answer_text", "start_offset": 12, "end_offset": 10, "confidence": 0}]}]}'
+        responses.add(responses.POST,
+                      url,
+                      body=mock_response,
+                      content_type='application/json',
+                      status=200)
+
+        # Set up parameter values
+        project_id = 'testString'
+
+        # Pass in all but one required param and check for a ValueError
+        req_param_dict = {
+            "project_id": project_id,
+        }
+        for param in req_param_dict.keys():
+            req_copy = {key:val if key is not param else None for (key,val) in req_param_dict.items()}
+            with pytest.raises(ValueError):
+                _service.query(**req_copy)
+
+    def test_query_value_error_with_retries(self):
+        # Enable retries and run test_query_value_error.
+        _service.enable_retries()
+        self.test_query_value_error()
+
+        # Disable retries and run test_query_value_error.
+        _service.disable_retries()
+        self.test_query_value_error()
+
+class TestGetAutocompletion():
+    """
+    Test Class for get_autocompletion
+    """
+
+    @responses.activate
+    def test_get_autocompletion_all_params(self):
+        """
+        get_autocompletion()
+        """
+        # Set up mock
+        url = preprocess_url('/v2/projects/testString/autocompletion')
+        mock_response = '{"completions": ["completions"]}'
+        responses.add(responses.GET,
+                      url,
+                      body=mock_response,
+                      content_type='application/json',
+                      status=200)
+
+        # Set up parameter values
+        project_id = 'testString'
+        prefix = 'testString'
+        collection_ids = ['testString']
+        field = 'testString'
+        count = 38
+
+        # Invoke method
+        response = _service.get_autocompletion(
+            project_id,
+            prefix,
+            collection_ids=collection_ids,
+            field=field,
+            count=count,
+            headers={}
+        )
+
+        # Check for correct operation
+        assert len(responses.calls) == 1
+        assert response.status_code == 200
+        # Validate query params
+        query_string = responses.calls[0].request.url.split('?',1)[1]
+        query_string = urllib.parse.unquote_plus(query_string)
+        assert 'prefix={}'.format(prefix) in query_string
+        assert 'collection_ids={}'.format(','.join(collection_ids)) in query_string
+        assert 'field={}'.format(field) in query_string
+        assert 'count={}'.format(count) in query_string
+
+    def test_get_autocompletion_all_params_with_retries(self):
+        # Enable retries and run test_get_autocompletion_all_params.
+        _service.enable_retries()
+        self.test_get_autocompletion_all_params()
+
+        # Disable retries and run test_get_autocompletion_all_params.
+        _service.disable_retries()
+        self.test_get_autocompletion_all_params()
+
+    @responses.activate
+    def test_get_autocompletion_required_params(self):
+        """
+        test_get_autocompletion_required_params()
+        """
+        # Set up mock
+        url = preprocess_url('/v2/projects/testString/autocompletion')
+        mock_response = '{"completions": ["completions"]}'
+        responses.add(responses.GET,
+                      url,
+                      body=mock_response,
+                      content_type='application/json',
+                      status=200)
+
+        # Set up parameter values
+        project_id = 'testString'
+        prefix = 'testString'
+
+        # Invoke method
+        response = _service.get_autocompletion(
+            project_id,
+            prefix,
+            headers={}
+        )
+
+        # Check for correct operation
+        assert len(responses.calls) == 1
+        assert response.status_code == 200
+        # Validate query params
+        query_string = responses.calls[0].request.url.split('?',1)[1]
+        query_string = urllib.parse.unquote_plus(query_string)
+        assert 'prefix={}'.format(prefix) in query_string
+
+    def test_get_autocompletion_required_params_with_retries(self):
+        # Enable retries and run test_get_autocompletion_required_params.
+        _service.enable_retries()
+        self.test_get_autocompletion_required_params()
+
+        # Disable retries and run test_get_autocompletion_required_params.
+        _service.disable_retries()
+        self.test_get_autocompletion_required_params()
+
+    @responses.activate
+    def test_get_autocompletion_value_error(self):
+        """
+        test_get_autocompletion_value_error()
+        """
+        # Set up mock
+        url = preprocess_url('/v2/projects/testString/autocompletion')
+        mock_response = '{"completions": ["completions"]}'
+        responses.add(responses.GET,
+                      url,
+                      body=mock_response,
+                      content_type='application/json',
+                      status=200)
+
+        # Set up parameter values
+        project_id = 'testString'
+        prefix = 'testString'
+
+        # Pass in all but one required param and check for a ValueError
+        req_param_dict = {
+            "project_id": project_id,
+            "prefix": prefix,
+        }
+        for param in req_param_dict.keys():
+            req_copy = {key:val if key is not param else None for (key,val) in req_param_dict.items()}
+            with pytest.raises(ValueError):
+                _service.get_autocompletion(**req_copy)
+
+    def test_get_autocompletion_value_error_with_retries(self):
+        # Enable retries and run test_get_autocompletion_value_error.
+        _service.enable_retries()
+        self.test_get_autocompletion_value_error()
+
+        # Disable retries and run test_get_autocompletion_value_error.
+        _service.disable_retries()
+        self.test_get_autocompletion_value_error()
+
+class TestQueryCollectionNotices():
+    """
+    Test Class for query_collection_notices
+    """
+
+    @responses.activate
+    def test_query_collection_notices_all_params(self):
+        """
+        query_collection_notices()
+        """
+        # Set up mock
+        url = preprocess_url('/v2/projects/testString/collections/testString/notices')
+        mock_response = '{"matching_results": 16, "notices": [{"notice_id": "notice_id", "created": "2019-01-01T12:00:00.000Z", "document_id": "document_id", "collection_id": "collection_id", "query_id": "query_id", "severity": "warning", "step": "step", "description": "description"}]}'
+        responses.add(responses.GET,
+                      url,
+                      body=mock_response,
+                      content_type='application/json',
+                      status=200)
+
+        # Set up parameter values
+        project_id = 'testString'
+        collection_id = 'testString'
+        filter = 'testString'
+        query = 'testString'
+        natural_language_query = 'testString'
+        count = 38
+        offset = 38
+
+        # Invoke method
+        response = _service.query_collection_notices(
+            project_id,
+            collection_id,
+            filter=filter,
+            query=query,
+            natural_language_query=natural_language_query,
+            count=count,
+            offset=offset,
+            headers={}
+        )
+
+        # Check for correct operation
+        assert len(responses.calls) == 1
+        assert response.status_code == 200
+        # Validate query params
+        query_string = responses.calls[0].request.url.split('?',1)[1]
+        query_string = urllib.parse.unquote_plus(query_string)
+        assert 'filter={}'.format(filter) in query_string
+        assert 'query={}'.format(query) in query_string
+        assert 'natural_language_query={}'.format(natural_language_query) in query_string
+        assert 'count={}'.format(count) in query_string
+        assert 'offset={}'.format(offset) in query_string
+
+    def test_query_collection_notices_all_params_with_retries(self):
+        # Enable retries and run test_query_collection_notices_all_params.
+        _service.enable_retries()
+        self.test_query_collection_notices_all_params()
+
+        # Disable retries and run test_query_collection_notices_all_params.
+        _service.disable_retries()
+        self.test_query_collection_notices_all_params()
+
+    @responses.activate
+    def test_query_collection_notices_required_params(self):
+        """
+        test_query_collection_notices_required_params()
+        """
+        # Set up mock
+        url = preprocess_url('/v2/projects/testString/collections/testString/notices')
+        mock_response = '{"matching_results": 16, "notices": [{"notice_id": "notice_id", "created": "2019-01-01T12:00:00.000Z", "document_id": "document_id", "collection_id": "collection_id", "query_id": "query_id", "severity": "warning", "step": "step", "description": "description"}]}'
+        responses.add(responses.GET,
+                      url,
+                      body=mock_response,
+                      content_type='application/json',
+                      status=200)
+
+        # Set up parameter values
+        project_id = 'testString'
+        collection_id = 'testString'
+
+        # Invoke method
+        response = _service.query_collection_notices(
+            project_id,
+            collection_id,
+            headers={}
+        )
+
+        # Check for correct operation
+        assert len(responses.calls) == 1
+        assert response.status_code == 200
+
+    def test_query_collection_notices_required_params_with_retries(self):
+        # Enable retries and run test_query_collection_notices_required_params.
+        _service.enable_retries()
+        self.test_query_collection_notices_required_params()
+
+        # Disable retries and run test_query_collection_notices_required_params.
+        _service.disable_retries()
+        self.test_query_collection_notices_required_params()
+
+    @responses.activate
+    def test_query_collection_notices_value_error(self):
+        """
+        test_query_collection_notices_value_error()
+        """
+        # Set up mock
+        url = preprocess_url('/v2/projects/testString/collections/testString/notices')
+        mock_response = '{"matching_results": 16, "notices": [{"notice_id": "notice_id", "created": "2019-01-01T12:00:00.000Z", "document_id": "document_id", "collection_id": "collection_id", "query_id": "query_id", "severity": "warning", "step": "step", "description": "description"}]}'
+        responses.add(responses.GET,
+                      url,
+                      body=mock_response,
+                      content_type='application/json',
+                      status=200)
+
+        # Set up parameter values
+        project_id = 'testString'
+        collection_id = 'testString'
+
+        # Pass in all but one required param and check for a ValueError
+        req_param_dict = {
+            "project_id": project_id,
+            "collection_id": collection_id,
+        }
+        for param in req_param_dict.keys():
+            req_copy = {key:val if key is not param else None for (key,val) in req_param_dict.items()}
+            with pytest.raises(ValueError):
+                _service.query_collection_notices(**req_copy)
+
+    def test_query_collection_notices_value_error_with_retries(self):
+        # Enable retries and run test_query_collection_notices_value_error.
+        _service.enable_retries()
+        self.test_query_collection_notices_value_error()
+
+        # Disable retries and run test_query_collection_notices_value_error.
+        _service.disable_retries()
+        self.test_query_collection_notices_value_error()
+
+class TestQueryNotices():
+    """
+    Test Class for query_notices
+    """
+
+    @responses.activate
+    def test_query_notices_all_params(self):
+        """
+        query_notices()
+        """
+        # Set up mock
+        url = preprocess_url('/v2/projects/testString/notices')
+        mock_response = '{"matching_results": 16, "notices": [{"notice_id": "notice_id", "created": "2019-01-01T12:00:00.000Z", "document_id": "document_id", "collection_id": "collection_id", "query_id": "query_id", "severity": "warning", "step": "step", "description": "description"}]}'
+        responses.add(responses.GET,
+                      url,
+                      body=mock_response,
+                      content_type='application/json',
+                      status=200)
+
+        # Set up parameter values
+        project_id = 'testString'
+        filter = 'testString'
+        query = 'testString'
+        natural_language_query = 'testString'
+        count = 38
+        offset = 38
+
+        # Invoke method
+        response = _service.query_notices(
+            project_id,
+            filter=filter,
+            query=query,
+            natural_language_query=natural_language_query,
+            count=count,
+            offset=offset,
+            headers={}
+        )
+
+        # Check for correct operation
+        assert len(responses.calls) == 1
+        assert response.status_code == 200
+        # Validate query params
+        query_string = responses.calls[0].request.url.split('?',1)[1]
+        query_string = urllib.parse.unquote_plus(query_string)
+        assert 'filter={}'.format(filter) in query_string
+        assert 'query={}'.format(query) in query_string
+        assert 'natural_language_query={}'.format(natural_language_query) in query_string
+        assert 'count={}'.format(count) in query_string
+        assert 'offset={}'.format(offset) in query_string
+
+    def test_query_notices_all_params_with_retries(self):
+        # Enable retries and run test_query_notices_all_params.
+        _service.enable_retries()
+        self.test_query_notices_all_params()
+
+        # Disable retries and run test_query_notices_all_params.
+        _service.disable_retries()
+        self.test_query_notices_all_params()
+
+    @responses.activate
+    def test_query_notices_required_params(self):
+        """
+        test_query_notices_required_params()
+        """
+        # Set up mock
+        url = preprocess_url('/v2/projects/testString/notices')
+        mock_response = '{"matching_results": 16, "notices": [{"notice_id": "notice_id", "created": "2019-01-01T12:00:00.000Z", "document_id": "document_id", "collection_id": "collection_id", "query_id": "query_id", "severity": "warning", "step": "step", "description": "description"}]}'
+        responses.add(responses.GET,
+                      url,
+                      body=mock_response,
+                      content_type='application/json',
+                      status=200)
+
+        # Set up parameter values
+        project_id = 'testString'
+
+        # Invoke method
+        response = _service.query_notices(
+            project_id,
+            headers={}
+        )
+
+        # Check for correct operation
+        assert len(responses.calls) == 1
+        assert response.status_code == 200
+
+    def test_query_notices_required_params_with_retries(self):
+        # Enable retries and run test_query_notices_required_params.
+        _service.enable_retries()
+        self.test_query_notices_required_params()
+
+        # Disable retries and run test_query_notices_required_params.
+        _service.disable_retries()
+        self.test_query_notices_required_params()
+
+    @responses.activate
+    def test_query_notices_value_error(self):
+        """
+        test_query_notices_value_error()
+        """
+        # Set up mock
+        url = preprocess_url('/v2/projects/testString/notices')
+        mock_response = '{"matching_results": 16, "notices": [{"notice_id": "notice_id", "created": "2019-01-01T12:00:00.000Z", "document_id": "document_id", "collection_id": "collection_id", "query_id": "query_id", "severity": "warning", "step": "step", "description": "description"}]}'
+        responses.add(responses.GET,
+                      url,
+                      body=mock_response,
+                      content_type='application/json',
+                      status=200)
+
+        # Set up parameter values
+        project_id = 'testString'
+
+        # Pass in all but one required param and check for a ValueError
+        req_param_dict = {
+            "project_id": project_id,
+        }
+        for param in req_param_dict.keys():
+            req_copy = {key:val if key is not param else None for (key,val) in req_param_dict.items()}
+            with pytest.raises(ValueError):
+                _service.query_notices(**req_copy)
+
+    def test_query_notices_value_error_with_retries(self):
+        # Enable retries and run test_query_notices_value_error.
+        _service.enable_retries()
+        self.test_query_notices_value_error()
+
+        # Disable retries and run test_query_notices_value_error.
+        _service.disable_retries()
+        self.test_query_notices_value_error()
+
+# endregion
+##############################################################################
+# End of Service: Queries
+##############################################################################
+
+##############################################################################
+# Start of Service: QueryModifications
+##############################################################################
+# region
+
+class TestGetStopwordList():
+    """
+    Test Class for get_stopword_list
+    """
+
+    @responses.activate
+    def test_get_stopword_list_all_params(self):
+        """
+        get_stopword_list()
+        """
+        # Set up mock
+        url = preprocess_url('/v2/projects/testString/collections/testString/stopwords')
+        mock_response = '{"stopwords": ["stopwords"]}'
+        responses.add(responses.GET,
+                      url,
+                      body=mock_response,
+                      content_type='application/json',
+                      status=200)
+
+        # Set up parameter values
+        project_id = 'testString'
+        collection_id = 'testString'
+
+        # Invoke method
+        response = _service.get_stopword_list(
+            project_id,
+            collection_id,
+            headers={}
+        )
+
+        # Check for correct operation
+        assert len(responses.calls) == 1
+        assert response.status_code == 200
+
+    def test_get_stopword_list_all_params_with_retries(self):
+        # Enable retries and run test_get_stopword_list_all_params.
+        _service.enable_retries()
+        self.test_get_stopword_list_all_params()
+
+        # Disable retries and run test_get_stopword_list_all_params.
+        _service.disable_retries()
+        self.test_get_stopword_list_all_params()
+
+    @responses.activate
+    def test_get_stopword_list_value_error(self):
+        """
+        test_get_stopword_list_value_error()
+        """
+        # Set up mock
+        url = preprocess_url('/v2/projects/testString/collections/testString/stopwords')
+        mock_response = '{"stopwords": ["stopwords"]}'
+        responses.add(responses.GET,
+                      url,
+                      body=mock_response,
+                      content_type='application/json',
+                      status=200)
+
+        # Set up parameter values
+        project_id = 'testString'
+        collection_id = 'testString'
+
+        # Pass in all but one required param and check for a ValueError
+        req_param_dict = {
+            "project_id": project_id,
+            "collection_id": collection_id,
+        }
+        for param in req_param_dict.keys():
+            req_copy = {key:val if key is not param else None for (key,val) in req_param_dict.items()}
+            with pytest.raises(ValueError):
+                _service.get_stopword_list(**req_copy)
+
+    def test_get_stopword_list_value_error_with_retries(self):
+        # Enable retries and run test_get_stopword_list_value_error.
+        _service.enable_retries()
+        self.test_get_stopword_list_value_error()
+
+        # Disable retries and run test_get_stopword_list_value_error.
+        _service.disable_retries()
+        self.test_get_stopword_list_value_error()
+
+class TestCreateStopwordList():
+    """
+    Test Class for create_stopword_list
+    """
+
+    @responses.activate
+    def test_create_stopword_list_all_params(self):
+        """
+        create_stopword_list()
+        """
+        # Set up mock
+        url = preprocess_url('/v2/projects/testString/collections/testString/stopwords')
+        mock_response = '{"stopwords": ["stopwords"]}'
+        responses.add(responses.POST,
+                      url,
+                      body=mock_response,
+                      content_type='application/json',
+                      status=200)
+
+        # Set up parameter values
+        project_id = 'testString'
+        collection_id = 'testString'
+        stopwords = ['testString']
+
+        # Invoke method
+        response = _service.create_stopword_list(
+            project_id,
+            collection_id,
+            stopwords=stopwords,
+            headers={}
+        )
+
+        # Check for correct operation
+        assert len(responses.calls) == 1
+        assert response.status_code == 200
+        # Validate body params
+        req_body = json.loads(str(responses.calls[0].request.body, 'utf-8'))
+        assert req_body['stopwords'] == ['testString']
+
+    def test_create_stopword_list_all_params_with_retries(self):
+        # Enable retries and run test_create_stopword_list_all_params.
+        _service.enable_retries()
+        self.test_create_stopword_list_all_params()
+
+        # Disable retries and run test_create_stopword_list_all_params.
+        _service.disable_retries()
+        self.test_create_stopword_list_all_params()
+
+    @responses.activate
+    def test_create_stopword_list_required_params(self):
+        """
+        test_create_stopword_list_required_params()
+        """
+        # Set up mock
+        url = preprocess_url('/v2/projects/testString/collections/testString/stopwords')
+        mock_response = '{"stopwords": ["stopwords"]}'
+        responses.add(responses.POST,
+                      url,
+                      body=mock_response,
+                      content_type='application/json',
+                      status=200)
+
+        # Set up parameter values
+        project_id = 'testString'
+        collection_id = 'testString'
+
+        # Invoke method
+        response = _service.create_stopword_list(
+            project_id,
+            collection_id,
+            headers={}
+        )
+
+        # Check for correct operation
+        assert len(responses.calls) == 1
+        assert response.status_code == 200
+
+    def test_create_stopword_list_required_params_with_retries(self):
+        # Enable retries and run test_create_stopword_list_required_params.
+        _service.enable_retries()
+        self.test_create_stopword_list_required_params()
+
+        # Disable retries and run test_create_stopword_list_required_params.
+        _service.disable_retries()
+        self.test_create_stopword_list_required_params()
+
+    @responses.activate
+    def test_create_stopword_list_value_error(self):
+        """
+        test_create_stopword_list_value_error()
+        """
+        # Set up mock
+        url = preprocess_url('/v2/projects/testString/collections/testString/stopwords')
+        mock_response = '{"stopwords": ["stopwords"]}'
+        responses.add(responses.POST,
+                      url,
+                      body=mock_response,
+                      content_type='application/json',
+                      status=200)
+
+        # Set up parameter values
+        project_id = 'testString'
+        collection_id = 'testString'
+
+        # Pass in all but one required param and check for a ValueError
+        req_param_dict = {
+            "project_id": project_id,
+            "collection_id": collection_id,
+        }
+        for param in req_param_dict.keys():
+            req_copy = {key:val if key is not param else None for (key,val) in req_param_dict.items()}
+            with pytest.raises(ValueError):
+                _service.create_stopword_list(**req_copy)
+
+    def test_create_stopword_list_value_error_with_retries(self):
+        # Enable retries and run test_create_stopword_list_value_error.
+        _service.enable_retries()
+        self.test_create_stopword_list_value_error()
+
+        # Disable retries and run test_create_stopword_list_value_error.
+        _service.disable_retries()
+        self.test_create_stopword_list_value_error()
+
+class TestDeleteStopwordList():
+    """
+    Test Class for delete_stopword_list
+    """
+
+    @responses.activate
+    def test_delete_stopword_list_all_params(self):
+        """
+        delete_stopword_list()
+        """
+        # Set up mock
+        url = preprocess_url('/v2/projects/testString/collections/testString/stopwords')
+        responses.add(responses.DELETE,
+                      url,
+                      status=204)
+
+        # Set up parameter values
+        project_id = 'testString'
+        collection_id = 'testString'
+
+        # Invoke method
+        response = _service.delete_stopword_list(
+            project_id,
+            collection_id,
+            headers={}
+        )
+
+        # Check for correct operation
+        assert len(responses.calls) == 1
+        assert response.status_code == 204
+
+    def test_delete_stopword_list_all_params_with_retries(self):
+        # Enable retries and run test_delete_stopword_list_all_params.
+        _service.enable_retries()
+        self.test_delete_stopword_list_all_params()
+
+        # Disable retries and run test_delete_stopword_list_all_params.
+        _service.disable_retries()
+        self.test_delete_stopword_list_all_params()
+
+    @responses.activate
+    def test_delete_stopword_list_value_error(self):
+        """
+        test_delete_stopword_list_value_error()
+        """
+        # Set up mock
+        url = preprocess_url('/v2/projects/testString/collections/testString/stopwords')
+        responses.add(responses.DELETE,
+                      url,
+                      status=204)
+
+        # Set up parameter values
+        project_id = 'testString'
+        collection_id = 'testString'
+
+        # Pass in all but one required param and check for a ValueError
+        req_param_dict = {
+            "project_id": project_id,
+            "collection_id": collection_id,
+        }
+        for param in req_param_dict.keys():
+            req_copy = {key:val if key is not param else None for (key,val) in req_param_dict.items()}
+            with pytest.raises(ValueError):
+                _service.delete_stopword_list(**req_copy)
+
+    def test_delete_stopword_list_value_error_with_retries(self):
+        # Enable retries and run test_delete_stopword_list_value_error.
+        _service.enable_retries()
+        self.test_delete_stopword_list_value_error()
+
+        # Disable retries and run test_delete_stopword_list_value_error.
+        _service.disable_retries()
+        self.test_delete_stopword_list_value_error()
+
+class TestListExpansions():
+    """
+    Test Class for list_expansions
+    """
+
+    @responses.activate
+    def test_list_expansions_all_params(self):
+        """
+        list_expansions()
+        """
+        # Set up mock
+        url = preprocess_url('/v2/projects/testString/collections/testString/expansions')
+        mock_response = '{"expansions": [{"input_terms": ["input_terms"], "expanded_terms": ["expanded_terms"]}]}'
+        responses.add(responses.GET,
+                      url,
+                      body=mock_response,
+                      content_type='application/json',
+                      status=200)
+
+        # Set up parameter values
+        project_id = 'testString'
+        collection_id = 'testString'
+
+        # Invoke method
+        response = _service.list_expansions(
+            project_id,
+            collection_id,
+            headers={}
+        )
+
+        # Check for correct operation
+        assert len(responses.calls) == 1
+        assert response.status_code == 200
+
+    def test_list_expansions_all_params_with_retries(self):
+        # Enable retries and run test_list_expansions_all_params.
+        _service.enable_retries()
+        self.test_list_expansions_all_params()
+
+        # Disable retries and run test_list_expansions_all_params.
+        _service.disable_retries()
+        self.test_list_expansions_all_params()
+
+    @responses.activate
+    def test_list_expansions_value_error(self):
+        """
+        test_list_expansions_value_error()
+        """
+        # Set up mock
+        url = preprocess_url('/v2/projects/testString/collections/testString/expansions')
+        mock_response = '{"expansions": [{"input_terms": ["input_terms"], "expanded_terms": ["expanded_terms"]}]}'
+        responses.add(responses.GET,
+                      url,
+                      body=mock_response,
+                      content_type='application/json',
+                      status=200)
+
+        # Set up parameter values
+        project_id = 'testString'
+        collection_id = 'testString'
+
+        # Pass in all but one required param and check for a ValueError
+        req_param_dict = {
+            "project_id": project_id,
+            "collection_id": collection_id,
+        }
+        for param in req_param_dict.keys():
+            req_copy = {key:val if key is not param else None for (key,val) in req_param_dict.items()}
+            with pytest.raises(ValueError):
+                _service.list_expansions(**req_copy)
+
+    def test_list_expansions_value_error_with_retries(self):
+        # Enable retries and run test_list_expansions_value_error.
+        _service.enable_retries()
+        self.test_list_expansions_value_error()
+
+        # Disable retries and run test_list_expansions_value_error.
+        _service.disable_retries()
+        self.test_list_expansions_value_error()
+
+class TestCreateExpansions():
+    """
+    Test Class for create_expansions
+    """
+
+    @responses.activate
+    def test_create_expansions_all_params(self):
+        """
+        create_expansions()
+        """
+        # Set up mock
+        url = preprocess_url('/v2/projects/testString/collections/testString/expansions')
+        mock_response = '{"expansions": [{"input_terms": ["input_terms"], "expanded_terms": ["expanded_terms"]}]}'
+        responses.add(responses.POST,
+                      url,
+                      body=mock_response,
+                      content_type='application/json',
+                      status=200)
+
+        # Construct a dict representation of a Expansion model
+        expansion_model = {}
+        expansion_model['input_terms'] = ['testString']
+        expansion_model['expanded_terms'] = ['testString']
+
+        # Set up parameter values
+        project_id = 'testString'
+        collection_id = 'testString'
+        expansions = [expansion_model]
+
+        # Invoke method
+        response = _service.create_expansions(
+            project_id,
+            collection_id,
+            expansions,
+            headers={}
+        )
+
+        # Check for correct operation
+        assert len(responses.calls) == 1
+        assert response.status_code == 200
+        # Validate body params
+        req_body = json.loads(str(responses.calls[0].request.body, 'utf-8'))
+        assert req_body['expansions'] == [expansion_model]
+
+    def test_create_expansions_all_params_with_retries(self):
+        # Enable retries and run test_create_expansions_all_params.
+        _service.enable_retries()
+        self.test_create_expansions_all_params()
+
+        # Disable retries and run test_create_expansions_all_params.
+        _service.disable_retries()
+        self.test_create_expansions_all_params()
+
+    @responses.activate
+    def test_create_expansions_value_error(self):
+        """
+        test_create_expansions_value_error()
+        """
+        # Set up mock
+        url = preprocess_url('/v2/projects/testString/collections/testString/expansions')
+        mock_response = '{"expansions": [{"input_terms": ["input_terms"], "expanded_terms": ["expanded_terms"]}]}'
+        responses.add(responses.POST,
+                      url,
+                      body=mock_response,
+                      content_type='application/json',
+                      status=200)
+
+        # Construct a dict representation of a Expansion model
+        expansion_model = {}
+        expansion_model['input_terms'] = ['testString']
+        expansion_model['expanded_terms'] = ['testString']
+
+        # Set up parameter values
+        project_id = 'testString'
+        collection_id = 'testString'
+        expansions = [expansion_model]
+
+        # Pass in all but one required param and check for a ValueError
+        req_param_dict = {
+            "project_id": project_id,
+            "collection_id": collection_id,
+            "expansions": expansions,
+        }
+        for param in req_param_dict.keys():
+            req_copy = {key:val if key is not param else None for (key,val) in req_param_dict.items()}
+            with pytest.raises(ValueError):
+                _service.create_expansions(**req_copy)
+
+    def test_create_expansions_value_error_with_retries(self):
+        # Enable retries and run test_create_expansions_value_error.
+        _service.enable_retries()
+        self.test_create_expansions_value_error()
+
+        # Disable retries and run test_create_expansions_value_error.
+        _service.disable_retries()
+        self.test_create_expansions_value_error()
+
+class TestDeleteExpansions():
+    """
+    Test Class for delete_expansions
+    """
+
+    @responses.activate
+    def test_delete_expansions_all_params(self):
+        """
+        delete_expansions()
+        """
+        # Set up mock
+        url = preprocess_url('/v2/projects/testString/collections/testString/expansions')
+        responses.add(responses.DELETE,
+                      url,
+                      status=204)
+
+        # Set up parameter values
+        project_id = 'testString'
+        collection_id = 'testString'
+
+        # Invoke method
+        response = _service.delete_expansions(
+            project_id,
+            collection_id,
+            headers={}
+        )
+
+        # Check for correct operation
+        assert len(responses.calls) == 1
+        assert response.status_code == 204
+
+    def test_delete_expansions_all_params_with_retries(self):
+        # Enable retries and run test_delete_expansions_all_params.
+        _service.enable_retries()
+        self.test_delete_expansions_all_params()
+
+        # Disable retries and run test_delete_expansions_all_params.
+        _service.disable_retries()
+        self.test_delete_expansions_all_params()
+
+    @responses.activate
+    def test_delete_expansions_value_error(self):
+        """
+        test_delete_expansions_value_error()
+        """
+        # Set up mock
+        url = preprocess_url('/v2/projects/testString/collections/testString/expansions')
+        responses.add(responses.DELETE,
+                      url,
+                      status=204)
+
+        # Set up parameter values
+        project_id = 'testString'
+        collection_id = 'testString'
+
+        # Pass in all but one required param and check for a ValueError
+        req_param_dict = {
+            "project_id": project_id,
+            "collection_id": collection_id,
+        }
+        for param in req_param_dict.keys():
+            req_copy = {key:val if key is not param else None for (key,val) in req_param_dict.items()}
+            with pytest.raises(ValueError):
+                _service.delete_expansions(**req_copy)
+
+    def test_delete_expansions_value_error_with_retries(self):
+        # Enable retries and run test_delete_expansions_value_error.
+        _service.enable_retries()
+        self.test_delete_expansions_value_error()
+
+        # Disable retries and run test_delete_expansions_value_error.
+        _service.disable_retries()
+        self.test_delete_expansions_value_error()
+
+# endregion
+##############################################################################
+# End of Service: QueryModifications
+##############################################################################
+
+##############################################################################
+# Start of Service: ComponentSettings
+##############################################################################
+# region
+
+class TestGetComponentSettings():
+    """
+    Test Class for get_component_settings
+    """
+
+    @responses.activate
+    def test_get_component_settings_all_params(self):
+        """
+        get_component_settings()
+        """
+        # Set up mock
+        url = preprocess_url('/v2/projects/testString/component_settings')
+        mock_response = '{"fields_shown": {"body": {"use_passage": false, "field": "field"}, "title": {"field": "field"}}, "autocomplete": true, "structured_search": false, "results_per_page": 16, "aggregations": [{"name": "name", "label": "label", "multiple_selections_allowed": false, "visualization_type": "auto"}]}'
+        responses.add(responses.GET,
+                      url,
+                      body=mock_response,
+                      content_type='application/json',
+                      status=200)
+
+        # Set up parameter values
+        project_id = 'testString'
+
+        # Invoke method
+        response = _service.get_component_settings(
+            project_id,
+            headers={}
+        )
+
+        # Check for correct operation
+        assert len(responses.calls) == 1
+        assert response.status_code == 200
+
+    def test_get_component_settings_all_params_with_retries(self):
+        # Enable retries and run test_get_component_settings_all_params.
+        _service.enable_retries()
+        self.test_get_component_settings_all_params()
+
+        # Disable retries and run test_get_component_settings_all_params.
+        _service.disable_retries()
+        self.test_get_component_settings_all_params()
+
+    @responses.activate
+    def test_get_component_settings_value_error(self):
+        """
+        test_get_component_settings_value_error()
+        """
+        # Set up mock
+        url = preprocess_url('/v2/projects/testString/component_settings')
+        mock_response = '{"fields_shown": {"body": {"use_passage": false, "field": "field"}, "title": {"field": "field"}}, "autocomplete": true, "structured_search": false, "results_per_page": 16, "aggregations": [{"name": "name", "label": "label", "multiple_selections_allowed": false, "visualization_type": "auto"}]}'
+        responses.add(responses.GET,
+                      url,
+                      body=mock_response,
+                      content_type='application/json',
+                      status=200)
+
+        # Set up parameter values
+        project_id = 'testString'
+
+        # Pass in all but one required param and check for a ValueError
+        req_param_dict = {
+            "project_id": project_id,
+        }
+        for param in req_param_dict.keys():
+            req_copy = {key:val if key is not param else None for (key,val) in req_param_dict.items()}
+            with pytest.raises(ValueError):
+                _service.get_component_settings(**req_copy)
+
+    def test_get_component_settings_value_error_with_retries(self):
+        # Enable retries and run test_get_component_settings_value_error.
+        _service.enable_retries()
+        self.test_get_component_settings_value_error()
+
+        # Disable retries and run test_get_component_settings_value_error.
+        _service.disable_retries()
+        self.test_get_component_settings_value_error()
+
+# endregion
+##############################################################################
+# End of Service: ComponentSettings
+##############################################################################
+
+##############################################################################
+# Start of Service: TrainingData
+##############################################################################
+# region
+
+class TestListTrainingQueries():
+    """
+    Test Class for list_training_queries
+    """
+
+    @responses.activate
+    def test_list_training_queries_all_params(self):
+        """
+        list_training_queries()
+        """
+        # Set up mock
+        url = preprocess_url('/v2/projects/testString/training_data/queries')
+        mock_response = '{"queries": [{"query_id": "query_id", "natural_language_query": "natural_language_query", "filter": "filter", "created": "2019-01-01T12:00:00.000Z", "updated": "2019-01-01T12:00:00.000Z", "examples": [{"document_id": "document_id", "collection_id": "collection_id", "relevance": 9, "created": "2019-01-01T12:00:00.000Z", "updated": "2019-01-01T12:00:00.000Z"}]}]}'
+        responses.add(responses.GET,
+                      url,
+                      body=mock_response,
+                      content_type='application/json',
+                      status=200)
+
+        # Set up parameter values
+        project_id = 'testString'
+
+        # Invoke method
+        response = _service.list_training_queries(
+            project_id,
+            headers={}
+        )
+
+        # Check for correct operation
+        assert len(responses.calls) == 1
+        assert response.status_code == 200
+
+    def test_list_training_queries_all_params_with_retries(self):
+        # Enable retries and run test_list_training_queries_all_params.
+        _service.enable_retries()
+        self.test_list_training_queries_all_params()
+
+        # Disable retries and run test_list_training_queries_all_params.
+        _service.disable_retries()
+        self.test_list_training_queries_all_params()
+
+    @responses.activate
+    def test_list_training_queries_value_error(self):
+        """
+        test_list_training_queries_value_error()
+        """
+        # Set up mock
+        url = preprocess_url('/v2/projects/testString/training_data/queries')
+        mock_response = '{"queries": [{"query_id": "query_id", "natural_language_query": "natural_language_query", "filter": "filter", "created": "2019-01-01T12:00:00.000Z", "updated": "2019-01-01T12:00:00.000Z", "examples": [{"document_id": "document_id", "collection_id": "collection_id", "relevance": 9, "created": "2019-01-01T12:00:00.000Z", "updated": "2019-01-01T12:00:00.000Z"}]}]}'
+        responses.add(responses.GET,
+                      url,
+                      body=mock_response,
+                      content_type='application/json',
+                      status=200)
+
+        # Set up parameter values
+        project_id = 'testString'
+
+        # Pass in all but one required param and check for a ValueError
+        req_param_dict = {
+            "project_id": project_id,
+        }
+        for param in req_param_dict.keys():
+            req_copy = {key:val if key is not param else None for (key,val) in req_param_dict.items()}
+            with pytest.raises(ValueError):
+                _service.list_training_queries(**req_copy)
+
+    def test_list_training_queries_value_error_with_retries(self):
+        # Enable retries and run test_list_training_queries_value_error.
+        _service.enable_retries()
+        self.test_list_training_queries_value_error()
+
+        # Disable retries and run test_list_training_queries_value_error.
+        _service.disable_retries()
+        self.test_list_training_queries_value_error()
+
+class TestDeleteTrainingQueries():
+    """
+    Test Class for delete_training_queries
+    """
+
+    @responses.activate
+    def test_delete_training_queries_all_params(self):
+        """
+        delete_training_queries()
+        """
+        # Set up mock
+        url = preprocess_url('/v2/projects/testString/training_data/queries')
+        responses.add(responses.DELETE,
+                      url,
+                      status=204)
+
+        # Set up parameter values
+        project_id = 'testString'
+
+        # Invoke method
+        response = _service.delete_training_queries(
+            project_id,
+            headers={}
+        )
+
+        # Check for correct operation
+        assert len(responses.calls) == 1
+        assert response.status_code == 204
+
+    def test_delete_training_queries_all_params_with_retries(self):
+        # Enable retries and run test_delete_training_queries_all_params.
+        _service.enable_retries()
+        self.test_delete_training_queries_all_params()
+
+        # Disable retries and run test_delete_training_queries_all_params.
+        _service.disable_retries()
+        self.test_delete_training_queries_all_params()
+
+    @responses.activate
+    def test_delete_training_queries_value_error(self):
+        """
+        test_delete_training_queries_value_error()
+        """
+        # Set up mock
+        url = preprocess_url('/v2/projects/testString/training_data/queries')
+        responses.add(responses.DELETE,
+                      url,
+                      status=204)
+
+        # Set up parameter values
+        project_id = 'testString'
+
+        # Pass in all but one required param and check for a ValueError
+        req_param_dict = {
+            "project_id": project_id,
+        }
+        for param in req_param_dict.keys():
+            req_copy = {key:val if key is not param else None for (key,val) in req_param_dict.items()}
+            with pytest.raises(ValueError):
+                _service.delete_training_queries(**req_copy)
+
+    def test_delete_training_queries_value_error_with_retries(self):
+        # Enable retries and run test_delete_training_queries_value_error.
+        _service.enable_retries()
+        self.test_delete_training_queries_value_error()
+
+        # Disable retries and run test_delete_training_queries_value_error.
+        _service.disable_retries()
+        self.test_delete_training_queries_value_error()
+
+class TestCreateTrainingQuery():
+    """
+    Test Class for create_training_query
+    """
+
+    @responses.activate
+    def test_create_training_query_all_params(self):
+        """
+        create_training_query()
+        """
+        # Set up mock
+        url = preprocess_url('/v2/projects/testString/training_data/queries')
+        mock_response = '{"query_id": "query_id", "natural_language_query": "natural_language_query", "filter": "filter", "created": "2019-01-01T12:00:00.000Z", "updated": "2019-01-01T12:00:00.000Z", "examples": [{"document_id": "document_id", "collection_id": "collection_id", "relevance": 9, "created": "2019-01-01T12:00:00.000Z", "updated": "2019-01-01T12:00:00.000Z"}]}'
+        responses.add(responses.POST,
+                      url,
+                      body=mock_response,
+                      content_type='application/json',
+                      status=201)
+
+        # Construct a dict representation of a TrainingExample model
+        training_example_model = {}
+        training_example_model['document_id'] = 'testString'
+        training_example_model['collection_id'] = 'testString'
+        training_example_model['relevance'] = 38
+
+        # Set up parameter values
+        project_id = 'testString'
+        natural_language_query = 'testString'
+        examples = [training_example_model]
+        filter = 'testString'
+
+        # Invoke method
+        response = _service.create_training_query(
+            project_id,
+            natural_language_query,
+            examples,
+            filter=filter,
+            headers={}
+        )
+
+        # Check for correct operation
+        assert len(responses.calls) == 1
+        assert response.status_code == 201
+        # Validate body params
+        req_body = json.loads(str(responses.calls[0].request.body, 'utf-8'))
+        assert req_body['natural_language_query'] == 'testString'
+        assert req_body['examples'] == [training_example_model]
+        assert req_body['filter'] == 'testString'
+
+    def test_create_training_query_all_params_with_retries(self):
+        # Enable retries and run test_create_training_query_all_params.
+        _service.enable_retries()
+        self.test_create_training_query_all_params()
+
+        # Disable retries and run test_create_training_query_all_params.
+        _service.disable_retries()
+        self.test_create_training_query_all_params()
+
+    @responses.activate
+    def test_create_training_query_value_error(self):
+        """
+        test_create_training_query_value_error()
+        """
+        # Set up mock
+        url = preprocess_url('/v2/projects/testString/training_data/queries')
+        mock_response = '{"query_id": "query_id", "natural_language_query": "natural_language_query", "filter": "filter", "created": "2019-01-01T12:00:00.000Z", "updated": "2019-01-01T12:00:00.000Z", "examples": [{"document_id": "document_id", "collection_id": "collection_id", "relevance": 9, "created": "2019-01-01T12:00:00.000Z", "updated": "2019-01-01T12:00:00.000Z"}]}'
+        responses.add(responses.POST,
+                      url,
+                      body=mock_response,
+                      content_type='application/json',
+                      status=201)
+
+        # Construct a dict representation of a TrainingExample model
+        training_example_model = {}
+        training_example_model['document_id'] = 'testString'
+        training_example_model['collection_id'] = 'testString'
+        training_example_model['relevance'] = 38
+
+        # Set up parameter values
+        project_id = 'testString'
+        natural_language_query = 'testString'
+        examples = [training_example_model]
+        filter = 'testString'
+
+        # Pass in all but one required param and check for a ValueError
+        req_param_dict = {
+            "project_id": project_id,
+            "natural_language_query": natural_language_query,
+            "examples": examples,
+        }
+        for param in req_param_dict.keys():
+            req_copy = {key:val if key is not param else None for (key,val) in req_param_dict.items()}
+            with pytest.raises(ValueError):
+                _service.create_training_query(**req_copy)
+
+    def test_create_training_query_value_error_with_retries(self):
+        # Enable retries and run test_create_training_query_value_error.
+        _service.enable_retries()
+        self.test_create_training_query_value_error()
+
+        # Disable retries and run test_create_training_query_value_error.
+        _service.disable_retries()
+        self.test_create_training_query_value_error()
+
+class TestGetTrainingQuery():
+    """
+    Test Class for get_training_query
+    """
+
+    @responses.activate
+    def test_get_training_query_all_params(self):
+        """
+        get_training_query()
+        """
+        # Set up mock
+        url = preprocess_url('/v2/projects/testString/training_data/queries/testString')
+        mock_response = '{"query_id": "query_id", "natural_language_query": "natural_language_query", "filter": "filter", "created": "2019-01-01T12:00:00.000Z", "updated": "2019-01-01T12:00:00.000Z", "examples": [{"document_id": "document_id", "collection_id": "collection_id", "relevance": 9, "created": "2019-01-01T12:00:00.000Z", "updated": "2019-01-01T12:00:00.000Z"}]}'
+        responses.add(responses.GET,
+                      url,
+                      body=mock_response,
+                      content_type='application/json',
+                      status=200)
+
+        # Set up parameter values
+        project_id = 'testString'
+        query_id = 'testString'
+
+        # Invoke method
+        response = _service.get_training_query(
+            project_id,
+            query_id,
+            headers={}
+        )
+
+        # Check for correct operation
+        assert len(responses.calls) == 1
+        assert response.status_code == 200
+
+    def test_get_training_query_all_params_with_retries(self):
+        # Enable retries and run test_get_training_query_all_params.
+        _service.enable_retries()
+        self.test_get_training_query_all_params()
+
+        # Disable retries and run test_get_training_query_all_params.
+        _service.disable_retries()
+        self.test_get_training_query_all_params()
+
+    @responses.activate
+    def test_get_training_query_value_error(self):
+        """
+        test_get_training_query_value_error()
+        """
+        # Set up mock
+        url = preprocess_url('/v2/projects/testString/training_data/queries/testString')
+        mock_response = '{"query_id": "query_id", "natural_language_query": "natural_language_query", "filter": "filter", "created": "2019-01-01T12:00:00.000Z", "updated": "2019-01-01T12:00:00.000Z", "examples": [{"document_id": "document_id", "collection_id": "collection_id", "relevance": 9, "created": "2019-01-01T12:00:00.000Z", "updated": "2019-01-01T12:00:00.000Z"}]}'
+        responses.add(responses.GET,
+                      url,
+                      body=mock_response,
+                      content_type='application/json',
+                      status=200)
+
+        # Set up parameter values
+        project_id = 'testString'
+        query_id = 'testString'
+
+        # Pass in all but one required param and check for a ValueError
+        req_param_dict = {
+            "project_id": project_id,
+            "query_id": query_id,
+        }
+        for param in req_param_dict.keys():
+            req_copy = {key:val if key is not param else None for (key,val) in req_param_dict.items()}
+            with pytest.raises(ValueError):
+                _service.get_training_query(**req_copy)
+
+    def test_get_training_query_value_error_with_retries(self):
+        # Enable retries and run test_get_training_query_value_error.
+        _service.enable_retries()
+        self.test_get_training_query_value_error()
+
+        # Disable retries and run test_get_training_query_value_error.
+        _service.disable_retries()
+        self.test_get_training_query_value_error()
+
+class TestUpdateTrainingQuery():
+    """
+    Test Class for update_training_query
+    """
+
+    @responses.activate
+    def test_update_training_query_all_params(self):
+        """
+        update_training_query()
+        """
+        # Set up mock
+        url = preprocess_url('/v2/projects/testString/training_data/queries/testString')
+        mock_response = '{"query_id": "query_id", "natural_language_query": "natural_language_query", "filter": "filter", "created": "2019-01-01T12:00:00.000Z", "updated": "2019-01-01T12:00:00.000Z", "examples": [{"document_id": "document_id", "collection_id": "collection_id", "relevance": 9, "created": "2019-01-01T12:00:00.000Z", "updated": "2019-01-01T12:00:00.000Z"}]}'
+        responses.add(responses.POST,
+                      url,
+                      body=mock_response,
+                      content_type='application/json',
+                      status=201)
+
+        # Construct a dict representation of a TrainingExample model
+        training_example_model = {}
+        training_example_model['document_id'] = 'testString'
+        training_example_model['collection_id'] = 'testString'
+        training_example_model['relevance'] = 38
+
+        # Set up parameter values
+        project_id = 'testString'
+        query_id = 'testString'
+        natural_language_query = 'testString'
+        examples = [training_example_model]
+        filter = 'testString'
+
+        # Invoke method
+        response = _service.update_training_query(
+            project_id,
+            query_id,
+            natural_language_query,
+            examples,
+            filter=filter,
+            headers={}
+        )
+
+        # Check for correct operation
+        assert len(responses.calls) == 1
+        assert response.status_code == 201
+        # Validate body params
+        req_body = json.loads(str(responses.calls[0].request.body, 'utf-8'))
+        assert req_body['natural_language_query'] == 'testString'
+        assert req_body['examples'] == [training_example_model]
+        assert req_body['filter'] == 'testString'
+
+    def test_update_training_query_all_params_with_retries(self):
+        # Enable retries and run test_update_training_query_all_params.
+        _service.enable_retries()
+        self.test_update_training_query_all_params()
+
+        # Disable retries and run test_update_training_query_all_params.
+        _service.disable_retries()
+        self.test_update_training_query_all_params()
+
+    @responses.activate
+    def test_update_training_query_value_error(self):
+        """
+        test_update_training_query_value_error()
+        """
+        # Set up mock
+        url = preprocess_url('/v2/projects/testString/training_data/queries/testString')
+        mock_response = '{"query_id": "query_id", "natural_language_query": "natural_language_query", "filter": "filter", "created": "2019-01-01T12:00:00.000Z", "updated": "2019-01-01T12:00:00.000Z", "examples": [{"document_id": "document_id", "collection_id": "collection_id", "relevance": 9, "created": "2019-01-01T12:00:00.000Z", "updated": "2019-01-01T12:00:00.000Z"}]}'
+        responses.add(responses.POST,
+                      url,
+                      body=mock_response,
+                      content_type='application/json',
+                      status=201)
+
+        # Construct a dict representation of a TrainingExample model
+        training_example_model = {}
+        training_example_model['document_id'] = 'testString'
+        training_example_model['collection_id'] = 'testString'
+        training_example_model['relevance'] = 38
+
+        # Set up parameter values
+        project_id = 'testString'
+        query_id = 'testString'
+        natural_language_query = 'testString'
+        examples = [training_example_model]
+        filter = 'testString'
+
+        # Pass in all but one required param and check for a ValueError
+        req_param_dict = {
+            "project_id": project_id,
+            "query_id": query_id,
+            "natural_language_query": natural_language_query,
+            "examples": examples,
+        }
+        for param in req_param_dict.keys():
+            req_copy = {key:val if key is not param else None for (key,val) in req_param_dict.items()}
+            with pytest.raises(ValueError):
+                _service.update_training_query(**req_copy)
+
+    def test_update_training_query_value_error_with_retries(self):
+        # Enable retries and run test_update_training_query_value_error.
+        _service.enable_retries()
+        self.test_update_training_query_value_error()
+
+        # Disable retries and run test_update_training_query_value_error.
+        _service.disable_retries()
+        self.test_update_training_query_value_error()
+
+class TestDeleteTrainingQuery():
+    """
+    Test Class for delete_training_query
+    """
+
+    @responses.activate
+    def test_delete_training_query_all_params(self):
+        """
+        delete_training_query()
+        """
+        # Set up mock
+        url = preprocess_url('/v2/projects/testString/training_data/queries/testString')
+        responses.add(responses.DELETE,
+                      url,
+                      status=204)
+
+        # Set up parameter values
+        project_id = 'testString'
+        query_id = 'testString'
+
+        # Invoke method
+        response = _service.delete_training_query(
+            project_id,
+            query_id,
+            headers={}
+        )
+
+        # Check for correct operation
+        assert len(responses.calls) == 1
+        assert response.status_code == 204
+
+    def test_delete_training_query_all_params_with_retries(self):
+        # Enable retries and run test_delete_training_query_all_params.
+        _service.enable_retries()
+        self.test_delete_training_query_all_params()
+
+        # Disable retries and run test_delete_training_query_all_params.
+        _service.disable_retries()
+        self.test_delete_training_query_all_params()
+
+    @responses.activate
+    def test_delete_training_query_value_error(self):
+        """
+        test_delete_training_query_value_error()
+        """
+        # Set up mock
+        url = preprocess_url('/v2/projects/testString/training_data/queries/testString')
+        responses.add(responses.DELETE,
+                      url,
+                      status=204)
+
+        # Set up parameter values
+        project_id = 'testString'
+        query_id = 'testString'
+
+        # Pass in all but one required param and check for a ValueError
+        req_param_dict = {
+            "project_id": project_id,
+            "query_id": query_id,
+        }
+        for param in req_param_dict.keys():
+            req_copy = {key:val if key is not param else None for (key,val) in req_param_dict.items()}
+            with pytest.raises(ValueError):
+                _service.delete_training_query(**req_copy)
+
+    def test_delete_training_query_value_error_with_retries(self):
+        # Enable retries and run test_delete_training_query_value_error.
+        _service.enable_retries()
+        self.test_delete_training_query_value_error()
+
+        # Disable retries and run test_delete_training_query_value_error.
+        _service.disable_retries()
+        self.test_delete_training_query_value_error()
+
+# endregion
+##############################################################################
+# End of Service: TrainingData
+##############################################################################
+
+##############################################################################
+# Start of Service: Enrichments
+##############################################################################
+# region
+
+class TestListEnrichments():
+    """
+    Test Class for list_enrichments
+    """
+
+    @responses.activate
+    def test_list_enrichments_all_params(self):
+        """
+        list_enrichments()
+        """
+        # Set up mock
+        url = preprocess_url('/v2/projects/testString/enrichments')
+        mock_response = '{"enrichments": [{"enrichment_id": "enrichment_id", "name": "name", "description": "description", "type": "part_of_speech", "options": {"languages": ["languages"], "entity_type": "entity_type", "regular_expression": "regular_expression", "result_field": "result_field", "classifier_id": "classifier_id", "model_id": "model_id", "confidence_threshold": 0, "top_k": 5}}]}'
+        responses.add(responses.GET,
+                      url,
+                      body=mock_response,
+                      content_type='application/json',
+                      status=200)
+
+        # Set up parameter values
+        project_id = 'testString'
+
+        # Invoke method
+        response = _service.list_enrichments(
+            project_id,
+            headers={}
+        )
+
+        # Check for correct operation
+        assert len(responses.calls) == 1
+        assert response.status_code == 200
+
+    def test_list_enrichments_all_params_with_retries(self):
+        # Enable retries and run test_list_enrichments_all_params.
+        _service.enable_retries()
+        self.test_list_enrichments_all_params()
+
+        # Disable retries and run test_list_enrichments_all_params.
+        _service.disable_retries()
+        self.test_list_enrichments_all_params()
+
+    @responses.activate
+    def test_list_enrichments_value_error(self):
+        """
+        test_list_enrichments_value_error()
+        """
+        # Set up mock
+        url = preprocess_url('/v2/projects/testString/enrichments')
+        mock_response = '{"enrichments": [{"enrichment_id": "enrichment_id", "name": "name", "description": "description", "type": "part_of_speech", "options": {"languages": ["languages"], "entity_type": "entity_type", "regular_expression": "regular_expression", "result_field": "result_field", "classifier_id": "classifier_id", "model_id": "model_id", "confidence_threshold": 0, "top_k": 5}}]}'
+        responses.add(responses.GET,
+                      url,
+                      body=mock_response,
+                      content_type='application/json',
+                      status=200)
+
+        # Set up parameter values
+        project_id = 'testString'
+
+        # Pass in all but one required param and check for a ValueError
+        req_param_dict = {
+            "project_id": project_id,
+        }
+        for param in req_param_dict.keys():
+            req_copy = {key:val if key is not param else None for (key,val) in req_param_dict.items()}
+            with pytest.raises(ValueError):
+                _service.list_enrichments(**req_copy)
+
+    def test_list_enrichments_value_error_with_retries(self):
+        # Enable retries and run test_list_enrichments_value_error.
+        _service.enable_retries()
+        self.test_list_enrichments_value_error()
+
+        # Disable retries and run test_list_enrichments_value_error.
+        _service.disable_retries()
+        self.test_list_enrichments_value_error()
+
+class TestCreateEnrichment():
+    """
+    Test Class for create_enrichment
+    """
+
+    @responses.activate
+    def test_create_enrichment_all_params(self):
+        """
+        create_enrichment()
+        """
+        # Set up mock
+        url = preprocess_url('/v2/projects/testString/enrichments')
+        mock_response = '{"enrichment_id": "enrichment_id", "name": "name", "description": "description", "type": "part_of_speech", "options": {"languages": ["languages"], "entity_type": "entity_type", "regular_expression": "regular_expression", "result_field": "result_field", "classifier_id": "classifier_id", "model_id": "model_id", "confidence_threshold": 0, "top_k": 5}}'
+        responses.add(responses.POST,
+                      url,
+                      body=mock_response,
+                      content_type='application/json',
+                      status=201)
+
+        # Construct a dict representation of a EnrichmentOptions model
+        enrichment_options_model = {}
+        enrichment_options_model['languages'] = ['testString']
+        enrichment_options_model['entity_type'] = 'testString'
+        enrichment_options_model['regular_expression'] = 'testString'
+        enrichment_options_model['result_field'] = 'testString'
+        enrichment_options_model['classifier_id'] = 'testString'
+        enrichment_options_model['model_id'] = 'testString'
+        enrichment_options_model['confidence_threshold'] = 0
+        enrichment_options_model['top_k'] = 38
+
+        # Construct a dict representation of a CreateEnrichment model
+        create_enrichment_model = {}
+        create_enrichment_model['name'] = 'testString'
+        create_enrichment_model['description'] = 'testString'
+        create_enrichment_model['type'] = 'classifier'
+        create_enrichment_model['options'] = enrichment_options_model
+
+        # Set up parameter values
+        project_id = 'testString'
+        enrichment = create_enrichment_model
+        file = io.BytesIO(b'This is a mock file.').getvalue()
+
+        # Invoke method
+        response = _service.create_enrichment(
+            project_id,
+            enrichment,
+            file=file,
+            headers={}
+        )
+
+        # Check for correct operation
+        assert len(responses.calls) == 1
+        assert response.status_code == 201
+
+    def test_create_enrichment_all_params_with_retries(self):
+        # Enable retries and run test_create_enrichment_all_params.
+        _service.enable_retries()
+        self.test_create_enrichment_all_params()
+
+        # Disable retries and run test_create_enrichment_all_params.
+        _service.disable_retries()
+        self.test_create_enrichment_all_params()
+
+    @responses.activate
+    def test_create_enrichment_required_params(self):
+        """
+        test_create_enrichment_required_params()
+        """
+        # Set up mock
+        url = preprocess_url('/v2/projects/testString/enrichments')
+        mock_response = '{"enrichment_id": "enrichment_id", "name": "name", "description": "description", "type": "part_of_speech", "options": {"languages": ["languages"], "entity_type": "entity_type", "regular_expression": "regular_expression", "result_field": "result_field", "classifier_id": "classifier_id", "model_id": "model_id", "confidence_threshold": 0, "top_k": 5}}'
+        responses.add(responses.POST,
+                      url,
+                      body=mock_response,
+                      content_type='application/json',
+                      status=201)
+
+        # Construct a dict representation of a EnrichmentOptions model
+        enrichment_options_model = {}
+        enrichment_options_model['languages'] = ['testString']
+        enrichment_options_model['entity_type'] = 'testString'
+        enrichment_options_model['regular_expression'] = 'testString'
+        enrichment_options_model['result_field'] = 'testString'
+        enrichment_options_model['classifier_id'] = 'testString'
+        enrichment_options_model['model_id'] = 'testString'
+        enrichment_options_model['confidence_threshold'] = 0
+        enrichment_options_model['top_k'] = 38
+
+        # Construct a dict representation of a CreateEnrichment model
+        create_enrichment_model = {}
+        create_enrichment_model['name'] = 'testString'
+        create_enrichment_model['description'] = 'testString'
+        create_enrichment_model['type'] = 'classifier'
+        create_enrichment_model['options'] = enrichment_options_model
+
+        # Set up parameter values
+        project_id = 'testString'
+        enrichment = create_enrichment_model
+
+        # Invoke method
+        response = _service.create_enrichment(
+            project_id,
+            enrichment,
+            headers={}
+        )
+
+        # Check for correct operation
+        assert len(responses.calls) == 1
+        assert response.status_code == 201
+
+    def test_create_enrichment_required_params_with_retries(self):
+        # Enable retries and run test_create_enrichment_required_params.
+        _service.enable_retries()
+        self.test_create_enrichment_required_params()
+
+        # Disable retries and run test_create_enrichment_required_params.
+        _service.disable_retries()
+        self.test_create_enrichment_required_params()
+
+    @responses.activate
+    def test_create_enrichment_value_error(self):
+        """
+        test_create_enrichment_value_error()
+        """
+        # Set up mock
+        url = preprocess_url('/v2/projects/testString/enrichments')
+        mock_response = '{"enrichment_id": "enrichment_id", "name": "name", "description": "description", "type": "part_of_speech", "options": {"languages": ["languages"], "entity_type": "entity_type", "regular_expression": "regular_expression", "result_field": "result_field", "classifier_id": "classifier_id", "model_id": "model_id", "confidence_threshold": 0, "top_k": 5}}'
+        responses.add(responses.POST,
+                      url,
+                      body=mock_response,
+                      content_type='application/json',
+                      status=201)
+
+        # Construct a dict representation of a EnrichmentOptions model
+        enrichment_options_model = {}
+        enrichment_options_model['languages'] = ['testString']
+        enrichment_options_model['entity_type'] = 'testString'
+        enrichment_options_model['regular_expression'] = 'testString'
+        enrichment_options_model['result_field'] = 'testString'
+        enrichment_options_model['classifier_id'] = 'testString'
+        enrichment_options_model['model_id'] = 'testString'
+        enrichment_options_model['confidence_threshold'] = 0
+        enrichment_options_model['top_k'] = 38
+
+        # Construct a dict representation of a CreateEnrichment model
+        create_enrichment_model = {}
+        create_enrichment_model['name'] = 'testString'
+        create_enrichment_model['description'] = 'testString'
+        create_enrichment_model['type'] = 'classifier'
+        create_enrichment_model['options'] = enrichment_options_model
+
+        # Set up parameter values
+        project_id = 'testString'
+        enrichment = create_enrichment_model
+
+        # Pass in all but one required param and check for a ValueError
+        req_param_dict = {
+            "project_id": project_id,
+            "enrichment": enrichment,
+        }
+        for param in req_param_dict.keys():
+            req_copy = {key:val if key is not param else None for (key,val) in req_param_dict.items()}
+            with pytest.raises(ValueError):
+                _service.create_enrichment(**req_copy)
+
+    def test_create_enrichment_value_error_with_retries(self):
+        # Enable retries and run test_create_enrichment_value_error.
+        _service.enable_retries()
+        self.test_create_enrichment_value_error()
+
+        # Disable retries and run test_create_enrichment_value_error.
+        _service.disable_retries()
+        self.test_create_enrichment_value_error()
+
+class TestGetEnrichment():
+    """
+    Test Class for get_enrichment
+    """
+
+    @responses.activate
+    def test_get_enrichment_all_params(self):
+        """
+        get_enrichment()
+        """
+        # Set up mock
+        url = preprocess_url('/v2/projects/testString/enrichments/testString')
+        mock_response = '{"enrichment_id": "enrichment_id", "name": "name", "description": "description", "type": "part_of_speech", "options": {"languages": ["languages"], "entity_type": "entity_type", "regular_expression": "regular_expression", "result_field": "result_field", "classifier_id": "classifier_id", "model_id": "model_id", "confidence_threshold": 0, "top_k": 5}}'
+        responses.add(responses.GET,
+                      url,
+                      body=mock_response,
+                      content_type='application/json',
+                      status=200)
+
+        # Set up parameter values
+        project_id = 'testString'
+        enrichment_id = 'testString'
+
+        # Invoke method
+        response = _service.get_enrichment(
+            project_id,
+            enrichment_id,
+            headers={}
+        )
+
+        # Check for correct operation
+        assert len(responses.calls) == 1
+        assert response.status_code == 200
+
+    def test_get_enrichment_all_params_with_retries(self):
+        # Enable retries and run test_get_enrichment_all_params.
+        _service.enable_retries()
+        self.test_get_enrichment_all_params()
+
+        # Disable retries and run test_get_enrichment_all_params.
+        _service.disable_retries()
+        self.test_get_enrichment_all_params()
+
+    @responses.activate
+    def test_get_enrichment_value_error(self):
+        """
+        test_get_enrichment_value_error()
+        """
+        # Set up mock
+        url = preprocess_url('/v2/projects/testString/enrichments/testString')
+        mock_response = '{"enrichment_id": "enrichment_id", "name": "name", "description": "description", "type": "part_of_speech", "options": {"languages": ["languages"], "entity_type": "entity_type", "regular_expression": "regular_expression", "result_field": "result_field", "classifier_id": "classifier_id", "model_id": "model_id", "confidence_threshold": 0, "top_k": 5}}'
+        responses.add(responses.GET,
+                      url,
+                      body=mock_response,
+                      content_type='application/json',
+                      status=200)
+
+        # Set up parameter values
+        project_id = 'testString'
+        enrichment_id = 'testString'
+
+        # Pass in all but one required param and check for a ValueError
+        req_param_dict = {
+            "project_id": project_id,
+            "enrichment_id": enrichment_id,
+        }
+        for param in req_param_dict.keys():
+            req_copy = {key:val if key is not param else None for (key,val) in req_param_dict.items()}
+            with pytest.raises(ValueError):
+                _service.get_enrichment(**req_copy)
+
+    def test_get_enrichment_value_error_with_retries(self):
+        # Enable retries and run test_get_enrichment_value_error.
+        _service.enable_retries()
+        self.test_get_enrichment_value_error()
+
+        # Disable retries and run test_get_enrichment_value_error.
+        _service.disable_retries()
+        self.test_get_enrichment_value_error()
+
+class TestUpdateEnrichment():
+    """
+    Test Class for update_enrichment
+    """
+
+    @responses.activate
+    def test_update_enrichment_all_params(self):
+        """
+        update_enrichment()
+        """
+        # Set up mock
+        url = preprocess_url('/v2/projects/testString/enrichments/testString')
+        mock_response = '{"enrichment_id": "enrichment_id", "name": "name", "description": "description", "type": "part_of_speech", "options": {"languages": ["languages"], "entity_type": "entity_type", "regular_expression": "regular_expression", "result_field": "result_field", "classifier_id": "classifier_id", "model_id": "model_id", "confidence_threshold": 0, "top_k": 5}}'
+        responses.add(responses.POST,
+                      url,
+                      body=mock_response,
+                      content_type='application/json',
+                      status=200)
+
+        # Set up parameter values
+        project_id = 'testString'
+        enrichment_id = 'testString'
+        name = 'testString'
+        description = 'testString'
+
+        # Invoke method
+        response = _service.update_enrichment(
+            project_id,
+            enrichment_id,
+            name,
+            description=description,
+            headers={}
+        )
+
+        # Check for correct operation
+        assert len(responses.calls) == 1
+        assert response.status_code == 200
+        # Validate body params
+        req_body = json.loads(str(responses.calls[0].request.body, 'utf-8'))
+        assert req_body['name'] == 'testString'
+        assert req_body['description'] == 'testString'
+
+    def test_update_enrichment_all_params_with_retries(self):
+        # Enable retries and run test_update_enrichment_all_params.
+        _service.enable_retries()
+        self.test_update_enrichment_all_params()
+
+        # Disable retries and run test_update_enrichment_all_params.
+        _service.disable_retries()
+        self.test_update_enrichment_all_params()
+
+    @responses.activate
+    def test_update_enrichment_value_error(self):
+        """
+        test_update_enrichment_value_error()
+        """
+        # Set up mock
+        url = preprocess_url('/v2/projects/testString/enrichments/testString')
+        mock_response = '{"enrichment_id": "enrichment_id", "name": "name", "description": "description", "type": "part_of_speech", "options": {"languages": ["languages"], "entity_type": "entity_type", "regular_expression": "regular_expression", "result_field": "result_field", "classifier_id": "classifier_id", "model_id": "model_id", "confidence_threshold": 0, "top_k": 5}}'
+        responses.add(responses.POST,
+                      url,
+                      body=mock_response,
+                      content_type='application/json',
+                      status=200)
+
+        # Set up parameter values
+        project_id = 'testString'
+        enrichment_id = 'testString'
+        name = 'testString'
+        description = 'testString'
+
+        # Pass in all but one required param and check for a ValueError
+        req_param_dict = {
+            "project_id": project_id,
+            "enrichment_id": enrichment_id,
+            "name": name,
+        }
+        for param in req_param_dict.keys():
+            req_copy = {key:val if key is not param else None for (key,val) in req_param_dict.items()}
+            with pytest.raises(ValueError):
+                _service.update_enrichment(**req_copy)
+
+    def test_update_enrichment_value_error_with_retries(self):
+        # Enable retries and run test_update_enrichment_value_error.
+        _service.enable_retries()
+        self.test_update_enrichment_value_error()
+
+        # Disable retries and run test_update_enrichment_value_error.
+        _service.disable_retries()
+        self.test_update_enrichment_value_error()
+
+class TestDeleteEnrichment():
+    """
+    Test Class for delete_enrichment
+    """
+
+    @responses.activate
+    def test_delete_enrichment_all_params(self):
+        """
+        delete_enrichment()
+        """
+        # Set up mock
+        url = preprocess_url('/v2/projects/testString/enrichments/testString')
+        responses.add(responses.DELETE,
+                      url,
+                      status=204)
+
+        # Set up parameter values
+        project_id = 'testString'
+        enrichment_id = 'testString'
+
+        # Invoke method
+        response = _service.delete_enrichment(
+            project_id,
+            enrichment_id,
+            headers={}
+        )
+
+        # Check for correct operation
+        assert len(responses.calls) == 1
+        assert response.status_code == 204
+
+    def test_delete_enrichment_all_params_with_retries(self):
+        # Enable retries and run test_delete_enrichment_all_params.
+        _service.enable_retries()
+        self.test_delete_enrichment_all_params()
+
+        # Disable retries and run test_delete_enrichment_all_params.
+        _service.disable_retries()
+        self.test_delete_enrichment_all_params()
+
+    @responses.activate
+    def test_delete_enrichment_value_error(self):
+        """
+        test_delete_enrichment_value_error()
+        """
+        # Set up mock
+        url = preprocess_url('/v2/projects/testString/enrichments/testString')
+        responses.add(responses.DELETE,
+                      url,
+                      status=204)
+
+        # Set up parameter values
+        project_id = 'testString'
+        enrichment_id = 'testString'
+
+        # Pass in all but one required param and check for a ValueError
+        req_param_dict = {
+            "project_id": project_id,
+            "enrichment_id": enrichment_id,
+        }
+        for param in req_param_dict.keys():
+            req_copy = {key:val if key is not param else None for (key,val) in req_param_dict.items()}
+            with pytest.raises(ValueError):
+                _service.delete_enrichment(**req_copy)
+
+    def test_delete_enrichment_value_error_with_retries(self):
+        # Enable retries and run test_delete_enrichment_value_error.
+        _service.enable_retries()
+        self.test_delete_enrichment_value_error()
+
+        # Disable retries and run test_delete_enrichment_value_error.
+        _service.disable_retries()
+        self.test_delete_enrichment_value_error()
+
+# endregion
+##############################################################################
+# End of Service: Enrichments
+##############################################################################
+
+##############################################################################
+# Start of Service: DocumentClassifiers
+##############################################################################
+# region
+
+class TestListDocumentClassifiers():
+    """
+    Test Class for list_document_classifiers
+    """
+
+    @responses.activate
+    def test_list_document_classifiers_all_params(self):
+        """
+        list_document_classifiers()
+        """
+        # Set up mock
+        url = preprocess_url('/v2/projects/testString/document_classifiers')
+        mock_response = '{"classifiers": [{"classifier_id": "classifier_id", "name": "name", "description": "description", "created": "2019-01-01T12:00:00.000Z", "language": "en", "enrichments": [{"enrichment_id": "enrichment_id", "fields": ["fields"]}], "recognized_fields": ["recognized_fields"], "answer_field": "answer_field", "training_data_file": "training_data_file", "test_data_file": "test_data_file", "federated_classification": {"field": "field"}}]}'
+        responses.add(responses.GET,
+                      url,
+                      body=mock_response,
+                      content_type='application/json',
+                      status=200)
+
+        # Set up parameter values
+        project_id = 'testString'
+
+        # Invoke method
+        response = _service.list_document_classifiers(
+            project_id,
+            headers={}
+        )
+
+        # Check for correct operation
+        assert len(responses.calls) == 1
+        assert response.status_code == 200
+
+    def test_list_document_classifiers_all_params_with_retries(self):
+        # Enable retries and run test_list_document_classifiers_all_params.
+        _service.enable_retries()
+        self.test_list_document_classifiers_all_params()
+
+        # Disable retries and run test_list_document_classifiers_all_params.
+        _service.disable_retries()
+        self.test_list_document_classifiers_all_params()
+
+    @responses.activate
+    def test_list_document_classifiers_value_error(self):
+        """
+        test_list_document_classifiers_value_error()
+        """
+        # Set up mock
+        url = preprocess_url('/v2/projects/testString/document_classifiers')
+        mock_response = '{"classifiers": [{"classifier_id": "classifier_id", "name": "name", "description": "description", "created": "2019-01-01T12:00:00.000Z", "language": "en", "enrichments": [{"enrichment_id": "enrichment_id", "fields": ["fields"]}], "recognized_fields": ["recognized_fields"], "answer_field": "answer_field", "training_data_file": "training_data_file", "test_data_file": "test_data_file", "federated_classification": {"field": "field"}}]}'
+        responses.add(responses.GET,
+                      url,
+                      body=mock_response,
+                      content_type='application/json',
+                      status=200)
+
+        # Set up parameter values
+        project_id = 'testString'
+
+        # Pass in all but one required param and check for a ValueError
+        req_param_dict = {
+            "project_id": project_id,
+        }
+        for param in req_param_dict.keys():
+            req_copy = {key:val if key is not param else None for (key,val) in req_param_dict.items()}
+            with pytest.raises(ValueError):
+                _service.list_document_classifiers(**req_copy)
+
+    def test_list_document_classifiers_value_error_with_retries(self):
+        # Enable retries and run test_list_document_classifiers_value_error.
+        _service.enable_retries()
+        self.test_list_document_classifiers_value_error()
+
+        # Disable retries and run test_list_document_classifiers_value_error.
+        _service.disable_retries()
+        self.test_list_document_classifiers_value_error()
+
+class TestCreateDocumentClassifier():
+    """
+    Test Class for create_document_classifier
+    """
+
+    @responses.activate
+    def test_create_document_classifier_all_params(self):
+        """
+        create_document_classifier()
+        """
+        # Set up mock
+        url = preprocess_url('/v2/projects/testString/document_classifiers')
+        mock_response = '{"classifier_id": "classifier_id", "name": "name", "description": "description", "created": "2019-01-01T12:00:00.000Z", "language": "en", "enrichments": [{"enrichment_id": "enrichment_id", "fields": ["fields"]}], "recognized_fields": ["recognized_fields"], "answer_field": "answer_field", "training_data_file": "training_data_file", "test_data_file": "test_data_file", "federated_classification": {"field": "field"}}'
+        responses.add(responses.POST,
+                      url,
+                      body=mock_response,
+                      content_type='application/json',
+                      status=201)
+
+        # Construct a dict representation of a DocumentClassifierEnrichment model
+        document_classifier_enrichment_model = {}
+        document_classifier_enrichment_model['enrichment_id'] = 'testString'
+        document_classifier_enrichment_model['fields'] = ['testString']
+
+        # Construct a dict representation of a ClassifierFederatedModel model
+        classifier_federated_model_model = {}
+        classifier_federated_model_model['field'] = 'testString'
+
+        # Construct a dict representation of a CreateDocumentClassifier model
+        create_document_classifier_model = {}
+        create_document_classifier_model['name'] = 'testString'
+        create_document_classifier_model['description'] = 'testString'
+        create_document_classifier_model['language'] = 'en'
+        create_document_classifier_model['answer_field'] = 'testString'
+        create_document_classifier_model['enrichments'] = [document_classifier_enrichment_model]
+        create_document_classifier_model['federated_classification'] = classifier_federated_model_model
+
+        # Set up parameter values
+        project_id = 'testString'
+        training_data = io.BytesIO(b'This is a mock file.').getvalue()
+        classifier = create_document_classifier_model
+        test_data = io.BytesIO(b'This is a mock file.').getvalue()
+
+        # Invoke method
+        response = _service.create_document_classifier(
+            project_id,
+            training_data,
+            classifier,
+            test_data=test_data,
+            headers={}
+        )
+
+        # Check for correct operation
+        assert len(responses.calls) == 1
+        assert response.status_code == 201
+
+    def test_create_document_classifier_all_params_with_retries(self):
+        # Enable retries and run test_create_document_classifier_all_params.
+        _service.enable_retries()
+        self.test_create_document_classifier_all_params()
+
+        # Disable retries and run test_create_document_classifier_all_params.
+        _service.disable_retries()
+        self.test_create_document_classifier_all_params()
+
+    @responses.activate
+    def test_create_document_classifier_required_params(self):
+        """
+        test_create_document_classifier_required_params()
+        """
+        # Set up mock
+        url = preprocess_url('/v2/projects/testString/document_classifiers')
+        mock_response = '{"classifier_id": "classifier_id", "name": "name", "description": "description", "created": "2019-01-01T12:00:00.000Z", "language": "en", "enrichments": [{"enrichment_id": "enrichment_id", "fields": ["fields"]}], "recognized_fields": ["recognized_fields"], "answer_field": "answer_field", "training_data_file": "training_data_file", "test_data_file": "test_data_file", "federated_classification": {"field": "field"}}'
+        responses.add(responses.POST,
+                      url,
+                      body=mock_response,
+                      content_type='application/json',
+                      status=201)
+
+        # Construct a dict representation of a DocumentClassifierEnrichment model
+        document_classifier_enrichment_model = {}
+        document_classifier_enrichment_model['enrichment_id'] = 'testString'
+        document_classifier_enrichment_model['fields'] = ['testString']
+
+        # Construct a dict representation of a ClassifierFederatedModel model
+        classifier_federated_model_model = {}
+        classifier_federated_model_model['field'] = 'testString'
+
+        # Construct a dict representation of a CreateDocumentClassifier model
+        create_document_classifier_model = {}
+        create_document_classifier_model['name'] = 'testString'
+        create_document_classifier_model['description'] = 'testString'
+        create_document_classifier_model['language'] = 'en'
+        create_document_classifier_model['answer_field'] = 'testString'
+        create_document_classifier_model['enrichments'] = [document_classifier_enrichment_model]
+        create_document_classifier_model['federated_classification'] = classifier_federated_model_model
+
+        # Set up parameter values
+        project_id = 'testString'
+        training_data = io.BytesIO(b'This is a mock file.').getvalue()
+        classifier = create_document_classifier_model
+
+        # Invoke method
+        response = _service.create_document_classifier(
+            project_id,
+            training_data,
+            classifier,
+            headers={}
+        )
+
+        # Check for correct operation
+        assert len(responses.calls) == 1
+        assert response.status_code == 201
+
+    def test_create_document_classifier_required_params_with_retries(self):
+        # Enable retries and run test_create_document_classifier_required_params.
+        _service.enable_retries()
+        self.test_create_document_classifier_required_params()
+
+        # Disable retries and run test_create_document_classifier_required_params.
+        _service.disable_retries()
+        self.test_create_document_classifier_required_params()
+
+    @responses.activate
+    def test_create_document_classifier_value_error(self):
+        """
+        test_create_document_classifier_value_error()
+        """
+        # Set up mock
+        url = preprocess_url('/v2/projects/testString/document_classifiers')
+        mock_response = '{"classifier_id": "classifier_id", "name": "name", "description": "description", "created": "2019-01-01T12:00:00.000Z", "language": "en", "enrichments": [{"enrichment_id": "enrichment_id", "fields": ["fields"]}], "recognized_fields": ["recognized_fields"], "answer_field": "answer_field", "training_data_file": "training_data_file", "test_data_file": "test_data_file", "federated_classification": {"field": "field"}}'
+        responses.add(responses.POST,
+                      url,
+                      body=mock_response,
+                      content_type='application/json',
+                      status=201)
+
+        # Construct a dict representation of a DocumentClassifierEnrichment model
+        document_classifier_enrichment_model = {}
+        document_classifier_enrichment_model['enrichment_id'] = 'testString'
+        document_classifier_enrichment_model['fields'] = ['testString']
+
+        # Construct a dict representation of a ClassifierFederatedModel model
+        classifier_federated_model_model = {}
+        classifier_federated_model_model['field'] = 'testString'
+
+        # Construct a dict representation of a CreateDocumentClassifier model
+        create_document_classifier_model = {}
+        create_document_classifier_model['name'] = 'testString'
+        create_document_classifier_model['description'] = 'testString'
+        create_document_classifier_model['language'] = 'en'
+        create_document_classifier_model['answer_field'] = 'testString'
+        create_document_classifier_model['enrichments'] = [document_classifier_enrichment_model]
+        create_document_classifier_model['federated_classification'] = classifier_federated_model_model
+
+        # Set up parameter values
+        project_id = 'testString'
+        training_data = io.BytesIO(b'This is a mock file.').getvalue()
+        classifier = create_document_classifier_model
+
+        # Pass in all but one required param and check for a ValueError
+        req_param_dict = {
+            "project_id": project_id,
+            "training_data": training_data,
+            "classifier": classifier,
+        }
+        for param in req_param_dict.keys():
+            req_copy = {key:val if key is not param else None for (key,val) in req_param_dict.items()}
+            with pytest.raises(ValueError):
+                _service.create_document_classifier(**req_copy)
+
+    def test_create_document_classifier_value_error_with_retries(self):
+        # Enable retries and run test_create_document_classifier_value_error.
+        _service.enable_retries()
+        self.test_create_document_classifier_value_error()
+
+        # Disable retries and run test_create_document_classifier_value_error.
+        _service.disable_retries()
+        self.test_create_document_classifier_value_error()
+
+class TestGetDocumentClassifier():
+    """
+    Test Class for get_document_classifier
+    """
+
+    @responses.activate
+    def test_get_document_classifier_all_params(self):
+        """
+        get_document_classifier()
+        """
+        # Set up mock
+        url = preprocess_url('/v2/projects/testString/document_classifiers/testString')
+        mock_response = '{"classifier_id": "classifier_id", "name": "name", "description": "description", "created": "2019-01-01T12:00:00.000Z", "language": "en", "enrichments": [{"enrichment_id": "enrichment_id", "fields": ["fields"]}], "recognized_fields": ["recognized_fields"], "answer_field": "answer_field", "training_data_file": "training_data_file", "test_data_file": "test_data_file", "federated_classification": {"field": "field"}}'
+        responses.add(responses.GET,
+                      url,
+                      body=mock_response,
+                      content_type='application/json',
+                      status=200)
+
+        # Set up parameter values
+        project_id = 'testString'
+        classifier_id = 'testString'
+
+        # Invoke method
+        response = _service.get_document_classifier(
+            project_id,
+            classifier_id,
+            headers={}
+        )
+
+        # Check for correct operation
+        assert len(responses.calls) == 1
+        assert response.status_code == 200
+
+    def test_get_document_classifier_all_params_with_retries(self):
+        # Enable retries and run test_get_document_classifier_all_params.
+        _service.enable_retries()
+        self.test_get_document_classifier_all_params()
+
+        # Disable retries and run test_get_document_classifier_all_params.
+        _service.disable_retries()
+        self.test_get_document_classifier_all_params()
+
+    @responses.activate
+    def test_get_document_classifier_value_error(self):
+        """
+        test_get_document_classifier_value_error()
+        """
+        # Set up mock
+        url = preprocess_url('/v2/projects/testString/document_classifiers/testString')
+        mock_response = '{"classifier_id": "classifier_id", "name": "name", "description": "description", "created": "2019-01-01T12:00:00.000Z", "language": "en", "enrichments": [{"enrichment_id": "enrichment_id", "fields": ["fields"]}], "recognized_fields": ["recognized_fields"], "answer_field": "answer_field", "training_data_file": "training_data_file", "test_data_file": "test_data_file", "federated_classification": {"field": "field"}}'
+        responses.add(responses.GET,
+                      url,
+                      body=mock_response,
+                      content_type='application/json',
+                      status=200)
+
+        # Set up parameter values
+        project_id = 'testString'
+        classifier_id = 'testString'
+
+        # Pass in all but one required param and check for a ValueError
+        req_param_dict = {
+            "project_id": project_id,
+            "classifier_id": classifier_id,
+        }
+        for param in req_param_dict.keys():
+            req_copy = {key:val if key is not param else None for (key,val) in req_param_dict.items()}
+            with pytest.raises(ValueError):
+                _service.get_document_classifier(**req_copy)
+
+    def test_get_document_classifier_value_error_with_retries(self):
+        # Enable retries and run test_get_document_classifier_value_error.
+        _service.enable_retries()
+        self.test_get_document_classifier_value_error()
+
+        # Disable retries and run test_get_document_classifier_value_error.
+        _service.disable_retries()
+        self.test_get_document_classifier_value_error()
+
+class TestUpdateDocumentClassifier():
+    """
+    Test Class for update_document_classifier
+    """
+
+    @responses.activate
+    def test_update_document_classifier_all_params(self):
+        """
+        update_document_classifier()
+        """
+        # Set up mock
+        url = preprocess_url('/v2/projects/testString/document_classifiers/testString')
+        mock_response = '{"classifier_id": "classifier_id", "name": "name", "description": "description", "created": "2019-01-01T12:00:00.000Z", "language": "en", "enrichments": [{"enrichment_id": "enrichment_id", "fields": ["fields"]}], "recognized_fields": ["recognized_fields"], "answer_field": "answer_field", "training_data_file": "training_data_file", "test_data_file": "test_data_file", "federated_classification": {"field": "field"}}'
+        responses.add(responses.POST,
+                      url,
+                      body=mock_response,
+                      content_type='application/json',
+                      status=201)
+
+        # Construct a dict representation of a UpdateDocumentClassifier model
+        update_document_classifier_model = {}
+        update_document_classifier_model['name'] = 'testString'
+        update_document_classifier_model['description'] = 'testString'
+
+        # Set up parameter values
+        project_id = 'testString'
+        classifier_id = 'testString'
+        classifier = update_document_classifier_model
+        training_data = io.BytesIO(b'This is a mock file.').getvalue()
+        test_data = io.BytesIO(b'This is a mock file.').getvalue()
+
+        # Invoke method
+        response = _service.update_document_classifier(
+            project_id,
+            classifier_id,
+            classifier,
+            training_data=training_data,
+            test_data=test_data,
+            headers={}
+        )
+
+        # Check for correct operation
+        assert len(responses.calls) == 1
+        assert response.status_code == 201
+
+    def test_update_document_classifier_all_params_with_retries(self):
+        # Enable retries and run test_update_document_classifier_all_params.
+        _service.enable_retries()
+        self.test_update_document_classifier_all_params()
+
+        # Disable retries and run test_update_document_classifier_all_params.
+        _service.disable_retries()
+        self.test_update_document_classifier_all_params()
+
+    @responses.activate
+    def test_update_document_classifier_required_params(self):
+        """
+        test_update_document_classifier_required_params()
+        """
+        # Set up mock
+        url = preprocess_url('/v2/projects/testString/document_classifiers/testString')
+        mock_response = '{"classifier_id": "classifier_id", "name": "name", "description": "description", "created": "2019-01-01T12:00:00.000Z", "language": "en", "enrichments": [{"enrichment_id": "enrichment_id", "fields": ["fields"]}], "recognized_fields": ["recognized_fields"], "answer_field": "answer_field", "training_data_file": "training_data_file", "test_data_file": "test_data_file", "federated_classification": {"field": "field"}}'
+        responses.add(responses.POST,
+                      url,
+                      body=mock_response,
+                      content_type='application/json',
+                      status=201)
+
+        # Construct a dict representation of a UpdateDocumentClassifier model
+        update_document_classifier_model = {}
+        update_document_classifier_model['name'] = 'testString'
+        update_document_classifier_model['description'] = 'testString'
+
+        # Set up parameter values
+        project_id = 'testString'
+        classifier_id = 'testString'
+        classifier = update_document_classifier_model
+
+        # Invoke method
+        response = _service.update_document_classifier(
+            project_id,
+            classifier_id,
+            classifier,
+            headers={}
+        )
+
+        # Check for correct operation
+        assert len(responses.calls) == 1
+        assert response.status_code == 201
+
+    def test_update_document_classifier_required_params_with_retries(self):
+        # Enable retries and run test_update_document_classifier_required_params.
+        _service.enable_retries()
+        self.test_update_document_classifier_required_params()
+
+        # Disable retries and run test_update_document_classifier_required_params.
+        _service.disable_retries()
+        self.test_update_document_classifier_required_params()
+
+    @responses.activate
+    def test_update_document_classifier_value_error(self):
+        """
+        test_update_document_classifier_value_error()
+        """
+        # Set up mock
+        url = preprocess_url('/v2/projects/testString/document_classifiers/testString')
+        mock_response = '{"classifier_id": "classifier_id", "name": "name", "description": "description", "created": "2019-01-01T12:00:00.000Z", "language": "en", "enrichments": [{"enrichment_id": "enrichment_id", "fields": ["fields"]}], "recognized_fields": ["recognized_fields"], "answer_field": "answer_field", "training_data_file": "training_data_file", "test_data_file": "test_data_file", "federated_classification": {"field": "field"}}'
+        responses.add(responses.POST,
+                      url,
+                      body=mock_response,
+                      content_type='application/json',
+                      status=201)
+
+        # Construct a dict representation of a UpdateDocumentClassifier model
+        update_document_classifier_model = {}
+        update_document_classifier_model['name'] = 'testString'
+        update_document_classifier_model['description'] = 'testString'
+
+        # Set up parameter values
+        project_id = 'testString'
+        classifier_id = 'testString'
+        classifier = update_document_classifier_model
+
+        # Pass in all but one required param and check for a ValueError
+        req_param_dict = {
+            "project_id": project_id,
+            "classifier_id": classifier_id,
+            "classifier": classifier,
+        }
+        for param in req_param_dict.keys():
+            req_copy = {key:val if key is not param else None for (key,val) in req_param_dict.items()}
+            with pytest.raises(ValueError):
+                _service.update_document_classifier(**req_copy)
+
+    def test_update_document_classifier_value_error_with_retries(self):
+        # Enable retries and run test_update_document_classifier_value_error.
+        _service.enable_retries()
+        self.test_update_document_classifier_value_error()
+
+        # Disable retries and run test_update_document_classifier_value_error.
+        _service.disable_retries()
+        self.test_update_document_classifier_value_error()
+
+class TestDeleteDocumentClassifier():
+    """
+    Test Class for delete_document_classifier
+    """
+
+    @responses.activate
+    def test_delete_document_classifier_all_params(self):
+        """
+        delete_document_classifier()
+        """
+        # Set up mock
+        url = preprocess_url('/v2/projects/testString/document_classifiers/testString')
+        responses.add(responses.DELETE,
+                      url,
+                      status=204)
+
+        # Set up parameter values
+        project_id = 'testString'
+        classifier_id = 'testString'
+
+        # Invoke method
+        response = _service.delete_document_classifier(
+            project_id,
+            classifier_id,
+            headers={}
+        )
+
+        # Check for correct operation
+        assert len(responses.calls) == 1
+        assert response.status_code == 204
+
+    def test_delete_document_classifier_all_params_with_retries(self):
+        # Enable retries and run test_delete_document_classifier_all_params.
+        _service.enable_retries()
+        self.test_delete_document_classifier_all_params()
+
+        # Disable retries and run test_delete_document_classifier_all_params.
+        _service.disable_retries()
+        self.test_delete_document_classifier_all_params()
+
+    @responses.activate
+    def test_delete_document_classifier_value_error(self):
+        """
+        test_delete_document_classifier_value_error()
+        """
+        # Set up mock
+        url = preprocess_url('/v2/projects/testString/document_classifiers/testString')
+        responses.add(responses.DELETE,
+                      url,
+                      status=204)
+
+        # Set up parameter values
+        project_id = 'testString'
+        classifier_id = 'testString'
+
+        # Pass in all but one required param and check for a ValueError
+        req_param_dict = {
+            "project_id": project_id,
+            "classifier_id": classifier_id,
+        }
+        for param in req_param_dict.keys():
+            req_copy = {key:val if key is not param else None for (key,val) in req_param_dict.items()}
+            with pytest.raises(ValueError):
+                _service.delete_document_classifier(**req_copy)
+
+    def test_delete_document_classifier_value_error_with_retries(self):
+        # Enable retries and run test_delete_document_classifier_value_error.
+        _service.enable_retries()
+        self.test_delete_document_classifier_value_error()
+
+        # Disable retries and run test_delete_document_classifier_value_error.
+        _service.disable_retries()
+        self.test_delete_document_classifier_value_error()
+
+# endregion
+##############################################################################
+# End of Service: DocumentClassifiers
+##############################################################################
+
+##############################################################################
+# Start of Service: DocumentClassifierModels
+##############################################################################
+# region
+
+class TestListDocumentClassifierModels():
+    """
+    Test Class for list_document_classifier_models
+    """
+
+    @responses.activate
+    def test_list_document_classifier_models_all_params(self):
+        """
+        list_document_classifier_models()
+        """
+        # Set up mock
+        url = preprocess_url('/v2/projects/testString/document_classifiers/testString/models')
+        mock_response = '{"models": [{"model_id": "model_id", "name": "name", "description": "description", "created": "2019-01-01T12:00:00.000Z", "updated": "2019-01-01T12:00:00.000Z", "training_data_file": "training_data_file", "test_data_file": "test_data_file", "status": "training", "evaluation": {"micro_average": {"precision": 0, "recall": 0, "f1": 0}, "macro_average": {"precision": 0, "recall": 0, "f1": 0}, "per_class": [{"name": "name", "precision": 0, "recall": 0, "f1": 0}]}, "enrichment_id": "enrichment_id", "deployed_at": "2019-01-01T12:00:00.000Z"}]}'
+        responses.add(responses.GET,
+                      url,
+                      body=mock_response,
+                      content_type='application/json',
+                      status=200)
+
+        # Set up parameter values
+        project_id = 'testString'
+        classifier_id = 'testString'
+
+        # Invoke method
+        response = _service.list_document_classifier_models(
+            project_id,
+            classifier_id,
+            headers={}
+        )
+
+        # Check for correct operation
+        assert len(responses.calls) == 1
+        assert response.status_code == 200
+
+    def test_list_document_classifier_models_all_params_with_retries(self):
+        # Enable retries and run test_list_document_classifier_models_all_params.
+        _service.enable_retries()
+        self.test_list_document_classifier_models_all_params()
+
+        # Disable retries and run test_list_document_classifier_models_all_params.
+        _service.disable_retries()
+        self.test_list_document_classifier_models_all_params()
+
+    @responses.activate
+    def test_list_document_classifier_models_value_error(self):
+        """
+        test_list_document_classifier_models_value_error()
+        """
+        # Set up mock
+        url = preprocess_url('/v2/projects/testString/document_classifiers/testString/models')
+        mock_response = '{"models": [{"model_id": "model_id", "name": "name", "description": "description", "created": "2019-01-01T12:00:00.000Z", "updated": "2019-01-01T12:00:00.000Z", "training_data_file": "training_data_file", "test_data_file": "test_data_file", "status": "training", "evaluation": {"micro_average": {"precision": 0, "recall": 0, "f1": 0}, "macro_average": {"precision": 0, "recall": 0, "f1": 0}, "per_class": [{"name": "name", "precision": 0, "recall": 0, "f1": 0}]}, "enrichment_id": "enrichment_id", "deployed_at": "2019-01-01T12:00:00.000Z"}]}'
+        responses.add(responses.GET,
+                      url,
+                      body=mock_response,
+                      content_type='application/json',
+                      status=200)
+
+        # Set up parameter values
+        project_id = 'testString'
+        classifier_id = 'testString'
+
+        # Pass in all but one required param and check for a ValueError
+        req_param_dict = {
+            "project_id": project_id,
+            "classifier_id": classifier_id,
+        }
+        for param in req_param_dict.keys():
+            req_copy = {key:val if key is not param else None for (key,val) in req_param_dict.items()}
+            with pytest.raises(ValueError):
+                _service.list_document_classifier_models(**req_copy)
+
+    def test_list_document_classifier_models_value_error_with_retries(self):
+        # Enable retries and run test_list_document_classifier_models_value_error.
+        _service.enable_retries()
+        self.test_list_document_classifier_models_value_error()
+
+        # Disable retries and run test_list_document_classifier_models_value_error.
+        _service.disable_retries()
+        self.test_list_document_classifier_models_value_error()
+
+class TestCreateDocumentClassifierModel():
+    """
+    Test Class for create_document_classifier_model
+    """
+
+    @responses.activate
+    def test_create_document_classifier_model_all_params(self):
+        """
+        create_document_classifier_model()
+        """
+        # Set up mock
+        url = preprocess_url('/v2/projects/testString/document_classifiers/testString/models')
+        mock_response = '{"model_id": "model_id", "name": "name", "description": "description", "created": "2019-01-01T12:00:00.000Z", "updated": "2019-01-01T12:00:00.000Z", "training_data_file": "training_data_file", "test_data_file": "test_data_file", "status": "training", "evaluation": {"micro_average": {"precision": 0, "recall": 0, "f1": 0}, "macro_average": {"precision": 0, "recall": 0, "f1": 0}, "per_class": [{"name": "name", "precision": 0, "recall": 0, "f1": 0}]}, "enrichment_id": "enrichment_id", "deployed_at": "2019-01-01T12:00:00.000Z"}'
+        responses.add(responses.POST,
+                      url,
+                      body=mock_response,
+                      content_type='application/json',
+                      status=201)
+
+        # Set up parameter values
+        project_id = 'testString'
+        classifier_id = 'testString'
+        name = 'testString'
+        description = 'testString'
+        learning_rate = 0
+        l1_regularization_strengths = [1.0E-6]
+        l2_regularization_strengths = [1.0E-6]
+        training_max_steps = 0
+        improvement_ratio = 0
+
+        # Invoke method
+        response = _service.create_document_classifier_model(
+            project_id,
+            classifier_id,
+            name,
+            description=description,
+            learning_rate=learning_rate,
+            l1_regularization_strengths=l1_regularization_strengths,
+            l2_regularization_strengths=l2_regularization_strengths,
+            training_max_steps=training_max_steps,
+            improvement_ratio=improvement_ratio,
+            headers={}
+        )
+
+        # Check for correct operation
+        assert len(responses.calls) == 1
+        assert response.status_code == 201
+        # Validate body params
+        req_body = json.loads(str(responses.calls[0].request.body, 'utf-8'))
+        assert req_body['name'] == 'testString'
+        assert req_body['description'] == 'testString'
+        assert req_body['learning_rate'] == 0
+        assert req_body['l1_regularization_strengths'] == [1.0E-6]
+        assert req_body['l2_regularization_strengths'] == [1.0E-6]
+        assert req_body['training_max_steps'] == 0
+        assert req_body['improvement_ratio'] == 0
+
+    def test_create_document_classifier_model_all_params_with_retries(self):
+        # Enable retries and run test_create_document_classifier_model_all_params.
+        _service.enable_retries()
+        self.test_create_document_classifier_model_all_params()
+
+        # Disable retries and run test_create_document_classifier_model_all_params.
+        _service.disable_retries()
+        self.test_create_document_classifier_model_all_params()
+
+    @responses.activate
+    def test_create_document_classifier_model_value_error(self):
+        """
+        test_create_document_classifier_model_value_error()
+        """
+        # Set up mock
+        url = preprocess_url('/v2/projects/testString/document_classifiers/testString/models')
+        mock_response = '{"model_id": "model_id", "name": "name", "description": "description", "created": "2019-01-01T12:00:00.000Z", "updated": "2019-01-01T12:00:00.000Z", "training_data_file": "training_data_file", "test_data_file": "test_data_file", "status": "training", "evaluation": {"micro_average": {"precision": 0, "recall": 0, "f1": 0}, "macro_average": {"precision": 0, "recall": 0, "f1": 0}, "per_class": [{"name": "name", "precision": 0, "recall": 0, "f1": 0}]}, "enrichment_id": "enrichment_id", "deployed_at": "2019-01-01T12:00:00.000Z"}'
+        responses.add(responses.POST,
+                      url,
+                      body=mock_response,
+                      content_type='application/json',
+                      status=201)
+
+        # Set up parameter values
+        project_id = 'testString'
+        classifier_id = 'testString'
+        name = 'testString'
+        description = 'testString'
+        learning_rate = 0
+        l1_regularization_strengths = [1.0E-6]
+        l2_regularization_strengths = [1.0E-6]
+        training_max_steps = 0
+        improvement_ratio = 0
+
+        # Pass in all but one required param and check for a ValueError
+        req_param_dict = {
+            "project_id": project_id,
+            "classifier_id": classifier_id,
+            "name": name,
+        }
+        for param in req_param_dict.keys():
+            req_copy = {key:val if key is not param else None for (key,val) in req_param_dict.items()}
+            with pytest.raises(ValueError):
+                _service.create_document_classifier_model(**req_copy)
+
+    def test_create_document_classifier_model_value_error_with_retries(self):
+        # Enable retries and run test_create_document_classifier_model_value_error.
+        _service.enable_retries()
+        self.test_create_document_classifier_model_value_error()
+
+        # Disable retries and run test_create_document_classifier_model_value_error.
+        _service.disable_retries()
+        self.test_create_document_classifier_model_value_error()
+
+class TestGetDocumentClassifierModel():
+    """
+    Test Class for get_document_classifier_model
+    """
+
+    @responses.activate
+    def test_get_document_classifier_model_all_params(self):
+        """
+        get_document_classifier_model()
+        """
+        # Set up mock
+        url = preprocess_url('/v2/projects/testString/document_classifiers/testString/models/testString')
+        mock_response = '{"model_id": "model_id", "name": "name", "description": "description", "created": "2019-01-01T12:00:00.000Z", "updated": "2019-01-01T12:00:00.000Z", "training_data_file": "training_data_file", "test_data_file": "test_data_file", "status": "training", "evaluation": {"micro_average": {"precision": 0, "recall": 0, "f1": 0}, "macro_average": {"precision": 0, "recall": 0, "f1": 0}, "per_class": [{"name": "name", "precision": 0, "recall": 0, "f1": 0}]}, "enrichment_id": "enrichment_id", "deployed_at": "2019-01-01T12:00:00.000Z"}'
+        responses.add(responses.GET,
+                      url,
+                      body=mock_response,
+                      content_type='application/json',
+                      status=200)
+
+        # Set up parameter values
+        project_id = 'testString'
+        classifier_id = 'testString'
+        model_id = 'testString'
+
+        # Invoke method
+        response = _service.get_document_classifier_model(
+            project_id,
+            classifier_id,
+            model_id,
+            headers={}
+        )
+
+        # Check for correct operation
+        assert len(responses.calls) == 1
+        assert response.status_code == 200
+
+    def test_get_document_classifier_model_all_params_with_retries(self):
+        # Enable retries and run test_get_document_classifier_model_all_params.
+        _service.enable_retries()
+        self.test_get_document_classifier_model_all_params()
+
+        # Disable retries and run test_get_document_classifier_model_all_params.
+        _service.disable_retries()
+        self.test_get_document_classifier_model_all_params()
+
+    @responses.activate
+    def test_get_document_classifier_model_value_error(self):
+        """
+        test_get_document_classifier_model_value_error()
+        """
+        # Set up mock
+        url = preprocess_url('/v2/projects/testString/document_classifiers/testString/models/testString')
+        mock_response = '{"model_id": "model_id", "name": "name", "description": "description", "created": "2019-01-01T12:00:00.000Z", "updated": "2019-01-01T12:00:00.000Z", "training_data_file": "training_data_file", "test_data_file": "test_data_file", "status": "training", "evaluation": {"micro_average": {"precision": 0, "recall": 0, "f1": 0}, "macro_average": {"precision": 0, "recall": 0, "f1": 0}, "per_class": [{"name": "name", "precision": 0, "recall": 0, "f1": 0}]}, "enrichment_id": "enrichment_id", "deployed_at": "2019-01-01T12:00:00.000Z"}'
+        responses.add(responses.GET,
+                      url,
+                      body=mock_response,
+                      content_type='application/json',
+                      status=200)
+
+        # Set up parameter values
+        project_id = 'testString'
+        classifier_id = 'testString'
+        model_id = 'testString'
+
+        # Pass in all but one required param and check for a ValueError
+        req_param_dict = {
+            "project_id": project_id,
+            "classifier_id": classifier_id,
+            "model_id": model_id,
+        }
+        for param in req_param_dict.keys():
+            req_copy = {key:val if key is not param else None for (key,val) in req_param_dict.items()}
+            with pytest.raises(ValueError):
+                _service.get_document_classifier_model(**req_copy)
+
+    def test_get_document_classifier_model_value_error_with_retries(self):
+        # Enable retries and run test_get_document_classifier_model_value_error.
+        _service.enable_retries()
+        self.test_get_document_classifier_model_value_error()
+
+        # Disable retries and run test_get_document_classifier_model_value_error.
+        _service.disable_retries()
+        self.test_get_document_classifier_model_value_error()
+
+class TestUpdateDocumentClassifierModel():
+    """
+    Test Class for update_document_classifier_model
+    """
+
+    @responses.activate
+    def test_update_document_classifier_model_all_params(self):
+        """
+        update_document_classifier_model()
+        """
+        # Set up mock
+        url = preprocess_url('/v2/projects/testString/document_classifiers/testString/models/testString')
+        mock_response = '{"model_id": "model_id", "name": "name", "description": "description", "created": "2019-01-01T12:00:00.000Z", "updated": "2019-01-01T12:00:00.000Z", "training_data_file": "training_data_file", "test_data_file": "test_data_file", "status": "training", "evaluation": {"micro_average": {"precision": 0, "recall": 0, "f1": 0}, "macro_average": {"precision": 0, "recall": 0, "f1": 0}, "per_class": [{"name": "name", "precision": 0, "recall": 0, "f1": 0}]}, "enrichment_id": "enrichment_id", "deployed_at": "2019-01-01T12:00:00.000Z"}'
+        responses.add(responses.POST,
+                      url,
+                      body=mock_response,
+                      content_type='application/json',
+                      status=201)
+
+        # Set up parameter values
+        project_id = 'testString'
+        classifier_id = 'testString'
+        model_id = 'testString'
+        name = 'testString'
+        description = 'testString'
+
+        # Invoke method
+        response = _service.update_document_classifier_model(
+            project_id,
+            classifier_id,
+            model_id,
+            name=name,
+            description=description,
+            headers={}
+        )
+
+        # Check for correct operation
+        assert len(responses.calls) == 1
+        assert response.status_code == 201
+        # Validate body params
+        req_body = json.loads(str(responses.calls[0].request.body, 'utf-8'))
+        assert req_body['name'] == 'testString'
+        assert req_body['description'] == 'testString'
+
+    def test_update_document_classifier_model_all_params_with_retries(self):
+        # Enable retries and run test_update_document_classifier_model_all_params.
+        _service.enable_retries()
+        self.test_update_document_classifier_model_all_params()
+
+        # Disable retries and run test_update_document_classifier_model_all_params.
+        _service.disable_retries()
+        self.test_update_document_classifier_model_all_params()
+
+    @responses.activate
+    def test_update_document_classifier_model_value_error(self):
+        """
+        test_update_document_classifier_model_value_error()
+        """
+        # Set up mock
+        url = preprocess_url('/v2/projects/testString/document_classifiers/testString/models/testString')
+        mock_response = '{"model_id": "model_id", "name": "name", "description": "description", "created": "2019-01-01T12:00:00.000Z", "updated": "2019-01-01T12:00:00.000Z", "training_data_file": "training_data_file", "test_data_file": "test_data_file", "status": "training", "evaluation": {"micro_average": {"precision": 0, "recall": 0, "f1": 0}, "macro_average": {"precision": 0, "recall": 0, "f1": 0}, "per_class": [{"name": "name", "precision": 0, "recall": 0, "f1": 0}]}, "enrichment_id": "enrichment_id", "deployed_at": "2019-01-01T12:00:00.000Z"}'
+        responses.add(responses.POST,
+                      url,
+                      body=mock_response,
+                      content_type='application/json',
+                      status=201)
+
+        # Set up parameter values
+        project_id = 'testString'
+        classifier_id = 'testString'
+        model_id = 'testString'
+        name = 'testString'
+        description = 'testString'
+
+        # Pass in all but one required param and check for a ValueError
+        req_param_dict = {
+            "project_id": project_id,
+            "classifier_id": classifier_id,
+            "model_id": model_id,
+        }
+        for param in req_param_dict.keys():
+            req_copy = {key:val if key is not param else None for (key,val) in req_param_dict.items()}
+            with pytest.raises(ValueError):
+                _service.update_document_classifier_model(**req_copy)
+
+    def test_update_document_classifier_model_value_error_with_retries(self):
+        # Enable retries and run test_update_document_classifier_model_value_error.
+        _service.enable_retries()
+        self.test_update_document_classifier_model_value_error()
+
+        # Disable retries and run test_update_document_classifier_model_value_error.
+        _service.disable_retries()
+        self.test_update_document_classifier_model_value_error()
+
+class TestDeleteDocumentClassifierModel():
+    """
+    Test Class for delete_document_classifier_model
+    """
+
+    @responses.activate
+    def test_delete_document_classifier_model_all_params(self):
+        """
+        delete_document_classifier_model()
+        """
+        # Set up mock
+        url = preprocess_url('/v2/projects/testString/document_classifiers/testString/models/testString')
+        responses.add(responses.DELETE,
+                      url,
+                      status=204)
+
+        # Set up parameter values
+        project_id = 'testString'
+        classifier_id = 'testString'
+        model_id = 'testString'
+
+        # Invoke method
+        response = _service.delete_document_classifier_model(
+            project_id,
+            classifier_id,
+            model_id,
+            headers={}
+        )
+
+        # Check for correct operation
+        assert len(responses.calls) == 1
+        assert response.status_code == 204
+
+    def test_delete_document_classifier_model_all_params_with_retries(self):
+        # Enable retries and run test_delete_document_classifier_model_all_params.
+        _service.enable_retries()
+        self.test_delete_document_classifier_model_all_params()
+
+        # Disable retries and run test_delete_document_classifier_model_all_params.
+        _service.disable_retries()
+        self.test_delete_document_classifier_model_all_params()
+
+    @responses.activate
+    def test_delete_document_classifier_model_value_error(self):
+        """
+        test_delete_document_classifier_model_value_error()
+        """
+        # Set up mock
+        url = preprocess_url('/v2/projects/testString/document_classifiers/testString/models/testString')
+        responses.add(responses.DELETE,
+                      url,
+                      status=204)
+
+        # Set up parameter values
+        project_id = 'testString'
+        classifier_id = 'testString'
+        model_id = 'testString'
+
+        # Pass in all but one required param and check for a ValueError
+        req_param_dict = {
+            "project_id": project_id,
+            "classifier_id": classifier_id,
+            "model_id": model_id,
+        }
+        for param in req_param_dict.keys():
+            req_copy = {key:val if key is not param else None for (key,val) in req_param_dict.items()}
+            with pytest.raises(ValueError):
+                _service.delete_document_classifier_model(**req_copy)
+
+    def test_delete_document_classifier_model_value_error_with_retries(self):
+        # Enable retries and run test_delete_document_classifier_model_value_error.
+        _service.enable_retries()
+        self.test_delete_document_classifier_model_value_error()
+
+        # Disable retries and run test_delete_document_classifier_model_value_error.
+        _service.disable_retries()
+        self.test_delete_document_classifier_model_value_error()
+
+# endregion
+##############################################################################
+# End of Service: DocumentClassifierModels
+##############################################################################
+
+##############################################################################
+# Start of Service: Analyze
+##############################################################################
+# region
+
+class TestAnalyzeDocument():
+    """
+    Test Class for analyze_document
+    """
+
+    @responses.activate
+    def test_analyze_document_all_params(self):
+        """
+        analyze_document()
+        """
+        # Set up mock
+        url = preprocess_url('/v2/projects/testString/collections/testString/analyze')
+        mock_response = '{"notices": [{"notice_id": "notice_id", "created": "2019-01-01T12:00:00.000Z", "document_id": "document_id", "collection_id": "collection_id", "query_id": "query_id", "severity": "warning", "step": "step", "description": "description"}], "result": {"metadata": {"mapKey": "anyValue"}}}'
+        responses.add(responses.POST,
+                      url,
+                      body=mock_response,
+                      content_type='application/json',
+                      status=200)
+
+        # Set up parameter values
+        project_id = 'testString'
+        collection_id = 'testString'
+        file = io.BytesIO(b'This is a mock file.').getvalue()
+        filename = 'testString'
+        file_content_type = 'application/json'
+        metadata = 'testString'
+
+        # Invoke method
+        response = _service.analyze_document(
+            project_id,
+            collection_id,
+            file=file,
+            filename=filename,
+            file_content_type=file_content_type,
+            metadata=metadata,
+            headers={}
+        )
+
+        # Check for correct operation
+        assert len(responses.calls) == 1
+        assert response.status_code == 200
+
+    def test_analyze_document_all_params_with_retries(self):
+        # Enable retries and run test_analyze_document_all_params.
+        _service.enable_retries()
+        self.test_analyze_document_all_params()
+
+        # Disable retries and run test_analyze_document_all_params.
+        _service.disable_retries()
+        self.test_analyze_document_all_params()
+
+    @responses.activate
+    def test_analyze_document_required_params(self):
+        """
+        test_analyze_document_required_params()
+        """
+        # Set up mock
+        url = preprocess_url('/v2/projects/testString/collections/testString/analyze')
+        mock_response = '{"notices": [{"notice_id": "notice_id", "created": "2019-01-01T12:00:00.000Z", "document_id": "document_id", "collection_id": "collection_id", "query_id": "query_id", "severity": "warning", "step": "step", "description": "description"}], "result": {"metadata": {"mapKey": "anyValue"}}}'
+        responses.add(responses.POST,
+                      url,
+                      body=mock_response,
+                      content_type='application/json',
+                      status=200)
+
+        # Set up parameter values
+        project_id = 'testString'
+        collection_id = 'testString'
+
+        # Invoke method
+        response = _service.analyze_document(
+            project_id,
+            collection_id,
+            headers={}
+        )
+
+        # Check for correct operation
+        assert len(responses.calls) == 1
+        assert response.status_code == 200
+
+    def test_analyze_document_required_params_with_retries(self):
+        # Enable retries and run test_analyze_document_required_params.
+        _service.enable_retries()
+        self.test_analyze_document_required_params()
+
+        # Disable retries and run test_analyze_document_required_params.
+        _service.disable_retries()
+        self.test_analyze_document_required_params()
+
+    @responses.activate
+    def test_analyze_document_value_error(self):
+        """
+        test_analyze_document_value_error()
+        """
+        # Set up mock
+        url = preprocess_url('/v2/projects/testString/collections/testString/analyze')
+        mock_response = '{"notices": [{"notice_id": "notice_id", "created": "2019-01-01T12:00:00.000Z", "document_id": "document_id", "collection_id": "collection_id", "query_id": "query_id", "severity": "warning", "step": "step", "description": "description"}], "result": {"metadata": {"mapKey": "anyValue"}}}'
+        responses.add(responses.POST,
+                      url,
+                      body=mock_response,
+                      content_type='application/json',
+                      status=200)
+
+        # Set up parameter values
+        project_id = 'testString'
+        collection_id = 'testString'
+
+        # Pass in all but one required param and check for a ValueError
+        req_param_dict = {
+            "project_id": project_id,
+            "collection_id": collection_id,
+        }
+        for param in req_param_dict.keys():
+            req_copy = {key:val if key is not param else None for (key,val) in req_param_dict.items()}
+            with pytest.raises(ValueError):
+                _service.analyze_document(**req_copy)
+
+    def test_analyze_document_value_error_with_retries(self):
+        # Enable retries and run test_analyze_document_value_error.
+        _service.enable_retries()
+        self.test_analyze_document_value_error()
+
+        # Disable retries and run test_analyze_document_value_error.
+        _service.disable_retries()
+        self.test_analyze_document_value_error()
+
+# endregion
+##############################################################################
+# End of Service: Analyze
 ##############################################################################
 
 ##############################################################################
@@ -3123,24 +5178,13 @@ class TestDeleteUserData():
     Test Class for delete_user_data
     """
 
-    def preprocess_url(self, request_url: str):
-        """
-        Preprocess the request URL to ensure the mock response will be found.
-        """
-        request_url = urllib.parse.unquote(request_url) # don't double-encode if already encoded
-        request_url = urllib.parse.quote(request_url, safe=':/')
-        if re.fullmatch('.*/+', request_url) is None:
-            return request_url
-        else:
-            return re.compile(request_url.rstrip('/') + '/+')
-
     @responses.activate
     def test_delete_user_data_all_params(self):
         """
         delete_user_data()
         """
         # Set up mock
-        url = self.preprocess_url(_base_url + '/v2/user_data')
+        url = preprocess_url('/v2/user_data')
         responses.add(responses.DELETE,
                       url,
                       status=200)
@@ -3162,6 +5206,14 @@ class TestDeleteUserData():
         query_string = urllib.parse.unquote_plus(query_string)
         assert 'customer_id={}'.format(customer_id) in query_string
 
+    def test_delete_user_data_all_params_with_retries(self):
+        # Enable retries and run test_delete_user_data_all_params.
+        _service.enable_retries()
+        self.test_delete_user_data_all_params()
+
+        # Disable retries and run test_delete_user_data_all_params.
+        _service.disable_retries()
+        self.test_delete_user_data_all_params()
 
     @responses.activate
     def test_delete_user_data_value_error(self):
@@ -3169,7 +5221,7 @@ class TestDeleteUserData():
         test_delete_user_data_value_error()
         """
         # Set up mock
-        url = self.preprocess_url(_base_url + '/v2/user_data')
+        url = preprocess_url('/v2/user_data')
         responses.add(responses.DELETE,
                       url,
                       status=200)
@@ -3186,7 +5238,14 @@ class TestDeleteUserData():
             with pytest.raises(ValueError):
                 _service.delete_user_data(**req_copy)
 
+    def test_delete_user_data_value_error_with_retries(self):
+        # Enable retries and run test_delete_user_data_value_error.
+        _service.enable_retries()
+        self.test_delete_user_data_value_error()
 
+        # Disable retries and run test_delete_user_data_value_error.
+        _service.disable_retries()
+        self.test_delete_user_data_value_error()
 
 # endregion
 ##############################################################################
@@ -3212,7 +5271,7 @@ class TestModel_AnalyzedDocument():
 
         notice_model = {} # Notice
         notice_model['notice_id'] = 'testString'
-        notice_model['created'] = "2019-01-01T12:00:00Z"
+        notice_model['created'] = '2019-01-01T12:00:00Z'
         notice_model['document_id'] = 'testString'
         notice_model['collection_id'] = 'testString'
         notice_model['query_id'] = 'testString'
@@ -3221,8 +5280,8 @@ class TestModel_AnalyzedDocument():
         notice_model['description'] = 'testString'
 
         analyzed_result_model = {} # AnalyzedResult
-        analyzed_result_model['metadata'] = {}
-        analyzed_result_model['foo'] = { 'foo': 'bar' }
+        analyzed_result_model['metadata'] = {'key1': 'testString'}
+        analyzed_result_model['foo'] = {'foo': 'bar'}
 
         # Construct a json representation of a AnalyzedDocument model
         analyzed_document_model_json = {}
@@ -3256,8 +5315,8 @@ class TestModel_AnalyzedResult():
 
         # Construct a json representation of a AnalyzedResult model
         analyzed_result_model_json = {}
-        analyzed_result_model_json['metadata'] = {}
-        analyzed_result_model_json['foo'] = { 'foo': 'bar' }
+        analyzed_result_model_json['metadata'] = {'key1': 'testString'}
+        analyzed_result_model_json['foo'] = {'foo': 'bar'}
 
         # Construct a model instance of AnalyzedResult by calling from_dict on the json representation
         analyzed_result_model = AnalyzedResult.from_dict(analyzed_result_model_json)
@@ -3279,10 +5338,88 @@ class TestModel_AnalyzedResult():
         actual_dict = analyzed_result_model.get_properties()
         assert actual_dict == {}
 
-        expected_dict = {'foo': { 'foo': 'bar' }}
+        expected_dict = {'foo': {'foo': 'bar'}}
         analyzed_result_model.set_properties(expected_dict)
         actual_dict = analyzed_result_model.get_properties()
         assert actual_dict == expected_dict
+
+class TestModel_ClassifierFederatedModel():
+    """
+    Test Class for ClassifierFederatedModel
+    """
+
+    def test_classifier_federated_model_serialization(self):
+        """
+        Test serialization/deserialization for ClassifierFederatedModel
+        """
+
+        # Construct a json representation of a ClassifierFederatedModel model
+        classifier_federated_model_model_json = {}
+        classifier_federated_model_model_json['field'] = 'testString'
+
+        # Construct a model instance of ClassifierFederatedModel by calling from_dict on the json representation
+        classifier_federated_model_model = ClassifierFederatedModel.from_dict(classifier_federated_model_model_json)
+        assert classifier_federated_model_model != False
+
+        # Construct a model instance of ClassifierFederatedModel by calling from_dict on the json representation
+        classifier_federated_model_model_dict = ClassifierFederatedModel.from_dict(classifier_federated_model_model_json).__dict__
+        classifier_federated_model_model2 = ClassifierFederatedModel(**classifier_federated_model_model_dict)
+
+        # Verify the model instances are equivalent
+        assert classifier_federated_model_model == classifier_federated_model_model2
+
+        # Convert model instance back to dict and verify no loss of data
+        classifier_federated_model_model_json2 = classifier_federated_model_model.to_dict()
+        assert classifier_federated_model_model_json2 == classifier_federated_model_model_json
+
+class TestModel_ClassifierModelEvaluation():
+    """
+    Test Class for ClassifierModelEvaluation
+    """
+
+    def test_classifier_model_evaluation_serialization(self):
+        """
+        Test serialization/deserialization for ClassifierModelEvaluation
+        """
+
+        # Construct dict forms of any model objects needed in order to build this model.
+
+        model_evaluation_micro_average_model = {} # ModelEvaluationMicroAverage
+        model_evaluation_micro_average_model['precision'] = 0
+        model_evaluation_micro_average_model['recall'] = 0
+        model_evaluation_micro_average_model['f1'] = 0
+
+        model_evaluation_macro_average_model = {} # ModelEvaluationMacroAverage
+        model_evaluation_macro_average_model['precision'] = 0
+        model_evaluation_macro_average_model['recall'] = 0
+        model_evaluation_macro_average_model['f1'] = 0
+
+        per_class_model_evaluation_model = {} # PerClassModelEvaluation
+        per_class_model_evaluation_model['name'] = 'testString'
+        per_class_model_evaluation_model['precision'] = 0
+        per_class_model_evaluation_model['recall'] = 0
+        per_class_model_evaluation_model['f1'] = 0
+
+        # Construct a json representation of a ClassifierModelEvaluation model
+        classifier_model_evaluation_model_json = {}
+        classifier_model_evaluation_model_json['micro_average'] = model_evaluation_micro_average_model
+        classifier_model_evaluation_model_json['macro_average'] = model_evaluation_macro_average_model
+        classifier_model_evaluation_model_json['per_class'] = [per_class_model_evaluation_model]
+
+        # Construct a model instance of ClassifierModelEvaluation by calling from_dict on the json representation
+        classifier_model_evaluation_model = ClassifierModelEvaluation.from_dict(classifier_model_evaluation_model_json)
+        assert classifier_model_evaluation_model != False
+
+        # Construct a model instance of ClassifierModelEvaluation by calling from_dict on the json representation
+        classifier_model_evaluation_model_dict = ClassifierModelEvaluation.from_dict(classifier_model_evaluation_model_json).__dict__
+        classifier_model_evaluation_model2 = ClassifierModelEvaluation(**classifier_model_evaluation_model_dict)
+
+        # Verify the model instances are equivalent
+        assert classifier_model_evaluation_model == classifier_model_evaluation_model2
+
+        # Convert model instance back to dict and verify no loss of data
+        classifier_model_evaluation_model_json2 = classifier_model_evaluation_model.to_dict()
+        assert classifier_model_evaluation_model_json2 == classifier_model_evaluation_model_json
 
 class TestModel_Collection():
     """
@@ -3330,14 +5467,19 @@ class TestModel_CollectionDetails():
         collection_enrichment_model['enrichment_id'] = 'testString'
         collection_enrichment_model['fields'] = ['testString']
 
+        collection_details_smart_document_understanding_model = {} # CollectionDetailsSmartDocumentUnderstanding
+        collection_details_smart_document_understanding_model['enabled'] = True
+        collection_details_smart_document_understanding_model['model'] = 'custom'
+
         # Construct a json representation of a CollectionDetails model
         collection_details_model_json = {}
         collection_details_model_json['collection_id'] = 'testString'
         collection_details_model_json['name'] = 'testString'
         collection_details_model_json['description'] = 'testString'
-        collection_details_model_json['created'] = "2019-01-01T12:00:00Z"
+        collection_details_model_json['created'] = '2019-01-01T12:00:00Z'
         collection_details_model_json['language'] = 'en'
         collection_details_model_json['enrichments'] = [collection_enrichment_model]
+        collection_details_model_json['smart_document_understanding'] = collection_details_smart_document_understanding_model
 
         # Construct a model instance of CollectionDetails by calling from_dict on the json representation
         collection_details_model = CollectionDetails.from_dict(collection_details_model_json)
@@ -3353,6 +5495,36 @@ class TestModel_CollectionDetails():
         # Convert model instance back to dict and verify no loss of data
         collection_details_model_json2 = collection_details_model.to_dict()
         assert collection_details_model_json2 == collection_details_model_json
+
+class TestModel_CollectionDetailsSmartDocumentUnderstanding():
+    """
+    Test Class for CollectionDetailsSmartDocumentUnderstanding
+    """
+
+    def test_collection_details_smart_document_understanding_serialization(self):
+        """
+        Test serialization/deserialization for CollectionDetailsSmartDocumentUnderstanding
+        """
+
+        # Construct a json representation of a CollectionDetailsSmartDocumentUnderstanding model
+        collection_details_smart_document_understanding_model_json = {}
+        collection_details_smart_document_understanding_model_json['enabled'] = True
+        collection_details_smart_document_understanding_model_json['model'] = 'custom'
+
+        # Construct a model instance of CollectionDetailsSmartDocumentUnderstanding by calling from_dict on the json representation
+        collection_details_smart_document_understanding_model = CollectionDetailsSmartDocumentUnderstanding.from_dict(collection_details_smart_document_understanding_model_json)
+        assert collection_details_smart_document_understanding_model != False
+
+        # Construct a model instance of CollectionDetailsSmartDocumentUnderstanding by calling from_dict on the json representation
+        collection_details_smart_document_understanding_model_dict = CollectionDetailsSmartDocumentUnderstanding.from_dict(collection_details_smart_document_understanding_model_json).__dict__
+        collection_details_smart_document_understanding_model2 = CollectionDetailsSmartDocumentUnderstanding(**collection_details_smart_document_understanding_model_dict)
+
+        # Verify the model instances are equivalent
+        assert collection_details_smart_document_understanding_model == collection_details_smart_document_understanding_model2
+
+        # Convert model instance back to dict and verify no loss of data
+        collection_details_smart_document_understanding_model_json2 = collection_details_smart_document_understanding_model.to_dict()
+        assert collection_details_smart_document_understanding_model_json2 == collection_details_smart_document_understanding_model_json
 
 class TestModel_CollectionEnrichment():
     """
@@ -3595,6 +5767,49 @@ class TestModel_ComponentSettingsResponse():
         component_settings_response_model_json2 = component_settings_response_model.to_dict()
         assert component_settings_response_model_json2 == component_settings_response_model_json
 
+class TestModel_CreateDocumentClassifier():
+    """
+    Test Class for CreateDocumentClassifier
+    """
+
+    def test_create_document_classifier_serialization(self):
+        """
+        Test serialization/deserialization for CreateDocumentClassifier
+        """
+
+        # Construct dict forms of any model objects needed in order to build this model.
+
+        document_classifier_enrichment_model = {} # DocumentClassifierEnrichment
+        document_classifier_enrichment_model['enrichment_id'] = 'testString'
+        document_classifier_enrichment_model['fields'] = ['testString']
+
+        classifier_federated_model_model = {} # ClassifierFederatedModel
+        classifier_federated_model_model['field'] = 'testString'
+
+        # Construct a json representation of a CreateDocumentClassifier model
+        create_document_classifier_model_json = {}
+        create_document_classifier_model_json['name'] = 'testString'
+        create_document_classifier_model_json['description'] = 'testString'
+        create_document_classifier_model_json['language'] = 'en'
+        create_document_classifier_model_json['answer_field'] = 'testString'
+        create_document_classifier_model_json['enrichments'] = [document_classifier_enrichment_model]
+        create_document_classifier_model_json['federated_classification'] = classifier_federated_model_model
+
+        # Construct a model instance of CreateDocumentClassifier by calling from_dict on the json representation
+        create_document_classifier_model = CreateDocumentClassifier.from_dict(create_document_classifier_model_json)
+        assert create_document_classifier_model != False
+
+        # Construct a model instance of CreateDocumentClassifier by calling from_dict on the json representation
+        create_document_classifier_model_dict = CreateDocumentClassifier.from_dict(create_document_classifier_model_json).__dict__
+        create_document_classifier_model2 = CreateDocumentClassifier(**create_document_classifier_model_dict)
+
+        # Verify the model instances are equivalent
+        assert create_document_classifier_model == create_document_classifier_model2
+
+        # Convert model instance back to dict and verify no loss of data
+        create_document_classifier_model_json2 = create_document_classifier_model.to_dict()
+        assert create_document_classifier_model_json2 == create_document_classifier_model_json
+
 class TestModel_CreateEnrichment():
     """
     Test Class for CreateEnrichment
@@ -3612,12 +5827,16 @@ class TestModel_CreateEnrichment():
         enrichment_options_model['entity_type'] = 'testString'
         enrichment_options_model['regular_expression'] = 'testString'
         enrichment_options_model['result_field'] = 'testString'
+        enrichment_options_model['classifier_id'] = 'testString'
+        enrichment_options_model['model_id'] = 'testString'
+        enrichment_options_model['confidence_threshold'] = 0
+        enrichment_options_model['top_k'] = 38
 
         # Construct a json representation of a CreateEnrichment model
         create_enrichment_model_json = {}
         create_enrichment_model_json['name'] = 'testString'
         create_enrichment_model_json['description'] = 'testString'
-        create_enrichment_model_json['type'] = 'dictionary'
+        create_enrichment_model_json['type'] = 'classifier'
         create_enrichment_model_json['options'] = enrichment_options_model
 
         # Construct a model instance of CreateEnrichment by calling from_dict on the json representation
@@ -3884,6 +6103,345 @@ class TestModel_DocumentAttribute():
         document_attribute_model_json2 = document_attribute_model.to_dict()
         assert document_attribute_model_json2 == document_attribute_model_json
 
+class TestModel_DocumentClassifier():
+    """
+    Test Class for DocumentClassifier
+    """
+
+    def test_document_classifier_serialization(self):
+        """
+        Test serialization/deserialization for DocumentClassifier
+        """
+
+        # Construct dict forms of any model objects needed in order to build this model.
+
+        document_classifier_enrichment_model = {} # DocumentClassifierEnrichment
+        document_classifier_enrichment_model['enrichment_id'] = 'testString'
+        document_classifier_enrichment_model['fields'] = ['testString']
+
+        classifier_federated_model_model = {} # ClassifierFederatedModel
+        classifier_federated_model_model['field'] = 'testString'
+
+        # Construct a json representation of a DocumentClassifier model
+        document_classifier_model_json = {}
+        document_classifier_model_json['classifier_id'] = 'testString'
+        document_classifier_model_json['name'] = 'testString'
+        document_classifier_model_json['description'] = 'testString'
+        document_classifier_model_json['created'] = '2019-01-01T12:00:00Z'
+        document_classifier_model_json['language'] = 'en'
+        document_classifier_model_json['enrichments'] = [document_classifier_enrichment_model]
+        document_classifier_model_json['recognized_fields'] = ['testString']
+        document_classifier_model_json['answer_field'] = 'testString'
+        document_classifier_model_json['training_data_file'] = 'testString'
+        document_classifier_model_json['test_data_file'] = 'testString'
+        document_classifier_model_json['federated_classification'] = classifier_federated_model_model
+
+        # Construct a model instance of DocumentClassifier by calling from_dict on the json representation
+        document_classifier_model = DocumentClassifier.from_dict(document_classifier_model_json)
+        assert document_classifier_model != False
+
+        # Construct a model instance of DocumentClassifier by calling from_dict on the json representation
+        document_classifier_model_dict = DocumentClassifier.from_dict(document_classifier_model_json).__dict__
+        document_classifier_model2 = DocumentClassifier(**document_classifier_model_dict)
+
+        # Verify the model instances are equivalent
+        assert document_classifier_model == document_classifier_model2
+
+        # Convert model instance back to dict and verify no loss of data
+        document_classifier_model_json2 = document_classifier_model.to_dict()
+        assert document_classifier_model_json2 == document_classifier_model_json
+
+class TestModel_DocumentClassifierEnrichment():
+    """
+    Test Class for DocumentClassifierEnrichment
+    """
+
+    def test_document_classifier_enrichment_serialization(self):
+        """
+        Test serialization/deserialization for DocumentClassifierEnrichment
+        """
+
+        # Construct a json representation of a DocumentClassifierEnrichment model
+        document_classifier_enrichment_model_json = {}
+        document_classifier_enrichment_model_json['enrichment_id'] = 'testString'
+        document_classifier_enrichment_model_json['fields'] = ['testString']
+
+        # Construct a model instance of DocumentClassifierEnrichment by calling from_dict on the json representation
+        document_classifier_enrichment_model = DocumentClassifierEnrichment.from_dict(document_classifier_enrichment_model_json)
+        assert document_classifier_enrichment_model != False
+
+        # Construct a model instance of DocumentClassifierEnrichment by calling from_dict on the json representation
+        document_classifier_enrichment_model_dict = DocumentClassifierEnrichment.from_dict(document_classifier_enrichment_model_json).__dict__
+        document_classifier_enrichment_model2 = DocumentClassifierEnrichment(**document_classifier_enrichment_model_dict)
+
+        # Verify the model instances are equivalent
+        assert document_classifier_enrichment_model == document_classifier_enrichment_model2
+
+        # Convert model instance back to dict and verify no loss of data
+        document_classifier_enrichment_model_json2 = document_classifier_enrichment_model.to_dict()
+        assert document_classifier_enrichment_model_json2 == document_classifier_enrichment_model_json
+
+class TestModel_DocumentClassifierModel():
+    """
+    Test Class for DocumentClassifierModel
+    """
+
+    def test_document_classifier_model_serialization(self):
+        """
+        Test serialization/deserialization for DocumentClassifierModel
+        """
+
+        # Construct dict forms of any model objects needed in order to build this model.
+
+        model_evaluation_micro_average_model = {} # ModelEvaluationMicroAverage
+        model_evaluation_micro_average_model['precision'] = 0
+        model_evaluation_micro_average_model['recall'] = 0
+        model_evaluation_micro_average_model['f1'] = 0
+
+        model_evaluation_macro_average_model = {} # ModelEvaluationMacroAverage
+        model_evaluation_macro_average_model['precision'] = 0
+        model_evaluation_macro_average_model['recall'] = 0
+        model_evaluation_macro_average_model['f1'] = 0
+
+        per_class_model_evaluation_model = {} # PerClassModelEvaluation
+        per_class_model_evaluation_model['name'] = 'testString'
+        per_class_model_evaluation_model['precision'] = 0
+        per_class_model_evaluation_model['recall'] = 0
+        per_class_model_evaluation_model['f1'] = 0
+
+        classifier_model_evaluation_model = {} # ClassifierModelEvaluation
+        classifier_model_evaluation_model['micro_average'] = model_evaluation_micro_average_model
+        classifier_model_evaluation_model['macro_average'] = model_evaluation_macro_average_model
+        classifier_model_evaluation_model['per_class'] = [per_class_model_evaluation_model]
+
+        # Construct a json representation of a DocumentClassifierModel model
+        document_classifier_model_model_json = {}
+        document_classifier_model_model_json['model_id'] = 'testString'
+        document_classifier_model_model_json['name'] = 'testString'
+        document_classifier_model_model_json['description'] = 'testString'
+        document_classifier_model_model_json['created'] = '2019-01-01T12:00:00Z'
+        document_classifier_model_model_json['updated'] = '2019-01-01T12:00:00Z'
+        document_classifier_model_model_json['training_data_file'] = 'testString'
+        document_classifier_model_model_json['test_data_file'] = 'testString'
+        document_classifier_model_model_json['status'] = 'training'
+        document_classifier_model_model_json['evaluation'] = classifier_model_evaluation_model
+        document_classifier_model_model_json['enrichment_id'] = 'testString'
+        document_classifier_model_model_json['deployed_at'] = '2019-01-01T12:00:00Z'
+
+        # Construct a model instance of DocumentClassifierModel by calling from_dict on the json representation
+        document_classifier_model_model = DocumentClassifierModel.from_dict(document_classifier_model_model_json)
+        assert document_classifier_model_model != False
+
+        # Construct a model instance of DocumentClassifierModel by calling from_dict on the json representation
+        document_classifier_model_model_dict = DocumentClassifierModel.from_dict(document_classifier_model_model_json).__dict__
+        document_classifier_model_model2 = DocumentClassifierModel(**document_classifier_model_model_dict)
+
+        # Verify the model instances are equivalent
+        assert document_classifier_model_model == document_classifier_model_model2
+
+        # Convert model instance back to dict and verify no loss of data
+        document_classifier_model_model_json2 = document_classifier_model_model.to_dict()
+        assert document_classifier_model_model_json2 == document_classifier_model_model_json
+
+class TestModel_DocumentClassifierModels():
+    """
+    Test Class for DocumentClassifierModels
+    """
+
+    def test_document_classifier_models_serialization(self):
+        """
+        Test serialization/deserialization for DocumentClassifierModels
+        """
+
+        # Construct dict forms of any model objects needed in order to build this model.
+
+        model_evaluation_micro_average_model = {} # ModelEvaluationMicroAverage
+        model_evaluation_micro_average_model['precision'] = 0
+        model_evaluation_micro_average_model['recall'] = 0
+        model_evaluation_micro_average_model['f1'] = 0
+
+        model_evaluation_macro_average_model = {} # ModelEvaluationMacroAverage
+        model_evaluation_macro_average_model['precision'] = 0
+        model_evaluation_macro_average_model['recall'] = 0
+        model_evaluation_macro_average_model['f1'] = 0
+
+        per_class_model_evaluation_model = {} # PerClassModelEvaluation
+        per_class_model_evaluation_model['name'] = 'testString'
+        per_class_model_evaluation_model['precision'] = 0
+        per_class_model_evaluation_model['recall'] = 0
+        per_class_model_evaluation_model['f1'] = 0
+
+        classifier_model_evaluation_model = {} # ClassifierModelEvaluation
+        classifier_model_evaluation_model['micro_average'] = model_evaluation_micro_average_model
+        classifier_model_evaluation_model['macro_average'] = model_evaluation_macro_average_model
+        classifier_model_evaluation_model['per_class'] = [per_class_model_evaluation_model]
+
+        document_classifier_model_model = {} # DocumentClassifierModel
+        document_classifier_model_model['model_id'] = 'testString'
+        document_classifier_model_model['name'] = 'testString'
+        document_classifier_model_model['description'] = 'testString'
+        document_classifier_model_model['created'] = '2019-01-01T12:00:00Z'
+        document_classifier_model_model['updated'] = '2019-01-01T12:00:00Z'
+        document_classifier_model_model['training_data_file'] = 'testString'
+        document_classifier_model_model['test_data_file'] = 'testString'
+        document_classifier_model_model['status'] = 'training'
+        document_classifier_model_model['evaluation'] = classifier_model_evaluation_model
+        document_classifier_model_model['enrichment_id'] = 'testString'
+        document_classifier_model_model['deployed_at'] = '2019-01-01T12:00:00Z'
+
+        # Construct a json representation of a DocumentClassifierModels model
+        document_classifier_models_model_json = {}
+        document_classifier_models_model_json['models'] = [document_classifier_model_model]
+
+        # Construct a model instance of DocumentClassifierModels by calling from_dict on the json representation
+        document_classifier_models_model = DocumentClassifierModels.from_dict(document_classifier_models_model_json)
+        assert document_classifier_models_model != False
+
+        # Construct a model instance of DocumentClassifierModels by calling from_dict on the json representation
+        document_classifier_models_model_dict = DocumentClassifierModels.from_dict(document_classifier_models_model_json).__dict__
+        document_classifier_models_model2 = DocumentClassifierModels(**document_classifier_models_model_dict)
+
+        # Verify the model instances are equivalent
+        assert document_classifier_models_model == document_classifier_models_model2
+
+        # Convert model instance back to dict and verify no loss of data
+        document_classifier_models_model_json2 = document_classifier_models_model.to_dict()
+        assert document_classifier_models_model_json2 == document_classifier_models_model_json
+
+class TestModel_DocumentClassifiers():
+    """
+    Test Class for DocumentClassifiers
+    """
+
+    def test_document_classifiers_serialization(self):
+        """
+        Test serialization/deserialization for DocumentClassifiers
+        """
+
+        # Construct dict forms of any model objects needed in order to build this model.
+
+        document_classifier_enrichment_model = {} # DocumentClassifierEnrichment
+        document_classifier_enrichment_model['enrichment_id'] = 'testString'
+        document_classifier_enrichment_model['fields'] = ['testString']
+
+        classifier_federated_model_model = {} # ClassifierFederatedModel
+        classifier_federated_model_model['field'] = 'testString'
+
+        document_classifier_model = {} # DocumentClassifier
+        document_classifier_model['classifier_id'] = 'testString'
+        document_classifier_model['name'] = 'testString'
+        document_classifier_model['description'] = 'testString'
+        document_classifier_model['created'] = '2019-01-01T12:00:00Z'
+        document_classifier_model['language'] = 'en'
+        document_classifier_model['enrichments'] = [document_classifier_enrichment_model]
+        document_classifier_model['recognized_fields'] = ['testString']
+        document_classifier_model['answer_field'] = 'testString'
+        document_classifier_model['training_data_file'] = 'testString'
+        document_classifier_model['test_data_file'] = 'testString'
+        document_classifier_model['federated_classification'] = classifier_federated_model_model
+
+        # Construct a json representation of a DocumentClassifiers model
+        document_classifiers_model_json = {}
+        document_classifiers_model_json['classifiers'] = [document_classifier_model]
+
+        # Construct a model instance of DocumentClassifiers by calling from_dict on the json representation
+        document_classifiers_model = DocumentClassifiers.from_dict(document_classifiers_model_json)
+        assert document_classifiers_model != False
+
+        # Construct a model instance of DocumentClassifiers by calling from_dict on the json representation
+        document_classifiers_model_dict = DocumentClassifiers.from_dict(document_classifiers_model_json).__dict__
+        document_classifiers_model2 = DocumentClassifiers(**document_classifiers_model_dict)
+
+        # Verify the model instances are equivalent
+        assert document_classifiers_model == document_classifiers_model2
+
+        # Convert model instance back to dict and verify no loss of data
+        document_classifiers_model_json2 = document_classifiers_model.to_dict()
+        assert document_classifiers_model_json2 == document_classifiers_model_json
+
+class TestModel_DocumentDetails():
+    """
+    Test Class for DocumentDetails
+    """
+
+    def test_document_details_serialization(self):
+        """
+        Test serialization/deserialization for DocumentDetails
+        """
+
+        # Construct dict forms of any model objects needed in order to build this model.
+
+        notice_model = {} # Notice
+        notice_model['notice_id'] = 'testString'
+        notice_model['created'] = '2019-01-01T12:00:00Z'
+        notice_model['document_id'] = 'testString'
+        notice_model['collection_id'] = 'testString'
+        notice_model['query_id'] = 'testString'
+        notice_model['severity'] = 'warning'
+        notice_model['step'] = 'testString'
+        notice_model['description'] = 'testString'
+
+        document_details_children_model = {} # DocumentDetailsChildren
+        document_details_children_model['have_notices'] = True
+        document_details_children_model['count'] = 38
+
+        # Construct a json representation of a DocumentDetails model
+        document_details_model_json = {}
+        document_details_model_json['document_id'] = 'testString'
+        document_details_model_json['created'] = '2019-01-01T12:00:00Z'
+        document_details_model_json['updated'] = '2019-01-01T12:00:00Z'
+        document_details_model_json['status'] = 'available'
+        document_details_model_json['notices'] = [notice_model]
+        document_details_model_json['children'] = document_details_children_model
+        document_details_model_json['filename'] = 'testString'
+        document_details_model_json['file_type'] = 'testString'
+        document_details_model_json['sha256'] = 'testString'
+
+        # Construct a model instance of DocumentDetails by calling from_dict on the json representation
+        document_details_model = DocumentDetails.from_dict(document_details_model_json)
+        assert document_details_model != False
+
+        # Construct a model instance of DocumentDetails by calling from_dict on the json representation
+        document_details_model_dict = DocumentDetails.from_dict(document_details_model_json).__dict__
+        document_details_model2 = DocumentDetails(**document_details_model_dict)
+
+        # Verify the model instances are equivalent
+        assert document_details_model == document_details_model2
+
+        # Convert model instance back to dict and verify no loss of data
+        document_details_model_json2 = document_details_model.to_dict()
+        assert document_details_model_json2 == document_details_model_json
+
+class TestModel_DocumentDetailsChildren():
+    """
+    Test Class for DocumentDetailsChildren
+    """
+
+    def test_document_details_children_serialization(self):
+        """
+        Test serialization/deserialization for DocumentDetailsChildren
+        """
+
+        # Construct a json representation of a DocumentDetailsChildren model
+        document_details_children_model_json = {}
+        document_details_children_model_json['have_notices'] = True
+        document_details_children_model_json['count'] = 38
+
+        # Construct a model instance of DocumentDetailsChildren by calling from_dict on the json representation
+        document_details_children_model = DocumentDetailsChildren.from_dict(document_details_children_model_json)
+        assert document_details_children_model != False
+
+        # Construct a model instance of DocumentDetailsChildren by calling from_dict on the json representation
+        document_details_children_model_dict = DocumentDetailsChildren.from_dict(document_details_children_model_json).__dict__
+        document_details_children_model2 = DocumentDetailsChildren(**document_details_children_model_dict)
+
+        # Verify the model instances are equivalent
+        assert document_details_children_model == document_details_children_model2
+
+        # Convert model instance back to dict and verify no loss of data
+        document_details_children_model_json2 = document_details_children_model.to_dict()
+        assert document_details_children_model_json2 == document_details_children_model_json
+
 class TestModel_Enrichment():
     """
     Test Class for Enrichment
@@ -3901,6 +6459,10 @@ class TestModel_Enrichment():
         enrichment_options_model['entity_type'] = 'testString'
         enrichment_options_model['regular_expression'] = 'testString'
         enrichment_options_model['result_field'] = 'testString'
+        enrichment_options_model['classifier_id'] = 'testString'
+        enrichment_options_model['model_id'] = 'testString'
+        enrichment_options_model['confidence_threshold'] = 0
+        enrichment_options_model['top_k'] = 38
 
         # Construct a json representation of a Enrichment model
         enrichment_model_json = {}
@@ -3941,6 +6503,10 @@ class TestModel_EnrichmentOptions():
         enrichment_options_model_json['entity_type'] = 'testString'
         enrichment_options_model_json['regular_expression'] = 'testString'
         enrichment_options_model_json['result_field'] = 'testString'
+        enrichment_options_model_json['classifier_id'] = 'testString'
+        enrichment_options_model_json['model_id'] = 'testString'
+        enrichment_options_model_json['confidence_threshold'] = 0
+        enrichment_options_model_json['top_k'] = 38
 
         # Construct a model instance of EnrichmentOptions by calling from_dict on the json representation
         enrichment_options_model = EnrichmentOptions.from_dict(enrichment_options_model_json)
@@ -3974,6 +6540,10 @@ class TestModel_Enrichments():
         enrichment_options_model['entity_type'] = 'testString'
         enrichment_options_model['regular_expression'] = 'testString'
         enrichment_options_model['result_field'] = 'testString'
+        enrichment_options_model['classifier_id'] = 'testString'
+        enrichment_options_model['model_id'] = 'testString'
+        enrichment_options_model['confidence_threshold'] = 0
+        enrichment_options_model['top_k'] = 38
 
         enrichment_model = {} # Enrichment
         enrichment_model['enrichment_id'] = 'testString'
@@ -4000,6 +6570,71 @@ class TestModel_Enrichments():
         # Convert model instance back to dict and verify no loss of data
         enrichments_model_json2 = enrichments_model.to_dict()
         assert enrichments_model_json2 == enrichments_model_json
+
+class TestModel_Expansion():
+    """
+    Test Class for Expansion
+    """
+
+    def test_expansion_serialization(self):
+        """
+        Test serialization/deserialization for Expansion
+        """
+
+        # Construct a json representation of a Expansion model
+        expansion_model_json = {}
+        expansion_model_json['input_terms'] = ['testString']
+        expansion_model_json['expanded_terms'] = ['testString']
+
+        # Construct a model instance of Expansion by calling from_dict on the json representation
+        expansion_model = Expansion.from_dict(expansion_model_json)
+        assert expansion_model != False
+
+        # Construct a model instance of Expansion by calling from_dict on the json representation
+        expansion_model_dict = Expansion.from_dict(expansion_model_json).__dict__
+        expansion_model2 = Expansion(**expansion_model_dict)
+
+        # Verify the model instances are equivalent
+        assert expansion_model == expansion_model2
+
+        # Convert model instance back to dict and verify no loss of data
+        expansion_model_json2 = expansion_model.to_dict()
+        assert expansion_model_json2 == expansion_model_json
+
+class TestModel_Expansions():
+    """
+    Test Class for Expansions
+    """
+
+    def test_expansions_serialization(self):
+        """
+        Test serialization/deserialization for Expansions
+        """
+
+        # Construct dict forms of any model objects needed in order to build this model.
+
+        expansion_model = {} # Expansion
+        expansion_model['input_terms'] = ['testString']
+        expansion_model['expanded_terms'] = ['testString']
+
+        # Construct a json representation of a Expansions model
+        expansions_model_json = {}
+        expansions_model_json['expansions'] = [expansion_model]
+
+        # Construct a model instance of Expansions by calling from_dict on the json representation
+        expansions_model = Expansions.from_dict(expansions_model_json)
+        assert expansions_model != False
+
+        # Construct a model instance of Expansions by calling from_dict on the json representation
+        expansions_model_dict = Expansions.from_dict(expansions_model_json).__dict__
+        expansions_model2 = Expansions(**expansions_model_dict)
+
+        # Verify the model instances are equivalent
+        assert expansions_model == expansions_model2
+
+        # Convert model instance back to dict and verify no loss of data
+        expansions_model_json2 = expansions_model.to_dict()
+        assert expansions_model_json2 == expansions_model_json
 
 class TestModel_Field():
     """
@@ -4066,6 +6701,63 @@ class TestModel_ListCollectionsResponse():
         # Convert model instance back to dict and verify no loss of data
         list_collections_response_model_json2 = list_collections_response_model.to_dict()
         assert list_collections_response_model_json2 == list_collections_response_model_json
+
+class TestModel_ListDocumentsResponse():
+    """
+    Test Class for ListDocumentsResponse
+    """
+
+    def test_list_documents_response_serialization(self):
+        """
+        Test serialization/deserialization for ListDocumentsResponse
+        """
+
+        # Construct dict forms of any model objects needed in order to build this model.
+
+        notice_model = {} # Notice
+        notice_model['notice_id'] = 'testString'
+        notice_model['created'] = '2019-01-01T12:00:00Z'
+        notice_model['document_id'] = 'testString'
+        notice_model['collection_id'] = 'testString'
+        notice_model['query_id'] = 'testString'
+        notice_model['severity'] = 'warning'
+        notice_model['step'] = 'testString'
+        notice_model['description'] = 'testString'
+
+        document_details_children_model = {} # DocumentDetailsChildren
+        document_details_children_model['have_notices'] = True
+        document_details_children_model['count'] = 38
+
+        document_details_model = {} # DocumentDetails
+        document_details_model['document_id'] = '4ffcfd8052005b99469e632506763bac_0'
+        document_details_model['created'] = '2019-01-01T12:00:00Z'
+        document_details_model['updated'] = '2019-01-01T12:00:00Z'
+        document_details_model['status'] = 'available'
+        document_details_model['notices'] = [notice_model]
+        document_details_model['children'] = document_details_children_model
+        document_details_model['filename'] = 'testString'
+        document_details_model['file_type'] = 'testString'
+        document_details_model['sha256'] = 'testString'
+
+        # Construct a json representation of a ListDocumentsResponse model
+        list_documents_response_model_json = {}
+        list_documents_response_model_json['matching_results'] = 38
+        list_documents_response_model_json['documents'] = [document_details_model]
+
+        # Construct a model instance of ListDocumentsResponse by calling from_dict on the json representation
+        list_documents_response_model = ListDocumentsResponse.from_dict(list_documents_response_model_json)
+        assert list_documents_response_model != False
+
+        # Construct a model instance of ListDocumentsResponse by calling from_dict on the json representation
+        list_documents_response_model_dict = ListDocumentsResponse.from_dict(list_documents_response_model_json).__dict__
+        list_documents_response_model2 = ListDocumentsResponse(**list_documents_response_model_dict)
+
+        # Verify the model instances are equivalent
+        assert list_documents_response_model == list_documents_response_model2
+
+        # Convert model instance back to dict and verify no loss of data
+        list_documents_response_model_json2 = list_documents_response_model.to_dict()
+        assert list_documents_response_model_json2 == list_documents_response_model_json
 
 class TestModel_ListFieldsResponse():
     """
@@ -4152,6 +6844,68 @@ class TestModel_ListProjectsResponse():
         list_projects_response_model_json2 = list_projects_response_model.to_dict()
         assert list_projects_response_model_json2 == list_projects_response_model_json
 
+class TestModel_ModelEvaluationMacroAverage():
+    """
+    Test Class for ModelEvaluationMacroAverage
+    """
+
+    def test_model_evaluation_macro_average_serialization(self):
+        """
+        Test serialization/deserialization for ModelEvaluationMacroAverage
+        """
+
+        # Construct a json representation of a ModelEvaluationMacroAverage model
+        model_evaluation_macro_average_model_json = {}
+        model_evaluation_macro_average_model_json['precision'] = 0
+        model_evaluation_macro_average_model_json['recall'] = 0
+        model_evaluation_macro_average_model_json['f1'] = 0
+
+        # Construct a model instance of ModelEvaluationMacroAverage by calling from_dict on the json representation
+        model_evaluation_macro_average_model = ModelEvaluationMacroAverage.from_dict(model_evaluation_macro_average_model_json)
+        assert model_evaluation_macro_average_model != False
+
+        # Construct a model instance of ModelEvaluationMacroAverage by calling from_dict on the json representation
+        model_evaluation_macro_average_model_dict = ModelEvaluationMacroAverage.from_dict(model_evaluation_macro_average_model_json).__dict__
+        model_evaluation_macro_average_model2 = ModelEvaluationMacroAverage(**model_evaluation_macro_average_model_dict)
+
+        # Verify the model instances are equivalent
+        assert model_evaluation_macro_average_model == model_evaluation_macro_average_model2
+
+        # Convert model instance back to dict and verify no loss of data
+        model_evaluation_macro_average_model_json2 = model_evaluation_macro_average_model.to_dict()
+        assert model_evaluation_macro_average_model_json2 == model_evaluation_macro_average_model_json
+
+class TestModel_ModelEvaluationMicroAverage():
+    """
+    Test Class for ModelEvaluationMicroAverage
+    """
+
+    def test_model_evaluation_micro_average_serialization(self):
+        """
+        Test serialization/deserialization for ModelEvaluationMicroAverage
+        """
+
+        # Construct a json representation of a ModelEvaluationMicroAverage model
+        model_evaluation_micro_average_model_json = {}
+        model_evaluation_micro_average_model_json['precision'] = 0
+        model_evaluation_micro_average_model_json['recall'] = 0
+        model_evaluation_micro_average_model_json['f1'] = 0
+
+        # Construct a model instance of ModelEvaluationMicroAverage by calling from_dict on the json representation
+        model_evaluation_micro_average_model = ModelEvaluationMicroAverage.from_dict(model_evaluation_micro_average_model_json)
+        assert model_evaluation_micro_average_model != False
+
+        # Construct a model instance of ModelEvaluationMicroAverage by calling from_dict on the json representation
+        model_evaluation_micro_average_model_dict = ModelEvaluationMicroAverage.from_dict(model_evaluation_micro_average_model_json).__dict__
+        model_evaluation_micro_average_model2 = ModelEvaluationMicroAverage(**model_evaluation_micro_average_model_dict)
+
+        # Verify the model instances are equivalent
+        assert model_evaluation_micro_average_model == model_evaluation_micro_average_model2
+
+        # Convert model instance back to dict and verify no loss of data
+        model_evaluation_micro_average_model_json2 = model_evaluation_micro_average_model.to_dict()
+        assert model_evaluation_micro_average_model_json2 == model_evaluation_micro_average_model_json
+
 class TestModel_Notice():
     """
     Test Class for Notice
@@ -4165,7 +6919,7 @@ class TestModel_Notice():
         # Construct a json representation of a Notice model
         notice_model_json = {}
         notice_model_json['notice_id'] = 'testString'
-        notice_model_json['created'] = "2019-01-01T12:00:00Z"
+        notice_model_json['created'] = '2019-01-01T12:00:00Z'
         notice_model_json['document_id'] = 'testString'
         notice_model_json['collection_id'] = 'testString'
         notice_model_json['query_id'] = 'testString'
@@ -4187,6 +6941,38 @@ class TestModel_Notice():
         # Convert model instance back to dict and verify no loss of data
         notice_model_json2 = notice_model.to_dict()
         assert notice_model_json2 == notice_model_json
+
+class TestModel_PerClassModelEvaluation():
+    """
+    Test Class for PerClassModelEvaluation
+    """
+
+    def test_per_class_model_evaluation_serialization(self):
+        """
+        Test serialization/deserialization for PerClassModelEvaluation
+        """
+
+        # Construct a json representation of a PerClassModelEvaluation model
+        per_class_model_evaluation_model_json = {}
+        per_class_model_evaluation_model_json['name'] = 'testString'
+        per_class_model_evaluation_model_json['precision'] = 0
+        per_class_model_evaluation_model_json['recall'] = 0
+        per_class_model_evaluation_model_json['f1'] = 0
+
+        # Construct a model instance of PerClassModelEvaluation by calling from_dict on the json representation
+        per_class_model_evaluation_model = PerClassModelEvaluation.from_dict(per_class_model_evaluation_model_json)
+        assert per_class_model_evaluation_model != False
+
+        # Construct a model instance of PerClassModelEvaluation by calling from_dict on the json representation
+        per_class_model_evaluation_model_dict = PerClassModelEvaluation.from_dict(per_class_model_evaluation_model_json).__dict__
+        per_class_model_evaluation_model2 = PerClassModelEvaluation(**per_class_model_evaluation_model_dict)
+
+        # Verify the model instances are equivalent
+        assert per_class_model_evaluation_model == per_class_model_evaluation_model2
+
+        # Convert model instance back to dict and verify no loss of data
+        per_class_model_evaluation_model_json2 = per_class_model_evaluation_model.to_dict()
+        assert per_class_model_evaluation_model_json2 == per_class_model_evaluation_model_json
 
 class TestModel_ProjectDetails():
     """
@@ -4491,6 +7277,37 @@ class TestModel_QueryLargePassages():
         query_large_passages_model_json2 = query_large_passages_model.to_dict()
         assert query_large_passages_model_json2 == query_large_passages_model_json
 
+class TestModel_QueryLargeSimilar():
+    """
+    Test Class for QueryLargeSimilar
+    """
+
+    def test_query_large_similar_serialization(self):
+        """
+        Test serialization/deserialization for QueryLargeSimilar
+        """
+
+        # Construct a json representation of a QueryLargeSimilar model
+        query_large_similar_model_json = {}
+        query_large_similar_model_json['enabled'] = False
+        query_large_similar_model_json['document_ids'] = ['testString']
+        query_large_similar_model_json['fields'] = ['testString']
+
+        # Construct a model instance of QueryLargeSimilar by calling from_dict on the json representation
+        query_large_similar_model = QueryLargeSimilar.from_dict(query_large_similar_model_json)
+        assert query_large_similar_model != False
+
+        # Construct a model instance of QueryLargeSimilar by calling from_dict on the json representation
+        query_large_similar_model_dict = QueryLargeSimilar.from_dict(query_large_similar_model_json).__dict__
+        query_large_similar_model2 = QueryLargeSimilar(**query_large_similar_model_dict)
+
+        # Verify the model instances are equivalent
+        assert query_large_similar_model == query_large_similar_model2
+
+        # Convert model instance back to dict and verify no loss of data
+        query_large_similar_model_json2 = query_large_similar_model.to_dict()
+        assert query_large_similar_model_json2 == query_large_similar_model_json
+
 class TestModel_QueryLargeSuggestedRefinements():
     """
     Test Class for QueryLargeSuggestedRefinements
@@ -4565,7 +7382,7 @@ class TestModel_QueryNoticesResponse():
 
         notice_model = {} # Notice
         notice_model['notice_id'] = 'testString'
-        notice_model['created'] = "2019-01-01T12:00:00Z"
+        notice_model['created'] = '2019-01-01T12:00:00Z'
         notice_model['document_id'] = 'testString'
         notice_model['collection_id'] = 'testString'
         notice_model['query_id'] = 'testString'
@@ -4626,10 +7443,10 @@ class TestModel_QueryResponse():
 
         query_result_model = {} # QueryResult
         query_result_model['document_id'] = 'testString'
-        query_result_model['metadata'] = {}
+        query_result_model['metadata'] = {'key1': 'testString'}
         query_result_model['result_metadata'] = query_result_metadata_model
         query_result_model['document_passages'] = [query_result_passage_model]
-        query_result_model['id'] = { 'foo': 'bar' }
+        query_result_model['id'] = {'foo': 'bar'}
 
         query_aggregation_model = {} # QueryFilterAggregation
         query_aggregation_model['type'] = 'filter'
@@ -4652,7 +7469,7 @@ class TestModel_QueryResponse():
 
         table_headers_model = {} # TableHeaders
         table_headers_model['cell_id'] = 'testString'
-        table_headers_model['location'] = { 'foo': 'bar' }
+        table_headers_model['location'] = {'foo': 'bar'}
         table_headers_model['text'] = 'testString'
         table_headers_model['row_index_begin'] = 26
         table_headers_model['row_index_end'] = 26
@@ -4671,7 +7488,7 @@ class TestModel_QueryResponse():
 
         table_column_headers_model = {} # TableColumnHeaders
         table_column_headers_model['cell_id'] = 'testString'
-        table_column_headers_model['location'] = { 'foo': 'bar' }
+        table_column_headers_model['location'] = {'foo': 'bar'}
         table_column_headers_model['text'] = 'testString'
         table_column_headers_model['text_normalized'] = 'testString'
         table_column_headers_model['row_index_begin'] = 26
@@ -4868,10 +7685,10 @@ class TestModel_QueryResult():
         # Construct a json representation of a QueryResult model
         query_result_model_json = {}
         query_result_model_json['document_id'] = 'testString'
-        query_result_model_json['metadata'] = {}
+        query_result_model_json['metadata'] = {'key1': 'testString'}
         query_result_model_json['result_metadata'] = query_result_metadata_model
         query_result_model_json['document_passages'] = [query_result_passage_model]
-        query_result_model_json['foo'] = { 'foo': 'bar' }
+        query_result_model_json['foo'] = {'foo': 'bar'}
 
         # Construct a model instance of QueryResult by calling from_dict on the json representation
         query_result_model = QueryResult.from_dict(query_result_model_json)
@@ -4893,7 +7710,7 @@ class TestModel_QueryResult():
         actual_dict = query_result_model.get_properties()
         assert actual_dict == {}
 
-        expected_dict = {'foo': { 'foo': 'bar' }}
+        expected_dict = {'foo': {'foo': 'bar'}}
         query_result_model.set_properties(expected_dict)
         actual_dict = query_result_model.get_properties()
         assert actual_dict == expected_dict
@@ -5022,7 +7839,7 @@ class TestModel_QueryTableResult():
 
         table_headers_model = {} # TableHeaders
         table_headers_model['cell_id'] = 'testString'
-        table_headers_model['location'] = { 'foo': 'bar' }
+        table_headers_model['location'] = {'foo': 'bar'}
         table_headers_model['text'] = 'testString'
         table_headers_model['row_index_begin'] = 26
         table_headers_model['row_index_end'] = 26
@@ -5041,7 +7858,7 @@ class TestModel_QueryTableResult():
 
         table_column_headers_model = {} # TableColumnHeaders
         table_column_headers_model['cell_id'] = 'testString'
-        table_column_headers_model['location'] = { 'foo': 'bar' }
+        table_column_headers_model['location'] = {'foo': 'bar'}
         table_column_headers_model['text'] = 'testString'
         table_column_headers_model['text_normalized'] = 'testString'
         table_column_headers_model['row_index_begin'] = 26
@@ -5231,7 +8048,7 @@ class TestModel_QueryTopHitsAggregationResult():
         # Construct a json representation of a QueryTopHitsAggregationResult model
         query_top_hits_aggregation_result_model_json = {}
         query_top_hits_aggregation_result_model_json['matching_results'] = 38
-        query_top_hits_aggregation_result_model_json['hits'] = [{}]
+        query_top_hits_aggregation_result_model_json['hits'] = [{'key1': 'testString'}]
 
         # Construct a model instance of QueryTopHitsAggregationResult by calling from_dict on the json representation
         query_top_hits_aggregation_result_model = QueryTopHitsAggregationResult.from_dict(query_top_hits_aggregation_result_model_json)
@@ -5308,6 +8125,35 @@ class TestModel_RetrievalDetails():
         # Convert model instance back to dict and verify no loss of data
         retrieval_details_model_json2 = retrieval_details_model.to_dict()
         assert retrieval_details_model_json2 == retrieval_details_model_json
+
+class TestModel_StopWordList():
+    """
+    Test Class for StopWordList
+    """
+
+    def test_stop_word_list_serialization(self):
+        """
+        Test serialization/deserialization for StopWordList
+        """
+
+        # Construct a json representation of a StopWordList model
+        stop_word_list_model_json = {}
+        stop_word_list_model_json['stopwords'] = ['testString']
+
+        # Construct a model instance of StopWordList by calling from_dict on the json representation
+        stop_word_list_model = StopWordList.from_dict(stop_word_list_model_json)
+        assert stop_word_list_model != False
+
+        # Construct a model instance of StopWordList by calling from_dict on the json representation
+        stop_word_list_model_dict = StopWordList.from_dict(stop_word_list_model_json).__dict__
+        stop_word_list_model2 = StopWordList(**stop_word_list_model_dict)
+
+        # Verify the model instances are equivalent
+        assert stop_word_list_model == stop_word_list_model2
+
+        # Convert model instance back to dict and verify no loss of data
+        stop_word_list_model_json2 = stop_word_list_model.to_dict()
+        assert stop_word_list_model_json2 == stop_word_list_model_json
 
 class TestModel_TableBodyCells():
     """
@@ -5554,7 +8400,7 @@ class TestModel_TableColumnHeaders():
         # Construct a json representation of a TableColumnHeaders model
         table_column_headers_model_json = {}
         table_column_headers_model_json['cell_id'] = 'testString'
-        table_column_headers_model_json['location'] = { 'foo': 'bar' }
+        table_column_headers_model_json['location'] = {'foo': 'bar'}
         table_column_headers_model_json['text'] = 'testString'
         table_column_headers_model_json['text_normalized'] = 'testString'
         table_column_headers_model_json['row_index_begin'] = 26
@@ -5620,7 +8466,7 @@ class TestModel_TableHeaders():
         # Construct a json representation of a TableHeaders model
         table_headers_model_json = {}
         table_headers_model_json['cell_id'] = 'testString'
-        table_headers_model_json['location'] = { 'foo': 'bar' }
+        table_headers_model_json['location'] = {'foo': 'bar'}
         table_headers_model_json['text'] = 'testString'
         table_headers_model_json['row_index_begin'] = 26
         table_headers_model_json['row_index_end'] = 26
@@ -5710,7 +8556,7 @@ class TestModel_TableResultTable():
 
         table_headers_model = {} # TableHeaders
         table_headers_model['cell_id'] = 'testString'
-        table_headers_model['location'] = { 'foo': 'bar' }
+        table_headers_model['location'] = {'foo': 'bar'}
         table_headers_model['text'] = 'testString'
         table_headers_model['row_index_begin'] = 26
         table_headers_model['row_index_end'] = 26
@@ -5729,7 +8575,7 @@ class TestModel_TableResultTable():
 
         table_column_headers_model = {} # TableColumnHeaders
         table_column_headers_model['cell_id'] = 'testString'
-        table_column_headers_model['location'] = { 'foo': 'bar' }
+        table_column_headers_model['location'] = {'foo': 'bar'}
         table_column_headers_model['text'] = 'testString'
         table_column_headers_model['text_normalized'] = 'testString'
         table_column_headers_model['row_index_begin'] = 26
@@ -5998,8 +8844,8 @@ class TestModel_TrainingExample():
         training_example_model_json['document_id'] = 'testString'
         training_example_model_json['collection_id'] = 'testString'
         training_example_model_json['relevance'] = 38
-        training_example_model_json['created'] = "2019-01-01T12:00:00Z"
-        training_example_model_json['updated'] = "2019-01-01T12:00:00Z"
+        training_example_model_json['created'] = '2019-01-01T12:00:00Z'
+        training_example_model_json['updated'] = '2019-01-01T12:00:00Z'
 
         # Construct a model instance of TrainingExample by calling from_dict on the json representation
         training_example_model = TrainingExample.from_dict(training_example_model_json)
@@ -6032,16 +8878,16 @@ class TestModel_TrainingQuery():
         training_example_model['document_id'] = 'testString'
         training_example_model['collection_id'] = 'testString'
         training_example_model['relevance'] = 38
-        training_example_model['created'] = "2019-01-01T12:00:00Z"
-        training_example_model['updated'] = "2019-01-01T12:00:00Z"
+        training_example_model['created'] = '2019-01-01T12:00:00Z'
+        training_example_model['updated'] = '2019-01-01T12:00:00Z'
 
         # Construct a json representation of a TrainingQuery model
         training_query_model_json = {}
         training_query_model_json['query_id'] = 'testString'
         training_query_model_json['natural_language_query'] = 'testString'
         training_query_model_json['filter'] = 'testString'
-        training_query_model_json['created'] = "2019-01-01T12:00:00Z"
-        training_query_model_json['updated'] = "2019-01-01T12:00:00Z"
+        training_query_model_json['created'] = '2019-01-01T12:00:00Z'
+        training_query_model_json['updated'] = '2019-01-01T12:00:00Z'
         training_query_model_json['examples'] = [training_example_model]
 
         # Construct a model instance of TrainingQuery by calling from_dict on the json representation
@@ -6075,15 +8921,15 @@ class TestModel_TrainingQuerySet():
         training_example_model['document_id'] = 'testString'
         training_example_model['collection_id'] = 'testString'
         training_example_model['relevance'] = 38
-        training_example_model['created'] = "2019-01-01T12:00:00Z"
-        training_example_model['updated'] = "2019-01-01T12:00:00Z"
+        training_example_model['created'] = '2019-01-01T12:00:00Z'
+        training_example_model['updated'] = '2019-01-01T12:00:00Z'
 
         training_query_model = {} # TrainingQuery
         training_query_model['query_id'] = 'testString'
         training_query_model['natural_language_query'] = 'testString'
         training_query_model['filter'] = 'testString'
-        training_query_model['created'] = "2019-01-01T12:00:00Z"
-        training_query_model['updated'] = "2019-01-01T12:00:00Z"
+        training_query_model['created'] = '2019-01-01T12:00:00Z'
+        training_query_model['updated'] = '2019-01-01T12:00:00Z'
         training_query_model['examples'] = [training_example_model]
 
         # Construct a json representation of a TrainingQuerySet model
@@ -6104,6 +8950,36 @@ class TestModel_TrainingQuerySet():
         # Convert model instance back to dict and verify no loss of data
         training_query_set_model_json2 = training_query_set_model.to_dict()
         assert training_query_set_model_json2 == training_query_set_model_json
+
+class TestModel_UpdateDocumentClassifier():
+    """
+    Test Class for UpdateDocumentClassifier
+    """
+
+    def test_update_document_classifier_serialization(self):
+        """
+        Test serialization/deserialization for UpdateDocumentClassifier
+        """
+
+        # Construct a json representation of a UpdateDocumentClassifier model
+        update_document_classifier_model_json = {}
+        update_document_classifier_model_json['name'] = 'testString'
+        update_document_classifier_model_json['description'] = 'testString'
+
+        # Construct a model instance of UpdateDocumentClassifier by calling from_dict on the json representation
+        update_document_classifier_model = UpdateDocumentClassifier.from_dict(update_document_classifier_model_json)
+        assert update_document_classifier_model != False
+
+        # Construct a model instance of UpdateDocumentClassifier by calling from_dict on the json representation
+        update_document_classifier_model_dict = UpdateDocumentClassifier.from_dict(update_document_classifier_model_json).__dict__
+        update_document_classifier_model2 = UpdateDocumentClassifier(**update_document_classifier_model_dict)
+
+        # Verify the model instances are equivalent
+        assert update_document_classifier_model == update_document_classifier_model2
+
+        # Convert model instance back to dict and verify no loss of data
+        update_document_classifier_model_json2 = update_document_classifier_model.to_dict()
+        assert update_document_classifier_model_json2 == update_document_classifier_model_json
 
 class TestModel_QueryCalculationAggregation():
     """
@@ -6337,7 +9213,7 @@ class TestModel_QueryTopHitsAggregation():
 
         query_top_hits_aggregation_result_model = {} # QueryTopHitsAggregationResult
         query_top_hits_aggregation_result_model['matching_results'] = 38
-        query_top_hits_aggregation_result_model['hits'] = [{}]
+        query_top_hits_aggregation_result_model['hits'] = [{'key1': 'testString'}]
 
         # Construct a json representation of a QueryTopHitsAggregation model
         query_top_hits_aggregation_model_json = {}

--- a/test/unit/test_discovery_v2.py
+++ b/test/unit/test_discovery_v2.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# (C) Copyright IBM Corp. 2022.
+# (C) Copyright IBM Corp. 2019-2022.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
Changes:
- Regenerated `ibm_watson/discovery_v2.py` using `openapi-sdkgen`
- Regenerated `test/unit/test_discovery_v2.py` using `openapi-sdkgen`

Generation was based on OpenAPI schema made available here: https://cloud.ibm.com/apidocs/discovery-data